### PR TITLE
Fix new score multipliers being displayed incorrectly for some mods

### DIFF
--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreMultiplierCalculatorV2.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreMultiplierCalculatorV2.cs
@@ -169,10 +169,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
             double selectedOverallDifficulty = convertFloatToDouble(difficultyAdjust.OverallDifficulty.Value ?? beatmapDifficulty.OverallDifficulty);
             double selectedApproachRate = convertFloatToDouble(difficultyAdjust.ApproachRate.Value ?? beatmapDifficulty.ApproachRate);
 
-            double csDifference = Math.Abs(selectedCircleSize - beatmapDifficulty.CircleSize);
-            double hpDifference = Math.Abs(selectedDrainRate - beatmapDifficulty.DrainRate);
-            double odDifference = Math.Abs(selectedOverallDifficulty - beatmapDifficulty.OverallDifficulty);
-            double arDifference = Math.Abs(selectedApproachRate - beatmapDifficulty.ApproachRate);
+            double csDifference = Math.Abs(selectedCircleSize - convertFloatToDouble(beatmapDifficulty.CircleSize));
+            double hpDifference = Math.Abs(selectedDrainRate - convertFloatToDouble(beatmapDifficulty.DrainRate));
+            double odDifference = Math.Abs(selectedOverallDifficulty - convertFloatToDouble(beatmapDifficulty.OverallDifficulty));
+            double arDifference = Math.Abs(selectedApproachRate - convertFloatToDouble(beatmapDifficulty.ApproachRate));
 
             // Per parameter, reduce multiplier by 0.05x per 0.1 change.
             double csMultiplier = Math.Max(0.1, 1.0 - csDifference * 0.5);

--- a/osu.Game.Rulesets.Osu/Scoring/OsuScoreMultiplierCalculatorV2.cs
+++ b/osu.Game.Rulesets.Osu/Scoring/OsuScoreMultiplierCalculatorV2.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
             Single<OsuModApproachDifferent>(hasMultiplier: 0.7);
             // Muted (1.0x)
             // No Scope (1.0x)
-            Single<OsuModMagnetised>(hasMultiplier: magnetised => 0.7 - magnetised.AttractionStrength.Value * 0.6);
+            Single<OsuModMagnetised>(hasMultiplier: magnetised => 0.7 - convertFloatToDouble(magnetised.AttractionStrength.Value) * 0.6);
             // Repel (1.0x)
             Single<ModAdaptiveSpeed>(hasMultiplier: 0.1);
             // Freeze Frame (1.0x)
@@ -154,7 +154,7 @@ namespace osu.Game.Rulesets.Osu.Scoring
         private static double flashlightMultiplier(OsuModFlashlight flashlight)
         {
             // Multiplier of 1.2x, reduced by 0.02 per 0.1 increase in flashlight size.
-            double value = Math.Max(1.02, Math.Min(1.2, 1.2 - 0.2 * (flashlight.SizeMultiplier.Value - 1)));
+            double value = Math.Max(1.02, Math.Min(1.2, 1.2 - 0.2 * (convertFloatToDouble(flashlight.SizeMultiplier.Value) - 1)));
 
             if (!flashlight.ComboBasedSize.Value)
                 value = 1 + (value - 1) / 5;
@@ -164,10 +164,10 @@ namespace osu.Game.Rulesets.Osu.Scoring
 
         private static double difficultyAdjustMultiplier(OsuModDifficultyAdjust difficultyAdjust, IBeatmapDifficultyInfo beatmapDifficulty)
         {
-            double selectedCircleSize = difficultyAdjust.CircleSize.Value ?? beatmapDifficulty.CircleSize;
-            double selectedDrainRate = difficultyAdjust.DrainRate.Value ?? beatmapDifficulty.DrainRate;
-            double selectedOverallDifficulty = difficultyAdjust.OverallDifficulty.Value ?? beatmapDifficulty.OverallDifficulty;
-            double selectedApproachRate = difficultyAdjust.ApproachRate.Value ?? beatmapDifficulty.ApproachRate;
+            double selectedCircleSize = convertFloatToDouble(difficultyAdjust.CircleSize.Value ?? beatmapDifficulty.CircleSize);
+            double selectedDrainRate = convertFloatToDouble(difficultyAdjust.DrainRate.Value ?? beatmapDifficulty.DrainRate);
+            double selectedOverallDifficulty = convertFloatToDouble(difficultyAdjust.OverallDifficulty.Value ?? beatmapDifficulty.OverallDifficulty);
+            double selectedApproachRate = convertFloatToDouble(difficultyAdjust.ApproachRate.Value ?? beatmapDifficulty.ApproachRate);
 
             double csDifference = Math.Abs(selectedCircleSize - beatmapDifficulty.CircleSize);
             double hpDifference = Math.Abs(selectedDrainRate - beatmapDifficulty.DrainRate);
@@ -195,6 +195,14 @@ namespace osu.Game.Rulesets.Osu.Scoring
         }
 
         private static double deflateMultiplier(OsuModDeflate deflate)
-            => 1.0 - Math.Max(0, 0.02 * (deflate.StartScale.Value - deflate.StartScale.Default));
+            => 1.0 - Math.Max(0, 0.02 * (convertFloatToDouble(deflate.StartScale.Value) - convertFloatToDouble(deflate.StartScale.Default)));
+
+        /// <summary>
+        /// Converts a float to a double. The value is floored to two decimal places.
+        /// </summary>
+        /// <param name="f">The float value to convert.</param>
+        /// <returns>The converted double value.</returns>
+        private static double convertFloatToDouble(float f)
+            => (int)(f * 100) / 100.0;
     }
 }


### PR DESCRIPTION
### The issue

With the introduction of the new score multipliers (see https://github.com/ppy/osu/pull/37967), some multipliers which depend on mod settings are displayed incorrectly in the client.

For instance, using FL with Flashlight size 1.3 should result in a multiplier of ``1.14x``, but it is displayed as ``1.15x``:

<img width="2560" height="1440" alt="osu_2026-06-06_18-28-25" src="https://github.com/user-attachments/assets/622bd80f-7247-47f1-aaec-6f9c00df7b4f" />

This is due to the flashlight size multiplier being stored as a float value instead of double, which leads ``flashlightMultiplier`` in ``OsuScoreMultiplierCalculatorV2.cs`` to return ``1.14000000953674`` in this case.

Because ``FormatScoreMultiplier`` in ``ModUtils.cs`` uses ``Ceiling`` and ``Floor`` rather than ``Round``, this value is displayed as ``1.15x``.

The same applies to *Difficulty Adjust*, *Deflate* and *Magnetised*. All other mods only use ``int`` and ``double``, so this doesn't occur.

### My attempt

I attempted to fix this by simply making sure all float values are properly converted to double before any calculations take place.

I don't have a lot of experience in ``C#`` so I don't know if that's the proper way to do it.
If not, I apologise, in that case just treat this as a bug report.