### PR TITLE
Use a space to pad hint text symbol in `FormFieldCaption`

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormFieldCaption.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormFieldCaption.cs
@@ -69,13 +69,15 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             if (TooltipText != default)
             {
+                // Use a space to pad the icon drawable, so that it does not have
+                // an awkward left margin if it gets pushed to a new line.
+                textFlow.AddText(" ", t => t.Width = 5);
                 textFlow.AddArbitraryDrawable(new SpriteIcon
                 {
                     Anchor = Anchor.BottomLeft,
                     Origin = Anchor.BottomLeft,
                     Size = new Vector2(10),
                     Icon = FontAwesome.Solid.QuestionCircle,
-                    Margin = new MarginPadding { Left = 5 },
                     Y = 1f,
                 });
             }


### PR DESCRIPTION
This avoids a case where just the symbol is pushed to the next line, with its left margin making things look ugly.

I would rather have an actual non-breakable space here, which would push the adjacent word to the next line as well, but to my understanding `TextFlowContainer` doesn't handle arbitrary drawables in that way.
    
| Before | After |
|--------|--------|
| <img width="355" height="109" alt="image" src="https://github.com/user-attachments/assets/8c7b1c4b-b467-4a60-83c3-07a7bdca0de8" /> | <img width="356" height="115" alt="image" src="https://github.com/user-attachments/assets/e90e8ae5-24f3-4672-8e05-1a092b1d8a7b" /> | 