### PR TITLE
Remove localisation schedule hack in `TabletSettings`

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -345,14 +345,14 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private partial class NoTabletMessage : CompositeDrawable
         {
-            private readonly Bindable<Language> currentLanguage = new Bindable<Language>();
+            private IBindable<string> noTabletDetectedText = new Bindable<string>();
             private LinkFlowContainer linkContainer;
 
             [Resolved]
             private LocalisationManager localisation { get; set; }
 
             [BackgroundDependencyLoader]
-            private void load(OsuGameBase game, OsuColour colours, OverlayColourProvider colourProvider)
+            private void load(OsuColour colours, OverlayColourProvider colourProvider)
             {
                 RelativeSizeAxes = Axes.X;
                 AutoSizeAxes = Axes.Y;
@@ -406,26 +406,23 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     },
                 };
 
-                if (game != null)
-                    currentLanguage.BindTo(game.CurrentLanguage);
+                const string url = @"https://opentabletdriver.net/Wiki/FAQ/General";
+                noTabletDetectedText = localisation.GetLocalisedBindableString(TabletSettingsStrings.NoTabletDetectedDescription(url));
             }
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
 
-                currentLanguage.BindValueChanged(_ =>
-                    // schedule required because `LocalisationManager` won't have new language set correctly yet.
-                    Schedule(() =>
-                    {
-                        linkContainer.Clear();
-                        linkContainer.NewLine();
+                noTabletDetectedText.BindValueChanged(_ =>
+                {
+                    linkContainer.Clear();
+                    linkContainer.NewLine();
 
-                        const string url = @"https://opentabletdriver.net/Wiki/FAQ/General";
-                        var formattedSource = MessageFormatter.FormatText(localisation.GetLocalisedString(TabletSettingsStrings.NoTabletDetectedDescription(url)));
+                    var formattedSource = MessageFormatter.FormatText(noTabletDetectedText.Value);
 
-                        linkContainer.AddLinks(formattedSource.Text, formattedSource.Links);
-                    }), true);
+                    linkContainer.AddLinks(formattedSource.Text, formattedSource.Links);
+                }, true);
             }
         }
     }


### PR DESCRIPTION
Originally added in https://github.com/ppy/osu/pull/36848.

The reason I'm bothering is that the original instance is being used in https://github.com/ppy/osu/pull/37494#discussion_r3391818630 as precedent justification for copy-pasting the same hack in however many places going forward and I do not want that to happen.