### PR TITLE
Fix changing difficulty in editor potentially seeking incorrectly in presence of user/platform offsets

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneDifficultySwitching.cs
@@ -10,6 +10,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Extensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
@@ -33,6 +34,9 @@ namespace osu.Game.Tests.Visual.Editing
 
         [Resolved]
         private BeatmapManager beatmaps { get; set; }
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
 
         private BeatmapSetInfo importedBeatmapSet;
 
@@ -62,17 +66,21 @@ namespace osu.Game.Tests.Visual.Editing
         [Test]
         public void TestClockPositionPreservedBetweenSwitches()
         {
+            AddStep("Set user audio offset", () => config.SetValue(OsuSetting.AudioOffset, 500.0));
+
             BeatmapInfo targetDifficulty = null;
             AddStep("seek editor to 00:05:00", () => EditorClock.Seek(5000));
 
             AddStep("set target difficulty", () => targetDifficulty = importedBeatmapSet.Beatmaps.Last(beatmap => !beatmap.Equals(Beatmap.Value.BeatmapInfo)));
             switchToDifficulty(() => targetDifficulty);
             confirmEditingBeatmap(() => targetDifficulty);
-            AddAssert("editor clock at 00:05:00", () => EditorClock.CurrentTime == 5000);
+            AddAssert("editor clock at 00:05:00", () => EditorClock.CurrentTime, () => Is.EqualTo(5000));
 
             AddStep("exit editor", () => Stack.Exit());
             // ensure editor loader didn't resume.
             AddAssert("stack empty", () => Stack.CurrentScreen == null);
+
+            AddStep("Revert user audio offset", () => config.SetValue(OsuSetting.AudioOffset, 0.0));
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TestSceneOpenEditorTimestamp.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneOpenEditorTimestamp.cs
@@ -128,14 +128,12 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void assertOnScreenAt(EditorScreenMode screen, double time)
         {
-            AddAssert($"stayed on {screen} at {time}", () =>
-                editor!.Mode.Value == screen
-                && editorClock.CurrentTime == time
-            );
+            AddAssert("screen is correct", () => editor!.Mode.Value, () => Is.EqualTo(screen));
+            AddAssert("time is correct", () => editorClock.CurrentTime, () => Is.EqualTo(time));
         }
 
-        private void assertMovedScreenTo(EditorScreenMode screen, string text = "moved to") =>
-            AddAssert($"{text} {screen}", () => editor!.Mode.Value == screen);
+        private void assertMovedScreenTo(EditorScreenMode screen) =>
+            AddAssert("screen is correct", () => editor!.Mode.Value, () => Is.EqualTo(screen));
 
         private void setUpEditor(RulesetInfo ruleset)
         {

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -55,6 +55,8 @@ namespace osu.Game.Beatmaps
 
         private Bindable<bool> experimentalAudio = null!;
 
+        private double? initialSeek;
+
         public bool IsRewinding { get; private set; }
 
         public FramedBeatmapClock(bool applyOffsets, bool requireDecoupling, IClock? source = null)
@@ -110,6 +112,9 @@ namespace osu.Game.Beatmaps
                         userBeatmapOffsetClock.Offset = val;
                     });
             }
+
+            if (initialSeek != null)
+                Seek(initialSeek.Value);
         }
 
         /// <summary>
@@ -196,6 +201,13 @@ namespace osu.Game.Beatmaps
 
         public bool Seek(double position)
         {
+            // TotalAppliedOffset will not be correct until fully loaded.
+            if (applyOffsets && !IsLoaded)
+            {
+                initialSeek = position;
+                return true;
+            }
+
             bool success = decoupledTrack.Seek(position - TotalAppliedOffset);
             finalClockSource.ProcessFrame();
 

--- a/osu.Game/Beatmaps/FramedBeatmapClock.cs
+++ b/osu.Game/Beatmaps/FramedBeatmapClock.cs
@@ -55,6 +55,14 @@ namespace osu.Game.Beatmaps
 
         private Bindable<bool> experimentalAudio = null!;
 
+        /// <summary>
+        /// Store seek target for any <see cref="Seek"/> performed before <see cref="LoadState.Loaded"/>.
+        /// </summary>
+        /// <remarks>
+        /// Initial seeks must be delayed until the <see cref="FramedBeatmapClock"/> instance is fully loaded.
+        ///
+        /// If not, <see cref="TotalAppliedOffset"/> will not be in a correct state and result in a potentially
+        /// incorrect seek target.</remarks>
         private double? initialSeek;
 
         public bool IsRewinding { get; private set; }
@@ -114,7 +122,10 @@ namespace osu.Game.Beatmaps
             }
 
             if (initialSeek != null)
+            {
                 Seek(initialSeek.Value);
+                initialSeek = null;
+            }
         }
 
         /// <summary>
@@ -226,7 +237,7 @@ namespace osu.Game.Beatmaps
 
         #region Delegation of IFrameBasedClock to clock with all offsets applied
 
-        public double CurrentTime => finalClockSource.CurrentTime;
+        public double CurrentTime => initialSeek ?? finalClockSource.CurrentTime;
 
         public bool IsRunning => finalClockSource.IsRunning;
 


### PR DESCRIPTION
Closes #38034.

Hoping the inline commentary is crafted enough to explain the issue and the resolution (if not it needs addressing).

One note: the linked issue can also be fixed with

```diff
diff --git a/osu.Game/Screens/Edit/Editor.cs b/osu.Game/Screens/Edit/Editor.cs
index 9c9ec1364f..64f2e21f4f 100644
--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -522,7 +522,7 @@ protected override void Dispose(bool isDisposing)
         /// Restore the editor to a provided state.
         /// </summary>
         /// <param name="state">The state to restore.</param>
-        public void RestoreState([NotNull] EditorState state) => Schedule(() =>
+        public void RestoreState([NotNull] EditorState state) => ScheduleAfterChildren(() =>
         {
             Mode.Value = state.Mode;
             clock.Seek(state.Time);

```

but this is localised and a similar issue may be raised elsewhere in the future. This PR applies a resolution which should hopefully hold tight(er) into the future.