### PR TITLE
Allow using V2 form controls in SettingSourceAttribute

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSkinEditor.cs
@@ -17,8 +17,8 @@ using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
@@ -335,7 +335,7 @@ namespace osu.Game.Tests.Visual.Gameplay
             {
                 InputManager.MoveMouseTo(
                     skinEditor.ChildrenOfType<SkinSettingsToolbox>().First()
-                              .ChildrenOfType<SettingsSlider<float>>().First()
+                              .ChildrenOfType<FormSliderBar<float>>().First()
                               .ChildrenOfType<SliderBar<float>>().First()
                 );
             });

--- a/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneSkinEditorNavigation.cs
@@ -17,8 +17,8 @@ using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Game.Online.API;
 using osu.Game.Beatmaps;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Mods;
-using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.SkinEditor;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
@@ -74,7 +74,7 @@ namespace osu.Game.Tests.Visual.Navigation
             {
                 InputManager.MoveMouseTo(
                     skinEditor.ChildrenOfType<SkinSettingsToolbox>().First()
-                              .ChildrenOfType<SettingsSlider<float>>().First()
+                              .ChildrenOfType<FormSliderBar<float>>().First()
                               .ChildrenOfType<SliderBar<float>>().First()
                 );
             });

--- a/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneSettingsSource.cs
@@ -2,12 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osuTK;
 
@@ -16,6 +18,9 @@ namespace osu.Game.Tests.Visual.Settings
     [TestFixture]
     public partial class TestSceneSettingsSource : OsuTestScene
     {
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
+
         public TestSceneSettingsSource()
         {
             Children = new Drawable[]
@@ -69,10 +74,13 @@ namespace osu.Game.Tests.Visual.Settings
                 Value = "Sample text"
             };
 
+            [SettingSource("Sample slider bar", "Slider bar component")]
+            public BindableNumber<float> FloatSliderBarBindable { get; } = new BindableNumber<float> { MinValue = 0, MaxValue = 10, Value = 5, Precision = 0.1f };
+
             [SettingSource("Sample number textbox", "Textbox number entry", SettingControlType = typeof(SettingsNumberBox))]
             public Bindable<int?> IntTextBoxBindable { get; } = new Bindable<int?>();
 
-            [SettingSource("Sample colour", "Change the colour", SettingControlType = typeof(SettingsColour))]
+            [SettingSource("Sample colour", "Change the colour")]
             public BindableColour4 ColourBindable { get; } = new BindableColour4
             {
                 Default = Colour4.White,

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormControls.cs
@@ -276,6 +276,11 @@ namespace osu.Game.Tests.Visual.UserInterface
                                                 Colour4.Yellow,
                                             }
                                         },
+                                        new FormColourPicker
+                                        {
+                                            Caption = "Colour picker",
+                                            HintText = "Allows to pick colours",
+                                        },
                                     },
                                 }
                             },

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneModDifficultyAdjustSettings.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneModDifficultyAdjustSettings.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -14,6 +15,7 @@ using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu.Mods;
 using osuTK;
@@ -25,6 +27,9 @@ namespace osu.Game.Tests.Visual.UserInterface
     public partial class TestSceneModDifficultyAdjustSettings : OsuManualInputManagerTestScene
     {
         private OsuModDifficultyAdjust modDifficultyAdjust;
+
+        [Cached]
+        private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Aquamarine);
 
         [SetUpSteps]
         public void SetUpSteps()

--- a/osu.Game/Configuration/SettingSourceAttribute.cs
+++ b/osu.Game/Configuration/SettingSourceAttribute.cs
@@ -12,7 +12,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
-using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays.Settings;
 using osu.Game.Utils;
 
@@ -118,94 +118,109 @@ namespace osu.Game.Configuration
                 if (attr.SettingControlType != null)
                 {
                     var controlType = attr.SettingControlType;
-                    if (controlType.EnumerateBaseTypes().All(t => !t.IsGenericType || t.GetGenericTypeDefinition() != typeof(SettingsItem<>)))
-                        throw new InvalidOperationException($"{nameof(SettingSourceAttribute)} had an unsupported custom control type ({controlType.ReadableName()})");
 
-                    var control = (Drawable)Activator.CreateInstance(controlType)!;
-                    controlType.GetProperty(nameof(SettingsItem<object>.SettingSourceObject))?.SetValue(control, obj);
-                    controlType.GetProperty(nameof(SettingsItem<object>.LabelText))?.SetValue(control, attr.Label);
-                    controlType.GetProperty(nameof(SettingsItem<object>.TooltipText))?.SetValue(control, attr.Description);
-                    controlType.GetProperty(nameof(SettingsItem<object>.Current))?.SetValue(control, value);
+                    if (controlType.GetInterface(nameof(IFormControl<object>)) != null)
+                    {
+                        var control = (Drawable)Activator.CreateInstance(controlType)!;
+                        controlType.GetProperty(nameof(IFormControl<object>.Caption))?.SetValue(control, attr.Label);
+                        controlType.GetProperty(nameof(IFormControl<object>.HintText))?.SetValue(control, attr.Description);
+                        controlType.GetProperty(nameof(IFormControl<object>.Current))?.SetValue(control, value);
 
-                    yield return control;
+                        yield return new SettingsItemV2((IFormControl)control);
 
-                    continue;
+                        continue;
+                    }
+
+                    if (controlType.EnumerateBaseTypes().Any(t => t.IsGenericType && t.GetGenericTypeDefinition() == typeof(SettingsItem<>)))
+                    {
+                        var control = (Drawable)Activator.CreateInstance(controlType)!;
+                        controlType.GetProperty(nameof(SettingsItem<object>.SettingSourceObject))?.SetValue(control, obj);
+                        controlType.GetProperty(nameof(SettingsItem<object>.LabelText))?.SetValue(control, attr.Label);
+                        controlType.GetProperty(nameof(SettingsItem<object>.TooltipText))?.SetValue(control, attr.Description);
+                        controlType.GetProperty(nameof(SettingsItem<object>.Current))?.SetValue(control, value);
+
+                        yield return control;
+
+                        continue;
+                    }
+
+                    throw new InvalidOperationException($"{nameof(SettingSourceAttribute)} had an unsupported custom control type ({controlType.ReadableName()})");
                 }
 
                 switch (value)
                 {
                     case BindableNumber<float> bNumber:
-                        yield return new SettingsSlider<float>
+                        yield return new SettingsItemV2(new FormSliderBar<float>
                         {
-                            LabelText = attr.Label,
-                            TooltipText = attr.Description,
+                            Caption = attr.Label,
+                            HintText = attr.Description,
                             Current = bNumber,
                             KeyboardStep = bNumber.Precision,
-                        };
+                        });
 
                         break;
 
                     case BindableNumber<double> bNumber:
-                        yield return new SettingsSlider<double>
+                        yield return new SettingsItemV2(new FormSliderBar<double>
                         {
-                            LabelText = attr.Label,
-                            TooltipText = attr.Description,
+                            Caption = attr.Label,
+                            HintText = attr.Description,
                             Current = bNumber,
                             KeyboardStep = (float)bNumber.Precision,
-                        };
+                        });
 
                         break;
 
                     case BindableNumber<int> bNumber:
-                        yield return new SettingsSlider<int>
+                        yield return new SettingsItemV2(new FormSliderBar<int>
                         {
-                            LabelText = attr.Label,
-                            TooltipText = attr.Description,
+                            Caption = attr.Label,
+                            HintText = attr.Description,
                             Current = bNumber,
                             KeyboardStep = bNumber.Precision,
-                        };
+                        });
 
                         break;
 
                     case Bindable<bool> bBool:
-                        yield return new SettingsCheckbox
+                        yield return new SettingsItemV2(new FormCheckBox
                         {
-                            LabelText = attr.Label,
-                            TooltipText = attr.Description,
-                            Current = bBool
-                        };
+                            Caption = attr.Label,
+                            HintText = attr.Description,
+                            Current = bBool,
+                        });
 
                         break;
 
                     case Bindable<string> bString:
-                        yield return new SettingsTextBox
+                        yield return new SettingsItemV2(new FormTextBox
                         {
-                            LabelText = attr.Label,
-                            TooltipText = attr.Description,
-                            Current = bString
-                        };
+                            Caption = attr.Label,
+                            HintText = attr.Description,
+                            Current = bString,
+                        });
 
                         break;
 
                     case BindableColour4 bColour:
-                        yield return new SettingsColour
+                        yield return new SettingsItemV2(new FormColourPicker
                         {
-                            LabelText = attr.Label,
-                            TooltipText = attr.Description,
-                            Current = bColour
-                        };
+                            Caption = attr.Label,
+                            HintText = attr.Description,
+                            Current = bColour,
+                        });
 
                         break;
 
                     case IBindable bindable:
                         var dropdownType = typeof(ModSettingsEnumDropdown<>).MakeGenericType(bindable.GetType().GetGenericArguments()[0]);
-                        var dropdown = (Drawable)Activator.CreateInstance(dropdownType)!;
+                        var dropdown = (IFormControl)Activator.CreateInstance(dropdownType)!;
 
-                        dropdownType.GetProperty(nameof(SettingsDropdown<object>.LabelText))?.SetValue(dropdown, attr.Label);
-                        dropdownType.GetProperty(nameof(SettingsDropdown<object>.TooltipText))?.SetValue(dropdown, attr.Description);
-                        dropdownType.GetProperty(nameof(SettingsDropdown<object>.Current))?.SetValue(dropdown, bindable);
+                        dropdownType.GetProperty(nameof(IFormControl<object>.Caption))?.SetValue(dropdown, attr.Label);
+                        dropdownType.GetProperty(nameof(IFormControl<object>.HintText))?.SetValue(dropdown, attr.Description);
+                        dropdownType.GetProperty(nameof(IFormControl<object>.Current))?.SetValue(dropdown, bindable);
 
-                        yield return dropdown;
+                        yield return new SettingsItemV2(dropdown);
 
                         break;
 
@@ -278,16 +293,11 @@ namespace osu.Game.Configuration
                   .OrderBy(attr => attr.Item1)
                   .ToArray();
 
-        private partial class ModSettingsEnumDropdown<T> : SettingsEnumDropdown<T>
+        private partial class ModSettingsEnumDropdown<T> : FormEnumDropdown<T>
             where T : struct, Enum
         {
-            protected override OsuDropdown<T> CreateDropdown() => new ModDropdownControl();
-
-            private partial class ModDropdownControl : DropdownControl
-            {
-                // Set menu's max height low enough to workaround nested scroll issues (see https://github.com/ppy/osu-framework/issues/4536).
-                protected override DropdownMenu CreateMenu() => base.CreateMenu().With(m => m.MaxHeight = 100);
-            }
+            // Set menu's max height low enough to workaround nested scroll issues (see https://github.com/ppy/osu-framework/issues/4536).
+            protected override DropdownMenu CreateMenu() => base.CreateMenu().With(m => m.MaxHeight = 100);
         }
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -8,14 +8,13 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Overlays;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormCheckBox : CompositeDrawable, IHasCurrentValue<bool>, IFormControl
+    public partial class FormCheckBox : CompositeDrawable, IFormControl<bool>
     {
         public Bindable<bool> Current
         {
@@ -25,18 +24,42 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private readonly BindableWithCurrent<bool> current = new BindableWithCurrent<bool>();
 
-        /// <summary>
-        /// Caption describing this slider bar, displayed on top of the controls.
-        /// </summary>
-        public LocalisableString Caption { get; init; }
+        private LocalisableString caption;
 
         /// <summary>
-        /// Hint text containing an extended description of this slider bar, displayed in a tooltip when hovering the caption.
+        /// Caption describing this check box, displayed on top of the controls.
         /// </summary>
-        public LocalisableString HintText { get; init; }
+        public LocalisableString Caption
+        {
+            get => caption;
+            set
+            {
+                caption = value;
+
+                if (IsLoaded)
+                    captionText.Caption = value;
+            }
+        }
+
+        private LocalisableString hintText;
+
+        /// <summary>
+        /// Hint text containing an extended description of this check box, displayed in a tooltip when hovering the caption.
+        /// </summary>
+        public LocalisableString HintText
+        {
+            get => hintText;
+            set
+            {
+                hintText = value;
+
+                if (IsLoaded)
+                    captionText.TooltipText = value;
+            }
+        }
 
         private FormControlBackground background = null!;
-        private FormFieldCaption caption = null!;
+        private FormFieldCaption captionText = null!;
 
         private SwitchButton switchButton = null!;
 
@@ -68,7 +91,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             Padding = new MarginPadding { Right = SwitchButton.WIDTH + 5 },
                             Children = new Drawable[]
                             {
-                                caption = new FormFieldCaption
+                                captionText = new FormFieldCaption
                                 {
                                     Caption = Caption,
                                     TooltipText = HintText,
@@ -120,7 +143,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private void updateState()
         {
-            caption.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+            captionText.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
 
             if (IsDisabled)
                 background.VisualStyle = VisualStyle.Disabled;

--- a/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormCheckBox.cs
@@ -66,6 +66,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        public FormCheckBox()
+        {
+            // IMPORTANT: bindable value change logic is in constructor intentionally to support
+            // "CreateSettingsControls" being used in a context it is never loaded, but requires bindable storage.
+            current.BindValueChanged(_ => ValueChanged?.Invoke());
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -117,8 +124,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 updateState();
                 background.Flash();
-
-                ValueChanged?.Invoke();
             });
             current.BindDisabledChanged(_ => updateState(), true);
         }

--- a/osu.Game/Graphics/UserInterfaceV2/FormColourPicker.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormColourPicker.cs
@@ -107,6 +107,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        public FormColourPicker()
+        {
+            // IMPORTANT: bindable value change logic is in constructor intentionally to support
+            // "CreateSettingsControls" being used in a context it is never loaded, but requires bindable storage.
+            current.BindValueChanged(_ => ValueChanged?.Invoke());
+        }
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -201,7 +208,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
             current.ValueChanged += e =>
             {
                 currentColourInstantaneous.Value = e.NewValue;
-                ValueChanged?.Invoke();
             };
 
             current.DisabledChanged += disabled =>

--- a/osu.Game/Graphics/UserInterfaceV2/FormColourPicker.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormColourPicker.cs
@@ -1,0 +1,344 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Framework.Utils;
+using osu.Game.Overlays;
+using osuTK;
+
+namespace osu.Game.Graphics.UserInterfaceV2
+{
+    public partial class FormColourPicker : CompositeDrawable, IHasCurrentValue<Colour4>, IFormControl
+    {
+        public Bindable<Colour4> Current
+        {
+            get => current.Current;
+            set
+            {
+                current.Current = value;
+
+                // the above `Current` set could have disabled the instantaneous bindable too,
+                // but we still need to copy out `Default` manually,
+                // so lift that disable for a second and then restore it
+                currentColourInstantaneous.Disabled = false;
+                currentColourInstantaneous.Default = current.Default;
+                currentColourInstantaneous.Disabled = current.Disabled;
+            }
+        }
+
+        private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>(Colour4.White);
+
+        private readonly Bindable<Colour4> currentColourInstantaneous = new Bindable<Colour4>();
+
+        /// <summary>
+        /// Whether changes to the value should instantaneously transfer to outside bindables.
+        /// If <see langword="false"/>, the transfer will happen on text box commit (explicit, or implicit via focus loss), or on colour picker commit.
+        /// </summary>
+        public bool TransferValueOnCommit { get; set; }
+
+        private CompositeDrawable? tabbableContentContainer;
+
+        public CompositeDrawable? TabbableContentContainer
+        {
+            set
+            {
+                tabbableContentContainer = value;
+
+                if (textBox.IsNotNull())
+                    textBox.TabbableContentContainer = tabbableContentContainer;
+            }
+        }
+
+        /// <summary>
+        /// Caption describing this color picker, displayed on top of the controls.
+        /// </summary>
+        public LocalisableString Caption { get; init; }
+
+        /// <summary>
+        /// Hint text containing an extended description of this color picker, displayed in a tooltip when hovering the caption.
+        /// </summary>
+        public LocalisableString HintText { get; init; }
+
+        private FormControlBackground background = null!;
+        private Box flashLayer = null!;
+        private FormTextBox.InnerTextBox textBox = null!;
+        private FormFieldCaption caption = null!;
+        private IFocusManager focusManager = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuColour colours)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                background = new FormControlBackground(),
+                flashLayer = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Colour4.Transparent,
+                },
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding
+                    {
+                        Vertical = 5,
+                        Left = 9,
+                        Right = 5,
+                    },
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute, size: 90),
+                    },
+                    RowDimensions = new[]
+                    {
+                        new Dimension(GridSizeMode.AutoSize),
+                    },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new FillFlowContainer
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y,
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0, 4),
+                                Padding = new MarginPadding
+                                {
+                                    Right = 10,
+                                    Vertical = 4,
+                                },
+                                Children = new Drawable[]
+                                {
+                                    caption = new FormFieldCaption
+                                    {
+                                        Anchor = Anchor.TopLeft,
+                                        Origin = Anchor.TopLeft,
+                                        Caption = Caption,
+                                        TooltipText = HintText,
+                                    },
+                                    textBox = new FormTextBox.InnerTextBox
+                                    {
+                                        RelativeSizeAxes = Axes.X,
+                                        CommitOnFocusLost = true,
+                                        SelectAllOnFocus = true,
+                                        OnInputError = () =>
+                                        {
+                                            flashLayer.Colour = ColourInfo.GradientVertical(colours.Red3.Opacity(0), colours.Red3);
+                                            flashLayer.FadeOutFromOne(200, Easing.OutQuint);
+                                        },
+                                        TabbableContentContainer = tabbableContentContainer,
+                                    },
+                                },
+                            },
+                            new InnerColourDisplay
+                            {
+                                Current = { BindTarget = currentColourInstantaneous },
+                            },
+                        },
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            focusManager = GetContainingFocusManager()!;
+
+            textBox.Focused.BindValueChanged(_ => updateState());
+            textBox.OnCommit += textCommitted;
+            textBox.Current.BindValueChanged(textChanged);
+
+            current.ValueChanged += e =>
+            {
+                currentColourInstantaneous.Value = e.NewValue;
+                ValueChanged?.Invoke();
+            };
+
+            current.DisabledChanged += disabled =>
+            {
+                if (disabled)
+                {
+                    // revert any changes before disabling to make sure we are in a consistent state.
+                    currentColourInstantaneous.Value = current.Value;
+                }
+
+                currentColourInstantaneous.Disabled = disabled;
+                if (IsLoaded)
+                    updateState();
+            };
+
+            current.CopyTo(currentColourInstantaneous);
+
+            currentColourInstantaneous.BindDisabledChanged(_ => updateState());
+            currentColourInstantaneous.BindValueChanged(e =>
+            {
+                if (!TransferValueOnCommit)
+                    current.Value = e.NewValue;
+
+                updateState();
+
+                // Debounce updates from the color picker in order to prevent
+                // the textbox from flickering when the color picker is dragged
+                // very fast.
+                if (!updatingFromTextBox)
+                    Scheduler.Add(updateTextBox);
+            }, true);
+        }
+
+        private bool updatingFromTextBox;
+
+        private void textChanged(ValueChangedEvent<string> change)
+        {
+            tryUpdateColourFromTextBox();
+        }
+
+        private void textCommitted(TextBox t, bool isNew)
+        {
+            tryUpdateColourFromTextBox();
+            // If the attempted update above failed, restore text box to match the slider.
+            currentColourInstantaneous.TriggerChange();
+            current.Value = currentColourInstantaneous.Value;
+
+            background.Flash();
+        }
+
+        private void tryUpdateColourFromTextBox()
+        {
+            updatingFromTextBox = true;
+
+            if (Colour4.TryParseHex(textBox.Current.Value, out var colour) && Precision.AlmostEquals(colour.A, 1))
+                currentColourInstantaneous.Value = colour;
+
+            updatingFromTextBox = false;
+        }
+
+        private void updateTextBox()
+        {
+            textBox.Text = currentColourInstantaneous.Value.ToHex();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            base.OnHoverLost(e);
+            updateState();
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (!Current.Disabled)
+                focusManager.ChangeFocus(textBox);
+
+            return true;
+        }
+
+        private void updateState()
+        {
+            textBox.ReadOnly = currentColourInstantaneous.Disabled;
+            textBox.Colour = currentColourInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
+
+            caption.Colour = currentColourInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+            textBox.Colour = currentColourInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+
+            if (Current.Disabled)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (textBox.Focused.Value)
+                background.VisualStyle = VisualStyle.Focused;
+            else if (IsHovered)
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
+        }
+
+        public partial class InnerColourDisplay : CompositeDrawable, IHasCurrentValue<Colour4>, IHasPopover
+        {
+            private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>();
+
+            public Bindable<Colour4> Current
+            {
+                get => current;
+                set => current.Current = value;
+            }
+
+            private Box colourDisplay = null!;
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                RelativeSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 5;
+                InternalChild = colourDisplay = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Current.BindValueChanged(e => colourDisplay.Colour = e.NewValue, true);
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                this.ShowPopover();
+                return true;
+            }
+
+            public Popover GetPopover() => new OsuPopover(false)
+            {
+                // Ensure the popover doesn't cover up the text input.
+                AllowableAnchors = [Anchor.TopCentre, Anchor.BottomCentre],
+                Child = new OsuHSVColourPicker
+                {
+                    Current = { BindTarget = Current },
+                },
+            };
+        }
+
+        public IEnumerable<LocalisableString> FilterTerms => new[] { Caption, HintText };
+
+        public event Action? ValueChanged;
+
+        public bool IsDefault => Current.IsDefault;
+
+        public void SetDefault() => Current.SetDefault();
+
+        public bool IsDisabled => Current.Disabled;
+
+        public float MainDrawHeight => DrawHeight;
+    }
+}

--- a/osu.Game/Graphics/UserInterfaceV2/FormColourPicker.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormColourPicker.cs
@@ -23,7 +23,7 @@ using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormColourPicker : CompositeDrawable, IHasCurrentValue<Colour4>, IFormControl
+    public partial class FormColourPicker : CompositeDrawable, IFormControl<Colour4>
     {
         public Bindable<Colour4> Current
         {
@@ -64,20 +64,44 @@ namespace osu.Game.Graphics.UserInterfaceV2
             }
         }
 
+        private LocalisableString caption;
+
         /// <summary>
         /// Caption describing this color picker, displayed on top of the controls.
         /// </summary>
-        public LocalisableString Caption { get; init; }
+        public LocalisableString Caption
+        {
+            get => caption;
+            set
+            {
+                caption = value;
+
+                if (IsLoaded)
+                    captionText.Caption = value;
+            }
+        }
+
+        private LocalisableString hintText;
 
         /// <summary>
         /// Hint text containing an extended description of this color picker, displayed in a tooltip when hovering the caption.
         /// </summary>
-        public LocalisableString HintText { get; init; }
+        public LocalisableString HintText
+        {
+            get => hintText;
+            set
+            {
+                hintText = value;
+
+                if (IsLoaded)
+                    captionText.TooltipText = value;
+            }
+        }
 
         private FormControlBackground background = null!;
         private Box flashLayer = null!;
         private FormTextBox.InnerTextBox textBox = null!;
-        private FormFieldCaption caption = null!;
+        private FormFieldCaption captionText = null!;
         private IFocusManager focusManager = null!;
 
         [Resolved]
@@ -133,7 +157,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                 },
                                 Children = new Drawable[]
                                 {
-                                    caption = new FormFieldCaption
+                                    captionText = new FormFieldCaption
                                     {
                                         Anchor = Anchor.TopLeft,
                                         Origin = Anchor.TopLeft,
@@ -221,7 +245,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private void textCommitted(TextBox t, bool isNew)
         {
             tryUpdateColourFromTextBox();
-            // If the attempted update above failed, restore text box to match the slider.
+            // If the attempted update above failed, restore text box to match the colour display.
             currentColourInstantaneous.TriggerChange();
             current.Value = currentColourInstantaneous.Value;
 
@@ -268,7 +292,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.ReadOnly = currentColourInstantaneous.Disabled;
             textBox.Colour = currentColourInstantaneous.Disabled ? colourProvider.Foreground1 : colourProvider.Content1;
 
-            caption.Colour = currentColourInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+            captionText.Colour = currentColourInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content2;
             textBox.Colour = currentColourInstantaneous.Disabled ? colourProvider.Background1 : colourProvider.Content2;
 
             if (Current.Disabled)

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -20,15 +20,19 @@ using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormDropdown<T> : OsuDropdown<T>, IFormControl
+    public partial class FormDropdown<T> : OsuDropdown<T>, IFormControl<T>
     {
         /// <summary>
-        /// Caption describing this slider bar, displayed on top of the controls.
+        /// Caption describing this dropdown, displayed on top of the controls.
         /// </summary>
-        public LocalisableString Caption { get; init; }
+        public LocalisableString Caption
+        {
+            get => header.Caption;
+            set => header.Caption = value;
+        }
 
         /// <summary>
-        /// Hint text containing an extended description of this slider bar, displayed in a tooltip when hovering the caption.
+        /// Hint text containing an extended description of this dropdown, displayed in a tooltip when hovering the caption.
         /// </summary>
         public LocalisableString HintText
         {

--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -59,9 +59,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
             header.HintText = HintText;
         }
 
-        protected override void LoadComplete()
+        public FormDropdown()
         {
-            base.LoadComplete();
+            // IMPORTANT: bindable value change logic is in constructor intentionally to support
+            // "CreateSettingsControls" being used in a context it is never loaded, but requires bindable storage.
             Current.BindValueChanged(_ => ValueChanged?.Invoke());
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -27,7 +27,7 @@ using Vector2 = osuTK.Vector2;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormSliderBar<T> : CompositeDrawable, IHasCurrentValue<T>, IFormControl
+    public partial class FormSliderBar<T> : CompositeDrawable, IFormControl<T>
         where T : struct, INumber<T>, IMinMaxValue<T>
     {
         public Bindable<T> Current
@@ -87,10 +87,22 @@ namespace osu.Game.Graphics.UserInterfaceV2
             }
         }
 
+        private LocalisableString hintText;
+
         /// <summary>
         /// Hint text containing an extended description of this slider bar, displayed in a tooltip when hovering the caption.
         /// </summary>
-        public LocalisableString HintText { get; init; }
+        public LocalisableString HintText
+        {
+            get => hintText;
+            set
+            {
+                hintText = value;
+
+                if (IsLoaded)
+                    captionText.TooltipText = value;
+            }
+        }
 
         /// <summary>
         /// A custom step value for each key press which actuates a change on this control.

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -110,6 +110,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
 
+        public FormTextBox()
+        {
+            // IMPORTANT: bindable value change logic is in constructor intentionally to support
+            // "CreateSettingsControls" being used in a context it is never loaded, but requires bindable storage.
+            current.BindValueChanged(_ => ValueChanged?.Invoke());
+        }
+
         [BackgroundDependencyLoader]
         private void load(OsuColour colours)
         {
@@ -177,7 +184,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
             focusManager = GetContainingFocusManager()!;
             textBox.Focused.BindValueChanged(_ => updateState());
 
-            current.BindValueChanged(_ => ValueChanged?.Invoke());
             current.BindDisabledChanged(_ => updateState(), true);
         }
 

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -23,7 +23,7 @@ using osuTK;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
-    public partial class FormTextBox : CompositeDrawable, IHasCurrentValue<string>, IFormControl
+    public partial class FormTextBox : CompositeDrawable, IFormControl<string>
     {
         public Bindable<string> Current
         {
@@ -62,15 +62,39 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         private readonly BindableWithCurrent<string> current = new BindableWithCurrent<string>();
 
-        /// <summary>
-        /// Caption describing this slider bar, displayed on top of the controls.
-        /// </summary>
-        public LocalisableString Caption { get; init; }
+        private LocalisableString caption;
 
         /// <summary>
-        /// Hint text containing an extended description of this slider bar, displayed in a tooltip when hovering the caption.
+        /// Caption describing this text box, displayed on top of the controls.
         /// </summary>
-        public LocalisableString HintText { get; init; }
+        public LocalisableString Caption
+        {
+            get => caption;
+            set
+            {
+                caption = value;
+
+                if (IsLoaded)
+                    captionText.Caption = value;
+            }
+        }
+
+        private LocalisableString hintText;
+
+        /// <summary>
+        /// Hint text containing an extended description of this text box, displayed in a tooltip when hovering the caption.
+        /// </summary>
+        public LocalisableString HintText
+        {
+            get => hintText;
+            set
+            {
+                hintText = value;
+
+                if (IsLoaded)
+                    captionText.TooltipText = value;
+            }
+        }
 
         /// <summary>
         /// Text displayed in the text box when its contents are empty.
@@ -80,7 +104,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
         private FormControlBackground background = null!;
         private Box flashLayer = null!;
         private InnerTextBox textBox = null!;
-        private FormFieldCaption caption = null!;
+        private FormFieldCaption captionText = null!;
         private IFocusManager focusManager = null!;
 
         [Resolved]
@@ -108,7 +132,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     Spacing = new Vector2(0, 4),
                     Children = new Drawable[]
                     {
-                        caption = new FormFieldCaption
+                        captionText = new FormFieldCaption
                         {
                             Anchor = Anchor.TopLeft,
                             Origin = Anchor.TopLeft,
@@ -182,7 +206,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             textBox.ReadOnly = disabled;
             textBox.Alpha = 1;
 
-            caption.Colour = disabled ? colourProvider.Background1 : colourProvider.Content2;
+            captionText.Colour = disabled ? colourProvider.Background1 : colourProvider.Content2;
             textBox.Colour = disabled ? colourProvider.Foreground1 : colourProvider.Content1;
 
             if (Current.Disabled)

--- a/osu.Game/Graphics/UserInterfaceV2/IFormControl.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/IFormControl.cs
@@ -4,6 +4,8 @@
 using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 
 namespace osu.Game.Graphics.UserInterfaceV2
 {
@@ -12,6 +14,16 @@ namespace osu.Game.Graphics.UserInterfaceV2
     /// </summary>
     public interface IFormControl : IDrawable, IHasFilterTerms
     {
+        /// <summary>
+        /// Caption describing this control, displayed on top of the controls.
+        /// </summary>
+        LocalisableString Caption { get; set; }
+
+        /// <summary>
+        /// Hint text containing an extended description of this control, displayed in a tooltip when hovering the caption.
+        /// </summary>
+        LocalisableString HintText { get; set; }
+
         /// <summary>
         /// Invoked when the value of the control has changed.
         /// </summary>
@@ -38,4 +50,6 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         float MainDrawHeight { get; }
     }
+
+    public interface IFormControl<T> : IFormControl, IHasCurrentValue<T>;
 }


### PR DESCRIPTION
Depends on https://github.com/ppy/osu/pull/37949.

This is the first step to migrating all the form controls defined
through `SettingSourceAttribue` to the new V2 ones.

For now this only allows specifying V2 form controls as the
`SettingControlType`, while also making them the default for any
bindable that does not specify a custom type. Follow-up PRs will be made
to port remaining controls that still use the old components, and also
fix any UI discrepancies caused by the new controls.

# [Add common form control properties to IFormControl](https://github.com/ppy/osu/commit/d1090dfb863057f0d6a37acc6698a4995393d851)

This is mostly a cleanup pass over the existing form control classes in order to add the necessary properties to `IFormControl` that will later be used in the actual change to `SettingSourceExtensions`. Also adjusts some comments/docstrings that were not accurate to the class they were written in.

# [Allow using V2 form controls in SettingSourceAttribute](https://github.com/ppy/osu/commit/2a86bbab1534ed39c2d224ee83defb4cec90e6a6)

The actual change in question.