### PR TITLE
Add tooltips to SD and PF mod settings

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModPerfect.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModPerfect.cs
@@ -11,7 +11,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 {
     public class ManiaModPerfect : ModPerfect
     {
-        [SettingSource("Require perfect hits")]
+        [SettingSource("Require perfect hits", "Also fail when getting a GREAT hit.")]
         public BindableBool RequirePerfectHits { get; } = new BindableBool();
 
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)

--- a/osu.Game.Rulesets.Osu/Mods/OsuModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModSuddenDeath.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Rulesets.Osu.Mods
             typeof(OsuModTargetPractice),
         }).ToArray();
 
-        [SettingSource("Also fail when missing a slider tail")]
+        [SettingSource("Require perfect combo", "Also fail when missing a slider tail.")]
         public BindableBool FailOnSliderTail { get; } = new BindableBool();
 
         protected override bool FailCondition(HealthProcessor healthProcessor, JudgementResult result)


### PR DESCRIPTION
The PF mod setting ``Require perfect hits`` (osu!mania) is currently missing a tooltip, so I added one.

The SD mod setting ``Also fail when missing a slider tail`` (osu!) is also missing one and in my opinion its name sounds more like a tooltip, so my suggestion is renaming this mod setting to ``Require perfect combo``.