### PR TITLE
Fix spinner drain not correctly considered after a break

### DIFF
--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -3,18 +3,15 @@
 
 #nullable disable
 
-using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Tests.Visual;
 
@@ -215,22 +212,43 @@ namespace osu.Game.Tests.Gameplay
             assertHealthNotEqualTo(0);
         }
 
+        /// <summary>
+        /// Tests an edge case where a single judgement should result in no drain,
+        /// but the simulation instead overflows and keeps drain at a high value.
+        /// </summary>
         [Test]
-        public void TestSingleLongObjectDoesNotDrain()
+        public void TestSingleJudgementDoesNotImmediatelyKill()
         {
-            var beatmap = new Beatmap
+            DrainingHealthProcessor hp = new DrainingHealthProcessor(0);
+            hp.ApplyBeatmap(new Beatmap<JudgeableHitObject>
             {
-                HitObjects = { new JudgeableLongHitObject() }
-            };
+                HitObjects =
+                {
+                    new JudgeableHitObject(),
+                }
+            });
 
-            beatmap.HitObjects[0].ApplyDefaults(new ControlPointInfo(), new BeatmapDifficulty());
+            Assert.That(hp.DrainRate, Is.Zero);
+        }
 
-            createProcessor(beatmap);
-            setTime(0);
-            assertHealthEqualTo(1);
+        /// <summary>
+        /// Similar to <see cref="TestSingleJudgementDoesNotImmediatelyKill"/>,
+        /// but forces an effective zero drain length through multiple immediate judgements.
+        /// </summary>
+        [Test]
+        public void TestZeroEffectiveLengthDoesNotImmediatelyKill()
+        {
+            DrainingHealthProcessor hp = new DrainingHealthProcessor(0);
+            hp.ApplyBeatmap(new Beatmap<JudgeableHitObject>
+            {
+                HitObjects =
+                {
+                    new JudgeableHitObject(),
+                    new JudgeableHitObject()
+                }
+            });
 
-            setTime(5000);
-            assertHealthEqualTo(1);
+            Assert.That(hp.DrainRate, Is.Zero);
         }
 
         [Test]
@@ -398,24 +416,6 @@ namespace osu.Game.Tests.Gameplay
                 {
                     MaxResult = maxResult;
                 }
-            }
-        }
-
-        private class JudgeableLongHitObject : JudgeableHitObject, IHasDuration
-        {
-            public double EndTime => StartTime + Duration;
-            public double Duration { get; set; } = 5000;
-
-            public JudgeableLongHitObject()
-                : base(HitResult.LargeBonus)
-            {
-            }
-
-            protected override void CreateNestedHitObjects(CancellationToken cancellationToken)
-            {
-                base.CreateNestedHitObjects(cancellationToken);
-
-                AddNested(new JudgeableHitObject());
             }
         }
     }

--- a/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
+++ b/osu.Game.Tests/Gameplay/TestSceneDrainingHealthProcessor.cs
@@ -311,6 +311,35 @@ namespace osu.Game.Tests.Gameplay
             Assert.That(hp.DrainRate, Is.EqualTo(9.1E-5).Within(0.1E-5));
         }
 
+        [Test]
+        public void TestDrainRateAroundBreaks()
+        {
+            DrainingHealthProcessor hp = new DrainingHealthProcessor(0);
+            hp.ApplyBeatmap(new Beatmap<JudgeableHitObject>
+            {
+                HitObjects =
+                {
+                    // Normal hit circle.
+                    new JudgeableHitObject { StartTime = 0 },
+
+                    // Spinner ticks.
+                    new JudgeableHitObject(HitResult.SmallBonus) { StartTime = 6000 },
+                    new JudgeableHitObject(HitResult.SmallBonus) { StartTime = 7000 },
+                    new JudgeableHitObject(HitResult.SmallBonus) { StartTime = 8000 },
+                    new JudgeableHitObject(HitResult.SmallBonus) { StartTime = 9000 },
+
+                    // Spinner end. This is the first object with a non-zero health increase after the break.
+                    new JudgeableHitObject { StartTime = 10000 }
+                },
+                Breaks =
+                {
+                    new BreakPeriod(1000, 5000)
+                }
+            });
+
+            Assert.That(hp.DrainRate, Is.EqualTo(2.2E-5).Within(0.1E-5));
+        }
+
         private Beatmap createBeatmap(double startTime, double endTime, params BreakPeriod[] breaks)
         {
             var beatmap = new Beatmap

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -167,7 +167,8 @@ namespace osu.Game.Rulesets.Scoring
 
         protected virtual double ComputeDrainRate()
         {
-            if (healthIncreases.Count <= 1)
+            // Drain requires there to be at least two objects in general.
+            if (healthIncreases.Count < 2)
                 return 0;
 
             int adjustment = 1;
@@ -207,14 +208,15 @@ namespace osu.Game.Rulesets.Scoring
 
                 // Stop if the resulting health is within a reasonable offset from the target
                 if (Math.Abs(lowestHealth - targetMinimumHealth) <= minimum_health_error)
-                    break;
+                    return result;
 
                 // This effectively works like a binary search - each iteration the search space moves closer to the target, but may exceed it.
                 adjustment *= 2;
                 result += 1.0 / adjustment * Math.Sign(lowestHealth - targetMinimumHealth);
             }
 
-            return result;
+            // The target health couldn't be reached.
+            return 0;
         }
 
         private record struct HealthIncrease(double Time, double Amount);

--- a/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs
@@ -134,11 +134,16 @@ namespace osu.Game.Rulesets.Scoring
         {
             base.ApplyResultInternal(result);
 
-            if (IsSimulating && !result.Type.IsBonus())
+            if (IsSimulating)
             {
-                healthIncreases.Add(new HealthIncrease(
-                    result.HitObject.GetEndTime() + result.TimeOffset,
-                    GetHealthIncreaseFor(result)));
+                if (result.Type.IsBonus())
+                {
+                    // Bonus objects are treated as if they don't award any health - they are optional.
+                    // However, they still need to be tracked in order for drain to start at the correct point in time after a break.
+                    healthIncreases.Add(new HealthIncrease(result.HitObject.GetEndTime() + result.TimeOffset, 0));
+                }
+                else
+                    healthIncreases.Add(new HealthIncrease(result.HitObject.GetEndTime() + result.TimeOffset, GetHealthIncreaseFor(result)));
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/37046

## Background

### 1. Between two objects separated by a break, there is no drain between the first object and the start of the break, and between the end of the break and the start of the second object.

This is a mechanic that is carry-forward from osu!stable.

For drain, the implementation of this lies here:

https://github.com/ppy/osu/blob/101cfffb80577e1910cb741b496743c2427617fa/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs#L107-L120

And for simulation, the implementation lies here:

https://github.com/ppy/osu/blob/101cfffb80577e1910cb741b496743c2427617fa/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs#L184-L191

### 2. Bonus objects are not required to be hit towards drain.

This is an osu!lazer-specific mechanic implemented since https://github.com/ppy/osu/pull/9528 and intended to fix osu!catch bananas over-weighting drain.

https://github.com/ppy/osu/blob/101cfffb80577e1910cb741b496743c2427617fa/osu.Game/Rulesets/Scoring/DrainingHealthProcessor.cs#L133-L143

## Problem

The issue arises in the following scenario:

```
(c = "combo object", - = "break", b = "bonus object")

                    c ------------------- bbbbbbbbbbbbc
no drain:             ^^^^^^^^^^^^^^^^^^^
gameplay drain:    ^^                     ^^^^^^^^^^^^^^
simulation drain:  ^^                                 ^^
```

In this case, the second drain section would be _simulated_ to start only at the second combo object, but in gameplay it actually starts with the leading bonus objects. This occurs because bonus objects are not tracked at all as a result of (2) from above.

Demonstration: [broken.zip](https://github.com/user-attachments/files/28460458/broken.zip)

## Fix

I've chosen to track the points in time where the bonus objects occur while keeping the osu!lazer-specific bonus object exclusion.