### PR TITLE
Improve sliders antialiasing

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacySliderBody.cs
@@ -26,9 +26,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         {
             protected override Color4 ColourAt(float position)
             {
-                // https://github.com/peppy/osu-stable-reference/blob/3ea48705eb67172c430371dcfc8a16a002ed0d3d/osu!/Graphics/Renderers/MmSliderRendererGL.cs#L99
-                float aaWidth = Math.Min(Math.Max(0.5f / PathRadius, 3.0f / 256.0f), 1.0f / 16.0f);
-
                 Color4 shadow = new Color4(0, 0, 0, 0.25f);
                 Color4 outerColour = AccentColour.Darken(0.1f);
                 Color4 innerColour = lighten(AccentColour, 0.5f);
@@ -37,19 +34,13 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 const float shadow_portion = 1 - (OsuLegacySkinTransformer.LEGACY_CIRCLE_RADIUS / OsuHitObject.OBJECT_RADIUS);
                 const float border_portion = 0.1875f;
 
-                if (position <= shadow_portion - aaWidth)
-                    return LegacyUtils.InterpolateNonLinear(position, Color4.Black.Opacity(0f), shadow, 0, shadow_portion - aaWidth);
+                if (position <= shadow_portion)
+                    return LegacyUtils.InterpolateNonLinear(position, Color4.Black.Opacity(0f), shadow, 0, shadow_portion);
 
-                if (position <= shadow_portion + aaWidth)
-                    return LegacyUtils.InterpolateNonLinear(position, shadow, BorderColour, shadow_portion - aaWidth, shadow_portion + aaWidth);
-
-                if (position <= border_portion - aaWidth)
+                if (position <= border_portion)
                     return BorderColour;
 
-                if (position <= border_portion + aaWidth)
-                    return LegacyUtils.InterpolateNonLinear(position, BorderColour, outerColour, border_portion - aaWidth, border_portion + aaWidth);
-
-                return LegacyUtils.InterpolateNonLinear(position, outerColour, innerColour, border_portion + aaWidth, 1);
+                return LegacyUtils.InterpolateNonLinear(position, outerColour, innerColour, border_portion, 1);
             }
 
             /// <summary>


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38033
Depends on:
- [ ] framework bump

Basically reverts https://github.com/ppy/osu/pull/38015 (with some simplifications) and relies on framework fix. With this approach there won't be any blur with any resolution/CS size.

| pre https://github.com/ppy/osu/pull/38015 | pr with https://github.com/ppy/osu-framework/pull/6767 |
|---|---|
|<img width="821" height="390" alt="pr-pre-framework" src="https://github.com/user-attachments/assets/348a1057-ead2-4bd1-b979-0009fe151603" />|<img width="821" height="390" alt="pr-post-framework" src="https://github.com/user-attachments/assets/08c4b322-115a-40a7-abce-70eb332b0dbe" />|
|<img width="1420" height="700" alt="pre" src="https://github.com/user-attachments/assets/0b22c05f-3dfe-4e9c-9ad0-e97a1d8e680e" />|<img width="1420" height="700" alt="post" src="https://github.com/user-attachments/assets/a1f2b9da-04be-468b-85b2-5e3ee28bd91c" />|
