### PR TITLE
Allow filtering the beatmap listing for maps that are not already downloaded

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/BeatmapCard.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Beatmaps.Drawables.Cards
         protected abstract Drawable IdleContent { get; }
         protected abstract Drawable DownloadInProgressContent { get; }
 
-        protected readonly BeatmapDownloadTracker DownloadTracker;
+        public readonly BeatmapDownloadTracker DownloadTracker;
 
         private readonly Bindable<bool> preferNoVideo = new BindableBool();
         private InputManager? containingInputManager;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingFilterControl.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Framework.Threading;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Configuration;
 using osu.Game.Online.API;
@@ -46,7 +47,7 @@ namespace osu.Game.Overlays.BeatmapListing
         /// <summary>
         /// True when pagination has reached the end of available results.
         /// </summary>
-        private bool noMoreResults;
+        public bool NoMoreResults { get; private set; }
 
         /// <summary>
         /// The current page fetched of results (zero index).
@@ -60,7 +61,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private readonly Bindable<BeatmapCardSize> cardSize = new Bindable<BeatmapCardSize>();
 
-        private readonly BeatmapListingSearchControl searchControl;
+        public readonly BeatmapListingSearchControl SearchControl;
         private readonly BeatmapListingSortTabControl sortControl;
         private readonly Box sortControlBackground;
 
@@ -71,6 +72,9 @@ namespace osu.Game.Overlays.BeatmapListing
 
         [Resolved]
         private IAPIProvider api { get; set; }
+
+        [Resolved]
+        private BeatmapManager beatmapManager { get; set; }
 
         private IBindable<APIUser> apiUser;
 
@@ -99,7 +103,7 @@ namespace osu.Game.Overlays.BeatmapListing
                             Radius = 3,
                             Offset = new Vector2(0f, 1f),
                         },
-                        Child = searchControl = new BeatmapListingSearchControl
+                        Child = SearchControl = new BeatmapListingSearchControl
                         {
                             TypingStarted = () => TypingStarted?.Invoke()
                         }
@@ -143,13 +147,13 @@ namespace osu.Game.Overlays.BeatmapListing
         }
 
         public void Search(string query)
-            => Schedule(() => searchControl.Query.Value = query);
+            => Schedule(() => SearchControl.Query.Value = query);
 
         public void FilterGenre(SearchGenre genre)
-            => Schedule(() => searchControl.Genre.Value = genre);
+            => Schedule(() => SearchControl.Genre.Value = genre);
 
         public void FilterLanguage(SearchLanguage language)
-            => Schedule(() => searchControl.Language.Value = language);
+            => Schedule(() => SearchControl.Language.Value = language);
 
         protected override void LoadComplete()
         {
@@ -157,26 +161,27 @@ namespace osu.Game.Overlays.BeatmapListing
 
             config.BindWith(OsuSetting.BeatmapListingCardSize, cardSize);
 
-            searchControl.Query.BindValueChanged(_ =>
+            SearchControl.Query.BindValueChanged(_ =>
             {
                 resetSortControl();
                 queueUpdateSearch(true);
             });
 
-            searchControl.Category.BindValueChanged(_ =>
+            SearchControl.Category.BindValueChanged(_ =>
             {
                 resetSortControl();
                 queueUpdateSearch();
             });
 
-            searchControl.General.CollectionChanged += (_, _) => queueUpdateSearch();
-            searchControl.Ruleset.BindValueChanged(_ => queueUpdateSearch());
-            searchControl.Genre.BindValueChanged(_ => queueUpdateSearch());
-            searchControl.Language.BindValueChanged(_ => queueUpdateSearch());
-            searchControl.Extra.CollectionChanged += (_, _) => queueUpdateSearch();
-            searchControl.Ranks.CollectionChanged += (_, _) => queueUpdateSearch();
-            searchControl.Played.BindValueChanged(_ => queueUpdateSearch());
-            searchControl.ExplicitContent.BindValueChanged(_ => queueUpdateSearch());
+            SearchControl.General.CollectionChanged += (_, _) => queueUpdateSearch();
+            SearchControl.Ruleset.BindValueChanged(_ => queueUpdateSearch());
+            SearchControl.Genre.BindValueChanged(_ => queueUpdateSearch());
+            SearchControl.Language.BindValueChanged(_ => queueUpdateSearch());
+            SearchControl.Extra.CollectionChanged += (_, _) => queueUpdateSearch();
+            SearchControl.Ranks.CollectionChanged += (_, _) => queueUpdateSearch();
+            SearchControl.Played.BindValueChanged(_ => queueUpdateSearch());
+            SearchControl.Downloaded.BindValueChanged(_ => queueUpdateSearch());
+            SearchControl.ExplicitContent.BindValueChanged(_ => queueUpdateSearch());
 
             sortControl.Current.BindValueChanged(_ => queueUpdateSearch());
             sortControl.SortDirection.BindValueChanged(_ => queueUpdateSearch());
@@ -185,7 +190,7 @@ namespace osu.Game.Overlays.BeatmapListing
             apiUser.BindValueChanged(_ => queueUpdateSearch());
         }
 
-        public void TakeFocus() => searchControl.TakeFocus();
+        public void TakeFocus() => SearchControl.TakeFocus();
 
         /// <summary>
         /// Fetch the next page of results. May result in a no-op if a fetch is already in progress, or if there are no results left.
@@ -193,7 +198,7 @@ namespace osu.Game.Overlays.BeatmapListing
         public void FetchNextPage()
         {
             // there may be no results left.
-            if (noMoreResults)
+            if (NoMoreResults)
                 return;
 
             // there may already be an active request.
@@ -206,7 +211,7 @@ namespace osu.Game.Overlays.BeatmapListing
             performRequest();
         }
 
-        private void resetSortControl() => sortControl.Reset(searchControl.Category.Value, !string.IsNullOrEmpty(searchControl.Query.Value));
+        private void resetSortControl() => sortControl.Reset(SearchControl.Category.Value, !string.IsNullOrEmpty(SearchControl.Query.Value));
 
         private void queueUpdateSearch(bool queryTextChanged = false)
         {
@@ -227,19 +232,19 @@ namespace osu.Game.Overlays.BeatmapListing
         private void performRequest()
         {
             getSetsRequest = new SearchBeatmapSetsRequest(
-                searchControl.Query.Value,
-                searchControl.Ruleset.Value,
+                SearchControl.Query.Value,
+                SearchControl.Ruleset.Value,
                 lastResponse?.Cursor,
-                searchControl.General,
-                searchControl.Category.Value,
+                SearchControl.General,
+                SearchControl.Category.Value,
                 sortControl.Current.Value,
                 sortControl.SortDirection.Value,
-                searchControl.Genre.Value,
-                searchControl.Language.Value,
-                searchControl.Extra,
-                searchControl.Ranks,
-                searchControl.Played.Value,
-                searchControl.ExplicitContent.Value);
+                SearchControl.Genre.Value,
+                SearchControl.Language.Value,
+                SearchControl.Extra,
+                SearchControl.Ranks,
+                SearchControl.Played.Value,
+                SearchControl.ExplicitContent.Value);
 
             getSetsRequest.Success += response =>
             {
@@ -247,10 +252,10 @@ namespace osu.Game.Overlays.BeatmapListing
 
                 // If the previous request returned a null cursor, the API is indicating we can't paginate further (maybe there are no more beatmaps left).
                 if (sets.Count == 0 || response.Cursor == null)
-                    noMoreResults = true;
+                    NoMoreResults = true;
 
                 if (CurrentPage == 0)
-                    searchControl.BeatmapSet = sets.FirstOrDefault();
+                    SearchControl.BeatmapSet = sets.FirstOrDefault();
 
                 lastResponse = response;
                 getSetsRequest = null;
@@ -260,10 +265,10 @@ namespace osu.Game.Overlays.BeatmapListing
                 {
                     List<LocalisableString> filters = new List<LocalisableString>();
 
-                    if (searchControl.Played.Value != SearchPlayed.Any)
+                    if (SearchControl.Played.Value != SearchPlayed.Any)
                         filters.Add(BeatmapsStrings.ListingSearchFiltersPlayed);
 
-                    if (searchControl.Ranks.Any())
+                    if (SearchControl.Ranks.Any())
                         filters.Add(BeatmapsStrings.ListingSearchFiltersRank);
 
                     if (filters.Any())
@@ -272,6 +277,16 @@ namespace osu.Game.Overlays.BeatmapListing
                         SearchFinished?.Invoke(supporterOnlyFilters);
                         return;
                     }
+                }
+
+                if (SearchControl.Downloaded.Value == SearchDownloaded.NotDownloaded)
+                {
+                    sets.RemoveAll(
+                        set =>
+                        {
+                            return beatmapManager.IsAvailableLocally(set.Beatmaps.First());
+                        }
+                    );
                 }
 
                 var resultsReturned = SearchResult.ResultsReturned(sets);
@@ -283,7 +298,7 @@ namespace osu.Game.Overlays.BeatmapListing
 
         private void resetSearch()
         {
-            noMoreResults = false;
+            NoMoreResults = false;
             CurrentPage = 0;
 
             lastResponse = null;

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -47,6 +47,8 @@ namespace osu.Game.Overlays.BeatmapListing
 
         public Bindable<SearchPlayed> Played => playedFilter.Current;
 
+        public Bindable<SearchDownloaded> Downloaded => downloadedFilter.Current;
+
         public Bindable<SearchExplicit> ExplicitContent => explicitContentFilter.Current;
 
         public APIBeatmapSet? BeatmapSet
@@ -73,6 +75,7 @@ namespace osu.Game.Overlays.BeatmapListing
         private readonly BeatmapSearchMultipleSelectionFilterRow<SearchExtra> extraFilter;
         private readonly BeatmapSearchScoreFilterRow ranksFilter;
         private readonly BeatmapSearchFilterRow<SearchPlayed> playedFilter;
+        private readonly BeatmapSearchFilterRow<SearchDownloaded> downloadedFilter;
         private readonly BeatmapSearchFilterRow<SearchExplicit> explicitContentFilter;
 
         private readonly Box background;
@@ -137,6 +140,7 @@ namespace osu.Game.Overlays.BeatmapListing
                                     extraFilter = new BeatmapSearchMultipleSelectionFilterRow<SearchExtra>(BeatmapsStrings.ListingSearchFiltersExtra),
                                     ranksFilter = new BeatmapSearchScoreFilterRow(),
                                     playedFilter = new BeatmapSearchFilterRow<SearchPlayed>(BeatmapsStrings.ListingSearchFiltersPlayed),
+                                    downloadedFilter = new BeatmapSearchFilterRow<SearchDownloaded>(BeatmapsStrings.ListingSearchFiltersDownloaded),
                                     explicitContentFilter = new BeatmapSearchFilterRow<SearchExplicit>(BeatmapsStrings.ListingSearchFiltersNsfw),
                                 }
                             }

--- a/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
+++ b/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.ComponentModel;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
 

--- a/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
+++ b/osu.Game/Overlays/BeatmapListing/SearchDownloaded.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+using osu.Framework.Localisation;
+using osu.Game.Resources.Localisation.Web;
+
+namespace osu.Game.Overlays.BeatmapListing
+{
+    public enum SearchDownloaded
+    {
+        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.DownloadedAny))]
+        Any,
+
+        [LocalisableDescription(typeof(BeatmapsStrings), nameof(BeatmapsStrings.DownloadedNotDownloaded))]
+        NotDownloaded,
+    }
+}

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -195,7 +195,7 @@ namespace osu.Game.Overlays
             }
         }
 
-        private IEnumerable<BeatmapCard> createCardsFor(IEnumerable<APIBeatmapSet> beatmapSets) => beatmapSets.Select(set => 
+        private IEnumerable<BeatmapCard> createCardsFor(IEnumerable<APIBeatmapSet> beatmapSets) => beatmapSets.Select(set =>
         {
             var card = BeatmapCard.Create(set, filterControl.CardSize.Value).With(c =>
             {

--- a/osu.Game/Overlays/BeatmapListingOverlay.cs
+++ b/osu.Game/Overlays/BeatmapListingOverlay.cs
@@ -28,6 +28,7 @@ using osu.Game.Overlays.BeatmapListing;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 using osuTK.Graphics;
+using System;
 
 namespace osu.Game.Overlays
 {
@@ -194,11 +195,27 @@ namespace osu.Game.Overlays
             }
         }
 
-        private IEnumerable<BeatmapCard> createCardsFor(IEnumerable<APIBeatmapSet> beatmapSets) => beatmapSets.Select(set => BeatmapCard.Create(set, filterControl.CardSize.Value).With(c =>
+        private IEnumerable<BeatmapCard> createCardsFor(IEnumerable<APIBeatmapSet> beatmapSets) => beatmapSets.Select(set => 
         {
-            c.Anchor = Anchor.TopCentre;
-            c.Origin = Anchor.TopCentre;
-        })).ToArray();
+            var card = BeatmapCard.Create(set, filterControl.CardSize.Value).With(c =>
+            {
+                c.Anchor = Anchor.TopCentre;
+                c.Origin = Anchor.TopCentre;
+            });
+
+            if (filterControl.SearchControl.Downloaded.Value == SearchDownloaded.NotDownloaded)
+            {
+                card.DownloadTracker.State.BindValueChanged(state =>
+                {
+                    if (state.NewValue == Online.DownloadState.LocallyAvailable)
+                    {
+                        Schedule(() => foundContent.Remove(card, false));
+                    }
+                });
+            }
+
+            return card;
+        }).ToArray();
 
         private static ReverseChildIDFillFlowContainer<BeatmapCard> createCardContainerFor(IEnumerable<BeatmapCard> newCards)
         {
@@ -371,7 +388,8 @@ namespace osu.Game.Overlays
 
             bool shouldShowMore = panelLoadTask?.IsCompleted != false
                                   && Time.Current - lastFetchDisplayedTime > time_between_fetches
-                                  && (ScrollFlow.ScrollableExtent > 0 && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance));
+                                  && ScrollFlow.IsScrolledToEnd(pagination_scroll_distance)
+                                  && !filterControl.NoMoreResults;
 
             if (shouldShowMore)
                 filterControl.FetchNextPage();


### PR DESCRIPTION
This allows for users with lots of maps to find new ones without having to sift through the ones they already have

Preview:

Any:
<img width="2178" height="1229" alt="Screenshot-2026-06-05_22:40:33" src="https://github.com/user-attachments/assets/c6a8ac7c-7f74-4804-96e9-7c4e69b7d97f" />

Not Downloaded:
<img width="2179" height="1228" alt="Screenshot-2026-06-05_22:40:49" src="https://github.com/user-attachments/assets/3c8811b4-1ca1-45de-98b7-4104eb08c266" />
