### PR TITLE
Add bookmark feature for replays

### DIFF
--- a/osu.Game.Tests/Database/ReplayBookmarkDatabaseTests.cs
+++ b/osu.Game.Tests/Database/ReplayBookmarkDatabaseTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Game.Beatmaps;
+using osu.Game.Scoring;
+
+namespace osu.Game.Tests.Database
+{
+    [TestFixture]
+    public class ReplayBookmarkDatabaseTests : RealmTest
+    {
+        [Test]
+        public void TestBookmarksPersist()
+        {
+            RunTestWithRealmAsync(async (realm, _) =>
+            {
+                Guid id = Guid.NewGuid();
+
+                await realm.WriteAsync(r =>
+                {
+                    var ruleset = CreateRuleset();
+                    r.Add(ruleset);
+                    r.Add(new ScoreInfo(ruleset: ruleset, beatmap: new BeatmapInfo(ruleset: ruleset)) { ID = id });
+                });
+
+                await realm.WriteAsync(r =>
+                {
+                    var si = r.Find<ScoreInfo>(id)!;
+                    si.ReplayBookmarks.Add(1000);
+                    si.ReplayBookmarks.Add(5000);
+                    si.ReplayBookmarks.Add(12000);
+                });
+
+                realm.Run(r => r.Refresh());
+
+                int[] bookmarks = realm.Run(r => r.Find<ScoreInfo>(id)!.ReplayBookmarks.ToArray());
+                Assert.That(bookmarks, Is.EqualTo(new[] { 1000, 5000, 12000 }));
+            });
+        }
+
+        [Test]
+        public void TestBookmarksClearedAndReplaced()
+        {
+            RunTestWithRealmAsync(async (realm, _) =>
+            {
+                Guid id = Guid.NewGuid();
+
+                await realm.WriteAsync(r =>
+                {
+                    var ruleset = CreateRuleset();
+                    r.Add(ruleset);
+                    r.Add(new ScoreInfo(ruleset: ruleset, beatmap: new BeatmapInfo(ruleset: ruleset)) { ID = id });
+                });
+
+                await realm.WriteAsync(r =>
+                {
+                    var si = r.Find<ScoreInfo>(id)!;
+                    si.ReplayBookmarks.Add(1000);
+                    si.ReplayBookmarks.Add(2000);
+                });
+
+                await realm.WriteAsync(r =>
+                {
+                    var si = r.Find<ScoreInfo>(id)!;
+                    si.ReplayBookmarks.Clear();
+                    si.ReplayBookmarks.Add(9000);
+                });
+
+                realm.Run(r => r.Refresh());
+
+                int[] bookmarks = realm.Run(r => r.Find<ScoreInfo>(id)!.ReplayBookmarks.ToArray());
+                Assert.That(bookmarks, Is.EqualTo(new[] { 9000 }));
+            });
+        }
+
+        [Test]
+        public void TestNoBookmarksReturnsEmpty()
+        {
+            RunTestWithRealmAsync(async (realm, _) =>
+            {
+                Guid id = Guid.NewGuid();
+
+                await realm.WriteAsync(r =>
+                {
+                    var ruleset = CreateRuleset();
+                    r.Add(ruleset);
+                    r.Add(new ScoreInfo(ruleset: ruleset, beatmap: new BeatmapInfo(ruleset: ruleset)) { ID = id });
+                });
+
+                realm.Run(r => r.Refresh());
+
+                int[] bookmarks = realm.Run(r => r.Find<ScoreInfo>(id)!.ReplayBookmarks.ToArray());
+                Assert.That(bookmarks, Is.Empty);
+            });
+        }
+    }
+}

--- a/osu.Game.Tests/Database/ReplayBookmarkDatabaseTests.cs
+++ b/osu.Game.Tests/Database/ReplayBookmarkDatabaseTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
-using osu.Framework.Extensions;
 using osu.Game.Beatmaps;
 using osu.Game.Scoring;
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayBookmark.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayBookmark.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Play;
-using osu.Game.Tests.Visual;
 
 namespace osu.Game.Tests.Visual.Gameplay
 {

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneReplayBookmark.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneReplayBookmark.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.Visual.Gameplay
+{
+    public partial class TestSceneReplayBookmark : RateAdjustedBeatmapTestScene
+    {
+        private TestReplayPlayer player = null!;
+
+        private ReplayBookmarkController bookmarkController
+            => player.ChildrenOfType<ReplayBookmarkController>().Single();
+
+        private void loadPlayer()
+        {
+            AddStep("load replay player", () =>
+            {
+                var ruleset = new OsuRuleset();
+                Beatmap.Value = CreateWorkingBeatmap(ruleset.RulesetInfo);
+                SelectedMods.Value = new[] { ruleset.GetAutoplayMod() };
+                player = new TestReplayPlayer(false);
+                LoadScreen(player);
+            });
+
+            AddUntilStep("wait for player loaded", () => player.IsLoaded);
+        }
+
+        [Test]
+        public void TestAddBookmark()
+        {
+            loadPlayer();
+
+            AddStep("seek to 5000", () => player.Seek(5000));
+            AddStep("add bookmark", () => bookmarkController.AddBookmarkAtCurrentTime());
+
+            AddAssert("one bookmark added", () => bookmarkController.Bookmarks.Count, () => Is.EqualTo(1));
+            AddAssert("bookmark near 5000", () => bookmarkController.Bookmarks[0], () => Is.EqualTo(5000).Within(200));
+        }
+
+        [Test]
+        public void TestNoDuplicateBookmark()
+        {
+            loadPlayer();
+
+            AddStep("seek to 5000", () => player.Seek(5000));
+            AddStep("add bookmark twice", () =>
+            {
+                bookmarkController.AddBookmarkAtCurrentTime();
+                bookmarkController.AddBookmarkAtCurrentTime();
+            });
+
+            AddAssert("only one bookmark", () => bookmarkController.Bookmarks.Count, () => Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestRemoveClosestBookmark()
+        {
+            loadPlayer();
+
+            AddStep("add bookmark at 5000", () => bookmarkController.Bookmarks.Add(5000));
+            AddStep("seek near bookmark", () => player.Seek(4500));
+            AddStep("remove closest", () => bookmarkController.RemoveClosestBookmark());
+
+            AddAssert("no bookmarks remain", () => bookmarkController.Bookmarks.Count, () => Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestRemoveDoesNothingWhenFar()
+        {
+            loadPlayer();
+
+            AddStep("add bookmark at 5000", () => bookmarkController.Bookmarks.Add(5000));
+            AddStep("seek far from bookmark", () => player.Seek(10000));
+            AddStep("remove closest", () => bookmarkController.RemoveClosestBookmark());
+
+            AddAssert("bookmark still present", () => bookmarkController.Bookmarks.Count, () => Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestSeekToNextBookmark()
+        {
+            loadPlayer();
+
+            AddStep("add bookmarks", () =>
+            {
+                bookmarkController.Bookmarks.Add(3000);
+                bookmarkController.Bookmarks.Add(7000);
+            });
+            AddStep("seek to start", () => player.Seek(0));
+            AddStep("seek to next bookmark", () => bookmarkController.SeekBookmark(1));
+
+            AddUntilStep("clock near first bookmark", () => player.GameplayClockContainer.CurrentTime, () => Is.EqualTo(3000).Within(500));
+        }
+
+        [Test]
+        public void TestSeekToPreviousBookmark()
+        {
+            loadPlayer();
+
+            AddStep("add bookmarks", () =>
+            {
+                bookmarkController.Bookmarks.Add(3000);
+                bookmarkController.Bookmarks.Add(7000);
+            });
+            AddStep("seek past second bookmark", () => player.Seek(9000));
+            AddStep("seek to previous bookmark", () => bookmarkController.SeekBookmark(-1));
+
+            AddUntilStep("clock near second bookmark", () => player.GameplayClockContainer.CurrentTime, () => Is.EqualTo(7000).Within(500));
+        }
+
+        [Test]
+        public void TestSeekWithNoBookmarksDoesNotThrow()
+        {
+            loadPlayer();
+
+            AddAssert("no bookmarks", () => bookmarkController.Bookmarks.Count, () => Is.EqualTo(0));
+            AddStep("seek forward (no-op)", () => bookmarkController.SeekBookmark(1));
+            AddStep("seek backward (no-op)", () => bookmarkController.SeekBookmark(-1));
+        }
+    }
+}

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -101,8 +101,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2026-05-22    Add ScoreInfo.ReplayBookmarks
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -195,6 +195,10 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(InputKey.Right, GlobalAction.SeekReplayForward),
             new KeyBinding(InputKey.Comma, GlobalAction.StepReplayBackward),
             new KeyBinding(InputKey.Period, GlobalAction.StepReplayForward),
+            new KeyBinding(new[] { InputKey.Control, InputKey.B }, GlobalAction.ReplayAddBookmark),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.B }, GlobalAction.ReplayRemoveClosestBookmark),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Left }, GlobalAction.ReplaySeekToPreviousBookmark),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Right }, GlobalAction.ReplaySeekToNextBookmark),
             new KeyBinding(new[] { InputKey.Control, InputKey.H }, GlobalAction.ToggleReplaySettings),
         };
 
@@ -535,7 +539,19 @@ namespace osu.Game.Input.Bindings
         EditorSubmitBeatmap,
 
         [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.EditExternally))]
-        EditorEditExternally
+        EditorEditExternally,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ReplayAddBookmark))]
+        ReplayAddBookmark,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ReplayRemoveClosestBookmark))]
+        ReplayRemoveClosestBookmark,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ReplaySeekToPreviousBookmark))]
+        ReplaySeekToPreviousBookmark,
+
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ReplaySeekToNextBookmark))]
+        ReplaySeekToNextBookmark
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -365,6 +365,26 @@ namespace osu.Game.Localisation
         public static LocalisableString StepReplayBackward => new TranslatableString(getKey(@"step_replay_backward"), @"Step replay backward one frame");
 
         /// <summary>
+        /// "Add bookmark to timeline"
+        /// </summary>
+        public static LocalisableString ReplayAddBookmark => new TranslatableString(getKey(@"add_replay_bookmark"), @"Add bookmark to timeline");
+        
+        /// <summary>
+        /// "Remove closest bookmark from timeline"
+        /// </summary>
+        public static LocalisableString ReplayRemoveClosestBookmark => new TranslatableString(getKey(@"remove_replay_closest_bookmark"), @"Remove closest bookmark from timeline");
+
+        /// <summary>
+        /// "Seek to previous bookmark"
+        /// </summary>
+        public static LocalisableString ReplaySeekToPreviousBookmark => new TranslatableString(getKey(@"seek_replay_to_previous_bookmark"), @"Seek to previous bookmark");
+
+        /// <summary>
+        /// "Seek to next bookmark"
+        /// </summary>
+        public static LocalisableString ReplaySeekToNextBookmark => new TranslatableString(getKey(@"seek_replay_to_next_bookmark"), @"Seek to next bookmark");
+        
+        /// <summary>
         /// "Toggle chat focus"
         /// </summary>
         public static LocalisableString ToggleChatFocus => new TranslatableString(getKey(@"toggle_chat_focus"), @"Toggle chat focus");

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -368,7 +368,7 @@ namespace osu.Game.Localisation
         /// "Add bookmark to timeline"
         /// </summary>
         public static LocalisableString ReplayAddBookmark => new TranslatableString(getKey(@"add_replay_bookmark"), @"Add bookmark to timeline");
-        
+
         /// <summary>
         /// "Remove closest bookmark from timeline"
         /// </summary>
@@ -383,7 +383,7 @@ namespace osu.Game.Localisation
         /// "Seek to next bookmark"
         /// </summary>
         public static LocalisableString ReplaySeekToNextBookmark => new TranslatableString(getKey(@"seek_replay_to_next_bookmark"), @"Seek to next bookmark");
-        
+
         /// <summary>
         /// "Toggle chat focus"
         /// </summary>

--- a/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
+++ b/osu.Game/Scoring/Legacy/LegacyReplaySoloScoreInfo.cs
@@ -52,6 +52,9 @@ namespace osu.Game.Scoring.Legacy
         [JsonProperty("pauses")]
         public int[] Pauses { get; set; } = [];
 
+        [JsonProperty("replay_bookmarks")]
+        public int[] ReplayBookmarks { get; set; } = [];
+
         public static LegacyReplaySoloScoreInfo FromScore(ScoreInfo score) => new LegacyReplaySoloScoreInfo
         {
             OnlineID = score.OnlineID,
@@ -63,6 +66,7 @@ namespace osu.Game.Scoring.Legacy
             UserID = score.User.OnlineID,
             TotalScoreWithoutMods = score.TotalScoreWithoutMods > 0 ? score.TotalScoreWithoutMods : null,
             Pauses = score.Pauses.ToArray(),
+            ReplayBookmarks = score.ReplayBookmarks.ToArray(),
         };
     }
 }

--- a/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreDecoder.cs
@@ -145,6 +145,7 @@ namespace osu.Game.Scoring.Legacy
                             PopulateTotalScoreWithoutMods(score.ScoreInfo);
 
                         score.ScoreInfo.Pauses.AddRange(readScore.Pauses);
+                        score.ScoreInfo.ReplayBookmarks.AddRange(readScore.ReplayBookmarks);
                     });
                 }
             }

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -158,6 +158,8 @@ namespace osu.Game.Scoring
 
         public IList<int> Pauses { get; } = null!;
 
+        public IList<int> ReplayBookmarks { get; } = null!;
+
         public ScoreInfo(BeatmapInfo? beatmap = null, RulesetInfo? ruleset = null, RealmUser? realmUser = null)
         {
             Ruleset = ruleset ?? new RulesetInfo();

--- a/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/ArgonSongProgress.cs
@@ -122,16 +122,33 @@ namespace osu.Game.Screens.Play.HUD
             graph.FadeTo(ShowGraph.Value ? 1 : 0, 200, Easing.In);
         }
 
+        private ReplayBookmarkOverlayBar? bookmarkOverlay;
+
         protected override void Update()
         {
             base.Update();
             content.Height = bar.Height + bar_height + info.Height;
             graphContainer.Height = bar.Height;
+            if (bookmarkOverlay != null)
+                bookmarkOverlay.Height = bar.Height;
         }
 
         protected override void UpdateProgress(double progress, bool isIntro)
         {
             bar.Progress = isIntro ? 0 : progress;
+        }
+
+        protected override Drawable CreateBookmarkOverlay()
+        {
+            return bookmarkOverlay = new ReplayBookmarkOverlayBar
+            {
+                Anchor = Anchor.BottomLeft,
+                Origin = Anchor.BottomLeft,
+                RelativeSizeAxes = Axes.X,
+                Height = bar_height,
+                StartTime = FirstHitTime,
+                EndTime = LastHitTime,
+            };
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/DefaultSongProgressGraph.cs
+++ b/osu.Game/Screens/Play/HUD/DefaultSongProgressGraph.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
+using osu.Framework.Allocation;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Objects;
 
@@ -13,6 +14,14 @@ namespace osu.Game.Screens.Play.HUD
 {
     public partial class DefaultSongProgressGraph : SquareGraph
     {
+        private const int granularity = 200;
+
+        private double firstHit;
+        private double lastHit;
+
+        [Resolved(CanBeNull = true)]
+        private ReplayBookmarkController bookmarkController { get; set; }
+
         private IEnumerable<HitObject> objects;
 
         public IEnumerable<HitObject> Objects
@@ -21,13 +30,15 @@ namespace osu.Game.Screens.Play.HUD
             {
                 objects = value;
 
-                const int granularity = 200;
                 Values = new int[granularity];
+
+                firstHit = 0;
+                lastHit = 0;
 
                 if (!objects.Any())
                     return;
 
-                (double firstHit, double lastHit) = BeatmapExtensions.CalculatePlayableBounds(objects);
+                (firstHit, lastHit) = BeatmapExtensions.CalculatePlayableBounds(objects);
 
                 if (lastHit == 0)
                     lastHit = objects.Last().StartTime;
@@ -46,6 +57,35 @@ namespace osu.Game.Screens.Play.HUD
                         Values[i]++;
                 }
             }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            bookmarkController?.Bookmarks.BindCollectionChanged((_, _) => RedrawBookmarks(), false);
+        }
+
+        protected override void RedrawBookmarks()
+        {
+            if (bookmarkController == null || ColumnCount == 0) return;
+
+            double length = lastHit - firstHit + 1;
+            if (length <= 0) return;
+
+            double interval = length / ColumnCount;
+
+            for (int i = 0; i < ColumnCount; i++)
+                Columns[i].IsBookmarked = false;
+
+            foreach (int b in bookmarkController.Bookmarks)
+            {
+                int col = (int)((b - firstHit) / interval);
+                if (col >= 0 && col < ColumnCount)
+                    Columns[col].IsBookmarked = true;
+            }
+
+            Columns.ForceRedraw();
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/SongProgress.cs
+++ b/osu.Game/Screens/Play/HUD/SongProgress.cs
@@ -38,6 +38,9 @@ namespace osu.Game.Screens.Play.HUD
         protected IGameplayClock GameplayClock { get; private set; } = null!;
 
         [Resolved]
+        protected ReplayBookmarkController? BookmarkController { get; private set; }
+
+        [Resolved]
         private IFrameStableClock? frameStableClock { get; set; }
 
         /// <summary>
@@ -64,8 +67,17 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
+            if (BookmarkController != null)
+            {
+                var overlay = CreateBookmarkOverlay();
+                if (overlay != null)
+                    AddInternal(overlay);
+            }
+
             Show();
         }
+
+        protected virtual Drawable? CreateBookmarkOverlay() => null;
 
         protected double FirstHitTime { get; private set; }
 

--- a/osu.Game/Screens/Play/ReplayBookmarkController.cs
+++ b/osu.Game/Screens/Play/ReplayBookmarkController.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Database;
+using osu.Game.Scoring;
+
+namespace osu.Game.Screens.Play
+{
+    /// <summary>
+    /// Manages replay bookmarks for a replay session.
+    /// Bookmarks are persisted when the score is stored in the database (e.g. not for autoplay).
+    /// </summary>
+    public partial class ReplayBookmarkController : Component
+    {
+        [Resolved]
+        private RealmAccess realm { get; set; } = null!;
+
+        [Resolved]
+        private ReplaySeekController seekController { get; set; } = null!;
+
+        [Resolved]
+        private ScoreInfo scoreInfo { get; set; } = null!;
+
+        public readonly BindableList<int> Bookmarks = new BindableList<int>();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            Bookmarks.AddRange(scoreInfo.ReplayBookmarks);
+
+            var id = scoreInfo.ID;
+            Bookmarks.BindCollectionChanged((_, _) =>
+            {
+                int[] current = Bookmarks.ToArray();
+                realm.Write(r =>
+                {
+                    var s = r.Find<ScoreInfo>(id);
+                    if (s == null) return;
+
+                    s.ReplayBookmarks.Clear();
+                    foreach (int b in current)
+                        s.ReplayBookmarks.Add(b);
+                });
+            });
+        }
+
+        public void AddBookmarkAtCurrentTime()
+        {
+            int bookmark = (int)seekController.CurrentTime;
+            int idx = Bookmarks.BinarySearch(bookmark);
+            if (idx < 0)
+                Bookmarks.Insert(~idx, bookmark);
+        }
+
+        public void RemoveClosestBookmark()
+        {
+            if (!Bookmarks.Any(b => Math.Abs(b - seekController.CurrentTime) < 2000))
+                return;
+
+            int closestBookmark = Bookmarks.MinBy(b => Math.Abs(b - seekController.CurrentTime));
+            Bookmarks.Remove(closestBookmark);
+        }
+
+        public void SeekBookmark(int direction)
+        {
+            // In the case of a backwards seek while playing, it can be hard to jump before a bookmark.
+            // Adding some lenience here makes it more user-friendly.
+            double seekLenience = seekController.IsRunning ? 1000 * seekController.Rate : 0;
+
+            int? targetBookmark = direction < 1
+                ? Bookmarks.Cast<int?>().LastOrDefault(b => b < seekController.CurrentTime - seekLenience)
+                : Bookmarks.Cast<int?>().FirstOrDefault(b => b > seekController.CurrentTime);
+
+            if (targetBookmark != null)
+                seekController.SeekSmoothlyTo(targetBookmark.Value);
+        }
+    }
+}

--- a/osu.Game/Screens/Play/ReplayBookmarkOverlayBar.cs
+++ b/osu.Game/Screens/Play/ReplayBookmarkOverlayBar.cs
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Extensions;
+using osu.Game.Graphics;
+
+namespace osu.Game.Screens.Play
+{
+    /// <summary>
+    /// Draws bookmark markers positioned over a horizontal replay progress bar.
+    /// </summary>
+    public partial class ReplayBookmarkOverlayBar : Container
+    {
+        private double startTime;
+
+        public double StartTime
+        {
+            get => startTime;
+            set
+            {
+                startTime = value;
+                if (IsLoaded) redrawMarkers();
+            }
+        }
+
+        private double endTime = 1;
+
+        public double EndTime
+        {
+            get => endTime;
+            set
+            {
+                endTime = value;
+                if (IsLoaded) redrawMarkers();
+            }
+        }
+
+        [Resolved]
+        private ReplayBookmarkController bookmarkController { get; set; } = null!;
+
+        private DrawablePool<ReplayBookmarkMarker> pool = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(pool = new DrawablePool<ReplayBookmarkMarker>(10));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            bookmarkController.Bookmarks.BindCollectionChanged((_, _) => redrawMarkers(), true);
+        }
+
+        private void redrawMarkers()
+        {
+            Clear(disposeChildren: false);
+
+            double length = endTime - startTime;
+            if (length <= 0) return;
+
+            foreach (int bookmark in bookmarkController.Bookmarks)
+            {
+                Add(pool.Get(v =>
+                {
+                    v.X = (float)((bookmark - startTime) / length);
+                    v.BookmarkTime = bookmark;
+                }));
+            }
+        }
+
+        private partial class ReplayBookmarkMarker : PoolableDrawable, IHasTooltip
+        {
+            public int BookmarkTime { get; set; }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                RelativePositionAxes = Axes.X;
+                RelativeSizeAxes = Axes.Y;
+
+                Anchor = Anchor.BottomLeft;
+                Origin = Anchor.BottomCentre;
+
+                Width = 4;
+                Height = 1.0f;
+
+                InternalChild = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colours.Red.Opacity(0.6f),
+                };
+            }
+
+            public LocalisableString TooltipText => $"{((double)BookmarkTime).ToEditorFormattedString()} bookmark";
+        }
+    }
+}

--- a/osu.Game/Screens/Play/ReplayPlayer.cs
+++ b/osu.Game/Screens/Play/ReplayPlayer.cs
@@ -50,6 +50,16 @@ namespace osu.Game.Screens.Play
 
         public ReplayOverlay ReplayOverlay { get; private set; } = null!;
 
+        [Cached]
+        private readonly ReplayBookmarkController bookmarkController = new ReplayBookmarkController();
+
+        private ReplaySeekController seekController = null!;
+
+        private DependencyContainer dependencies = null!;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            => dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
+
         protected override bool CheckModsAllowFailure()
         {
             // autoplay should be able to fail if the beatmap is not humanly beatable
@@ -92,6 +102,12 @@ namespace osu.Game.Screens.Play
                 return;
 
             AddInternal(leaderboardProvider);
+
+            dependencies.CacheAs(seekController = new ReplaySeekController(GameplayClockContainer));
+            AddInternal(seekController);
+
+            dependencies.CacheAs(Score.ScoreInfo);
+            AddInternal(bookmarkController);
 
             GameplayClockContainer.Add(ReplayOverlay = new ReplayOverlay());
 
@@ -190,6 +206,22 @@ namespace osu.Game.Screens.Play
                         GameplayClockContainer.Start();
                     else
                         GameplayClockContainer.Stop();
+                    return true;
+
+                case GlobalAction.ReplayAddBookmark:
+                    bookmarkController.AddBookmarkAtCurrentTime();
+                    return true;
+
+                case GlobalAction.ReplaySeekToPreviousBookmark:
+                    bookmarkController.SeekBookmark(-1);
+                    return true;
+
+                case GlobalAction.ReplaySeekToNextBookmark:
+                    bookmarkController.SeekBookmark(1);
+                    return true;
+
+                case GlobalAction.ReplayRemoveClosestBookmark:
+                    bookmarkController.RemoveClosestBookmark();
                     return true;
             }
 

--- a/osu.Game/Screens/Play/ReplaySeekController.cs
+++ b/osu.Game/Screens/Play/ReplaySeekController.cs
@@ -1,0 +1,77 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Transforms;
+using osu.Framework.Timing;
+using osu.Framework.Utils;
+
+namespace osu.Game.Screens.Play
+{
+    /// <summary>
+    /// Provides seek operations for replay playback, including smooth animated seeking.
+    /// This is not a clock — <see cref="GameplayClockContainer"/> remains the timing source.
+    /// This component exists solely to give <see cref="ReplayBookmarkController"/> a way to
+    /// seek without a direct reference to <see cref="ReplayPlayer"/>.
+    /// </summary>
+    public partial class ReplaySeekController : Component
+    {
+        private readonly GameplayClockContainer gameplayClockContainer;
+
+        public double CurrentTime => gameplayClockContainer.CurrentTime;
+
+        public bool IsRunning => gameplayClockContainer.IsRunning;
+
+        public double Rate => ((IAdjustableClock)gameplayClockContainer).Rate;
+
+        public ReplaySeekController(GameplayClockContainer gameplayClockContainer)
+        {
+            this.gameplayClockContainer = gameplayClockContainer;
+        }
+
+        public void Seek(double time) => gameplayClockContainer.Seek(time);
+
+        /// <summary>
+        /// Seeks smoothly to the destination if close enough, otherwise seeks immediately.
+        /// </summary>
+        public void SeekSmoothlyTo(double seekDestination)
+        {
+            const double smooth_seek_max_proximity = 5000;
+
+            if (IsRunning || Math.Abs(seekDestination - CurrentTime) > smooth_seek_max_proximity)
+            {
+                Seek(seekDestination);
+                return;
+            }
+
+            transformSeekTo(seekDestination, 300, Easing.OutQuint);
+        }
+
+        private void transformSeekTo(double seek, double duration = 0, Easing easing = Easing.None)
+            => this.TransformTo(this.PopulateTransform(new TransformSeek(), seek, duration, easing));
+
+        private double currentTime
+        {
+            get => gameplayClockContainer.CurrentTime;
+            set => gameplayClockContainer.Seek(value);
+        }
+
+        private class TransformSeek : Transform<double, ReplaySeekController>
+        {
+            public override string TargetMember => nameof(currentTime);
+
+            protected override void Apply(ReplaySeekController controller, double time) => controller.currentTime = valueAt(time);
+
+            private double valueAt(double time)
+            {
+                if (time < StartTime) return StartValue;
+                if (time >= EndTime) return EndValue;
+
+                return Interpolation.ValueAt(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            }
+
+            protected override void ReadIntoStartValue(ReplaySeekController controller) => StartValue = controller.currentTime;
+        }
+    }
+}

--- a/osu.Game/Screens/Play/SquareGraph.cs
+++ b/osu.Game/Screens/Play/SquareGraph.cs
@@ -23,9 +23,9 @@ namespace osu.Game.Screens.Play
 {
     public partial class SquareGraph : Container
     {
-        private BufferedContainer<Column> columns;
+        protected BufferedContainer<Column> Columns;
 
-        public int ColumnCount => columns?.Children.Count ?? 0;
+        public int ColumnCount => Columns?.Children.Count ?? 0;
 
         private int progress;
 
@@ -86,7 +86,7 @@ namespace osu.Game.Screens.Play
 
             if (!layout.IsValid)
             {
-                columns?.FadeOut(500, Easing.OutQuint).Expire();
+                Columns?.FadeOut(500, Easing.OutQuint).Expire();
 
                 scheduledCreate?.Cancel();
                 scheduledCreate = Scheduler.AddDelayed(RecreateGraph, 500);
@@ -124,14 +124,17 @@ namespace osu.Game.Screens.Play
 
             LoadComponentAsync(newColumns, c =>
             {
-                Child = columns = c;
-                columns.FadeInFromZero(500, Easing.OutQuint);
+                Child = Columns = c;
+                Columns.FadeInFromZero(500, Easing.OutQuint);
 
                 recalculateValues();
                 redrawFilled();
                 redrawProgress();
+                RedrawBookmarks();
             }, (cts = new CancellationTokenSource()).Token);
         }
+
+        protected virtual void RedrawBookmarks() { }
 
         /// <summary>
         /// Redraws all the columns to match their lit/dimmed state.
@@ -139,8 +142,8 @@ namespace osu.Game.Screens.Play
         private void redrawProgress()
         {
             for (int i = 0; i < ColumnCount; i++)
-                columns[i].State = i <= progress ? ColumnState.Lit : ColumnState.Dimmed;
-            columns?.ForceRedraw();
+                Columns[i].State = i <= progress ? ColumnState.Lit : ColumnState.Dimmed;
+            Columns?.ForceRedraw();
         }
 
         /// <summary>
@@ -149,8 +152,8 @@ namespace osu.Game.Screens.Play
         private void redrawFilled()
         {
             for (int i = 0; i < ColumnCount; i++)
-                columns[i].Filled = calculatedValues.ElementAtOrDefault(i);
-            columns?.ForceRedraw();
+                Columns[i].Filled = calculatedValues.ElementAtOrDefault(i);
+            Columns?.ForceRedraw();
         }
 
         /// <summary>
@@ -185,6 +188,21 @@ namespace osu.Game.Screens.Play
             protected readonly Color4 EmptyColour = Color4.White.Opacity(20);
             public Color4 LitColour = Color4.LightBlue;
             protected readonly Color4 DimmedColour = Color4.White.Opacity(140);
+            public Color4 BookmarkColour = Color4.Red;
+
+            private bool isBookmarked;
+
+            public bool IsBookmarked
+            {
+                get => isBookmarked;
+                set
+                {
+                    if (value == isBookmarked) return;
+
+                    isBookmarked = value;
+                    if (IsLoaded) fillActive();
+                }
+            }
 
             private float cubeCount => DrawHeight / WIDTH;
             private const float cube_size = 4;
@@ -256,9 +274,16 @@ namespace osu.Game.Screens.Play
 
             private void fillActive()
             {
-                Color4 colour = State == ColumnState.Lit ? LitColour : DimmedColour;
-
                 int countFilled = (int)Math.Clamp(filled * drawableRows.Count, 0, drawableRows.Count);
+
+                if (isBookmarked)
+                {
+                    for (int i = 0; i < drawableRows.Count; i++)
+                        drawableRows[i].Colour = i < countFilled ? BookmarkColour : EmptyColour;
+                    return;
+                }
+
+                Color4 colour = State == ColumnState.Lit ? LitColour : DimmedColour;
 
                 for (int i = 0; i < drawableRows.Count; i++)
                     drawableRows[i].Colour = i < countFilled ? colour : EmptyColour;

--- a/osu.Game/Skinning/LegacySongProgress.cs
+++ b/osu.Game/Skinning/LegacySongProgress.cs
@@ -65,6 +65,13 @@ namespace osu.Game.Skinning
             };
         }
 
+        protected override Drawable CreateBookmarkOverlay() => new LegacySongProgressBookmarkOverlay
+        {
+            RelativeSizeAxes = Axes.Both,
+            StartTime = FirstHitTime,
+            EndTime = LastHitTime,
+        };
+
         protected override void UpdateProgress(double progress, bool isIntro)
         {
             if (isIntro)

--- a/osu.Game/Skinning/LegacySongProgressBookmarkOverlay.cs
+++ b/osu.Game/Skinning/LegacySongProgressBookmarkOverlay.cs
@@ -1,0 +1,108 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Localisation;
+using osu.Game.Extensions;
+using osu.Game.Graphics;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Skinning
+{
+    /// <summary>
+    /// Draws bookmark markers as radial tick marks on the legacy circular progress ring.
+    /// </summary>
+    public partial class LegacySongProgressBookmarkOverlay : Container
+    {
+        private double startTime;
+
+        public double StartTime
+        {
+            get => startTime;
+            set
+            {
+                startTime = value;
+                if (IsLoaded) redrawMarkers();
+            }
+        }
+
+        private double endTime = 1;
+
+        public double EndTime
+        {
+            get => endTime;
+            set
+            {
+                endTime = value;
+                if (IsLoaded) redrawMarkers();
+            }
+        }
+
+        [Resolved]
+        private ReplayBookmarkController bookmarkController { get; set; } = null!;
+
+        private DrawablePool<BookmarkTick> pool = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            AddInternal(pool = new DrawablePool<BookmarkTick>(10));
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            bookmarkController.Bookmarks.BindCollectionChanged((_, _) => redrawMarkers(), true);
+        }
+
+        private void redrawMarkers()
+        {
+            Clear(disposeChildren: false);
+
+            double length = endTime - startTime;
+            if (length <= 0) return;
+
+            foreach (int bookmark in bookmarkController.Bookmarks)
+            {
+                float fraction = (float)((bookmark - startTime) / length);
+
+                // rotate a full-size container so the tick at 12 o'clock lands at the bookmark angle.
+                // rotation clockwise, matching CircularProgress which fills from the top.
+                Add(pool.Get(v =>
+                {
+                    v.Rotation = fraction * 360f;
+                    v.BookmarkTime = bookmark;
+                }));
+            }
+        }
+
+        private partial class BookmarkTick : PoolableDrawable, IHasTooltip
+        {
+            public int BookmarkTime { get; set; }
+
+            [BackgroundDependencyLoader]
+            private void load(OsuColour colours)
+            {
+                RelativeSizeAxes = Axes.Both;
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                InternalChild = new Box
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.Centre,
+                    Colour = colours.Red,
+                    Width = 3,
+                    Height = 3,
+                };
+            }
+
+            public LocalisableString TooltipText => $"{((double)BookmarkTime).ToEditorFormattedString()} bookmark";
+        }
+    }
+}


### PR DESCRIPTION
Like the bookmark editor system, we implemented a bookmark system for replays. 
This could improve the UX when watching replays, allowing players to save a specific playback time.

They work similar to the editor’s system and allow to:
- add a bookmark (Ctrl+B)
- remove the nearest bookmark (Ctrl+Shift+B)
- jump between the previous or next bookmark (Alt+Left /Alt+Right).
(shortcuts defined by default)

Bookmark logic is managed by `ReplayBookmarkController.cs`. Bookmarks are persisted in the database, attached to the corresponding score.

Visually, bookmarks appear as small red markers on the song progress bar and work across Argon, Default and Legacy progress bars.

To ensure our feature was functional, we also decided to write some UI (`TestSceneReplayBookmark.cs`) and Unit tests (`ReplayBookmarkDatabaseTests.cs`) to validate its functionality and guarantee everything is working as intended.

https://github.com/user-attachments/assets/00c25d56-327b-4ee1-90a6-05e495f61f27

