### PR TITLE
Fix crash when trying to scope to beatmap set in multiplayer freestyle select screen with sorting/grouping mode which has difficulties split apart

### DIFF
--- a/osu.Game/Screens/Select/PanelBeatmapStandalone.SpreadDisplay.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapStandalone.SpreadDisplay.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Screens.Select
         {
             public Bindable<BeatmapInfo?> Beatmap { get; } = new Bindable<BeatmapInfo?>();
             public Bindable<StarDifficulty> StarDifficulty { get; } = new Bindable<StarDifficulty>();
+            public BindableBool Selected { get; } = new BindableBool();
 
             protected override Colour4 DimColour => Colour4.White;
 
@@ -140,6 +141,8 @@ namespace osu.Game.Screens.Select
                 StarDifficulty.BindValueChanged(_ => updateBeatmap());
                 showConvertedBeatmaps.BindValueChanged(_ => updateBeatmap());
                 scopedBeatmapSet.BindValueChanged(_ => updateBeatmap(), true);
+                Selected.BindValueChanged(_ => updateEnabled());
+                scopedBeatmapSet.BindDisabledChanged(_ => updateEnabled(), true);
                 Enabled.BindValueChanged(_ => updateAppearance(), true);
                 FinishTransforms(true);
             }
@@ -252,6 +255,11 @@ namespace osu.Game.Screens.Select
             {
                 updateAppearance();
                 base.OnHoverLost(e);
+            }
+
+            private void updateEnabled()
+            {
+                Enabled.Value = Selected.Value && !scopedBeatmapSet.Disabled;
             }
 
             private void updateAppearance()

--- a/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
+++ b/osu.Game/Screens/Select/PanelBeatmapStandalone.cs
@@ -194,6 +194,7 @@ namespace osu.Game.Screens.Select
                                         {
                                             Origin = Anchor.CentreLeft,
                                             Anchor = Anchor.CentreLeft,
+                                            Selected = { BindTarget = Selected },
                                         }
                                     },
                                 }
@@ -214,7 +215,6 @@ namespace osu.Game.Screens.Select
             Selected.BindValueChanged(s =>
             {
                 Expanded.Value = s.NewValue;
-                spreadDisplay.Enabled.Value = s.NewValue;
             }, true);
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/37995.

See https://github.com/ppy/osu/blob/9727d95ad9a46ecaafd8b4fe62e68f45db607661/osu.Game/Screens/Select/SongSelect.cs#L91-L95 for why this would crash.