### PR TITLE
Fix difficulty selection behavior when going back from scoped beatmapset select

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFiltering.cs
@@ -419,7 +419,7 @@ namespace osu.Game.Tests.Visual.SongSelect
 
         [TestCase(false)]
         [TestCase(true)]
-        public void TestUnscopeRevertsToOriginalSelection(bool grouped)
+        public void TestUnscopeRevertsToFinalSelection(bool grouped)
         {
             ImportBeatmapForRuleset(0);
             ImportBeatmapForRuleset(0);
@@ -445,7 +445,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             WaitForFiltering();
 
             checkMatchedBeatmaps(6);
-            AddAssert("normal difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Normal")));
+            AddAssert("insane difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Insane")));
 
             AddStep("reset star difficulty filter", () => Config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1));
         }
@@ -480,7 +480,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             });
             WaitForFiltering();
 
-            AddAssert("hard difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Hard")));
+            AddAssert("insane difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Insane")));
 
             AddStep("reset star difficulty filter", () => Config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1));
         }
@@ -543,7 +543,7 @@ namespace osu.Game.Tests.Visual.SongSelect
             AddStep("show converts", () => Config.SetValue(OsuSetting.ShowConvertedBeatmaps, true));
             WaitForFiltering();
 
-            AddAssert("hard difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Hard")));
+            AddAssert("insane difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Insane")));
 
             AddStep("revert convert setting", () => Config.SetValue(OsuSetting.ShowConvertedBeatmaps, showConverts));
             AddStep("reset star difficulty filter", () => Config.SetValue(OsuSetting.DisplayStarsMaximum, 10.1));

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1276,7 +1276,10 @@ namespace osu.Game.Screens.Select
                 return;
 
             if (beforeScopedSelection != null)
-                queueBeatmapSelection(beforeScopedSelection);
+            {
+                var beatmapToSwitchTo = carousel.CurrentGroupedBeatmap ?? beforeScopedSelection;
+                queueBeatmapSelection(beatmapToSwitchTo);
+            }
 
             scopedBeatmapSet.Value = null;
             beforeScopedSelection = null;


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/36769

When a player switches to a `ScopedBeatmapSetDisplay`, selects a different difficulty than they started at, and then goes back to showing all filtered beatmaps, the song select screen currently switches to the map they started at, which may feel unintuitive to the player, especially when selecting a difficulty that's way lower or way higher in the list. This change aims to fix this behavior and switch to the map they last selected instead.

**Before**:

https://github.com/user-attachments/assets/6c30e889-c16d-426a-bb1e-fd5144775e9e

**After**:

https://github.com/user-attachments/assets/25c0eaef-e6ae-4ea1-80ed-a133ade1d955