### PR TITLE
Hide deferred vulkan renderer for users which aren't already using it

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Graphics/RendererSettings.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -27,14 +28,22 @@ namespace osu.Game.Overlays.Settings.Sections.Graphics
             var renderer = config.GetBindable<RendererType>(FrameworkSetting.Renderer);
             automaticRendererInUse = renderer.Value == RendererType.Automatic;
 
+            IEnumerable<RendererType> availableRenderers = host.GetPreferredRenderersForCurrentPlatform().Order();
+
+            // Vulkan renderers are pretty broken to the point it may result in a startup crash at worst.
+            // If a user isn't already using it let's hide it until we can fix.
+            if (renderer.Value != RendererType.Deferred_Vulkan)
+                availableRenderers = availableRenderers.Where(t => t != RendererType.Deferred_Vulkan);
+            if (renderer.Value != RendererType.Vulkan)
+                availableRenderers = availableRenderers.Where(t => t != RendererType.Vulkan);
+
             Children = new Drawable[]
             {
                 new SettingsItemV2(new RendererDropdown
                 {
                     Caption = GraphicsSettingsStrings.Renderer,
                     Current = renderer,
-                    Items = host.GetPreferredRenderersForCurrentPlatform().Order()
-                                .Where(t => t != RendererType.Vulkan),
+                    Items = availableRenderers,
                 })
                 {
                     Keywords = new[] { @"compatibility", @"directx" },


### PR DESCRIPTION
Had a few reports in the wild of it bricking games. Is not in a great state so let's not have users attempt to use it for now.

If you're a user looking at this and about to complain, you can still update your config file manually to get this renderer back.

Discussed with @smoogipoo IRL