### PR TITLE
Enable osu-stable sliders smoothness

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -27,10 +27,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
             protected override Color4 ColourAt(float position)
             {
                 // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L99
-                // float aaWidth = Math.Min(Math.Max(0.5f / PathRadius, 3.0f / 256.0f), 1.0f / 16.0f);
-                // applying the aa_width constant from stable makes sliders blurry, especially on CS>5. set to zero for now.
-                // this might be related to SmoothPath applying AA internally, but disabling that does not seem to have much of an effect.
-                const float aa_width = 0f;
+                float aaWidth = Math.Min(Math.Max(0.5f / PathRadius, 3.0f / 256.0f), 1.0f / 16.0f);
 
                 Color4 shadow = new Color4(0, 0, 0, 0.25f);
                 Color4 outerColour = AccentColour.Darken(0.1f);
@@ -40,19 +37,19 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
                 const float border_portion = 0.1875f;
 
-                if (position <= shadow_portion - aa_width)
-                    return LegacyUtils.InterpolateNonLinear(position, Color4.Black.Opacity(0f), shadow, 0, shadow_portion - aa_width);
+                if (position <= shadow_portion - aaWidth)
+                    return LegacyUtils.InterpolateNonLinear(position, Color4.Black.Opacity(0f), shadow, 0, shadow_portion - aaWidth);
 
-                if (position <= shadow_portion + aa_width)
-                    return LegacyUtils.InterpolateNonLinear(position, shadow, BorderColour, shadow_portion - aa_width, shadow_portion + aa_width);
+                if (position <= shadow_portion + aaWidth)
+                    return LegacyUtils.InterpolateNonLinear(position, shadow, BorderColour, shadow_portion - aaWidth, shadow_portion + aaWidth);
 
-                if (position <= border_portion - aa_width)
+                if (position <= border_portion - aaWidth)
                     return BorderColour;
 
-                if (position <= border_portion + aa_width)
-                    return LegacyUtils.InterpolateNonLinear(position, BorderColour, outerColour, border_portion - aa_width, border_portion + aa_width);
+                if (position <= border_portion + aaWidth)
+                    return LegacyUtils.InterpolateNonLinear(position, BorderColour, outerColour, border_portion - aaWidth, border_portion + aaWidth);
 
-                return LegacyUtils.InterpolateNonLinear(position, outerColour, innerColour, border_portion + aa_width, 1);
+                return LegacyUtils.InterpolateNonLinear(position, outerColour, innerColour, border_portion + aaWidth, 1);
             }
 
             /// <summary>


### PR DESCRIPTION
Recent changes in path rendering framework-side made sliders more sharp.
Prior to https://github.com/ppy/osu-framework/pull/6658 when rendering path's frame buffer linear filtering was applied which combined with `SmoothPath`'s internal antialiasing made them already smooth enough to disable this osu-side additional smoothing.
Now we can re-enable this.

(also there's https://github.com/ppy/osu-framework/pull/6763 which fixes edge artifacts present in master)

|stable|master|pr|pr with https://github.com/ppy/osu-framework/pull/6763|
|---|---|---|---|
|<img width="1044" height="547" alt="stable" src="https://github.com/user-attachments/assets/bdd2e267-4e5f-4a01-9951-79708f215c38" />|<img width="1044" height="547" alt="master" src="https://github.com/user-attachments/assets/c9f8ac36-b1cc-4737-a180-d4ee5a19e95b" />|<img width="1044" height="547" alt="pr" src="https://github.com/user-attachments/assets/1004069d-16ea-49c0-9453-49681896bd8e" />|<img width="1044" height="547" alt="pr-edge-fix" src="https://github.com/user-attachments/assets/9aeace49-30f3-4cde-a498-63086880d3d5" />|