### PR TITLE
Fix a couple of cases where favouriting a beatmap resulting in error hits sentry

### DIFF
--- a/osu.Game/Beatmaps/Drawables/Cards/Buttons/FavouriteButton.cs
+++ b/osu.Game/Beatmaps/Drawables/Cards/Buttons/FavouriteButton.cs
@@ -1,16 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Game.Online.API.Requests.Responses;
-using osu.Framework.Logging;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
@@ -27,10 +26,13 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
 
         private readonly APIBeatmapSet beatmapSet;
 
-        private PostBeatmapFavouriteRequest favouriteRequest;
+        private PostBeatmapFavouriteRequest? favouriteRequest;
 
         [Resolved]
-        private IAPIProvider api { get; set; }
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private INotificationOverlay? notifications { get; set; }
 
         public FavouriteButton(APIBeatmapSet beatmapSet)
         {
@@ -66,7 +68,12 @@ namespace osu.Game.Beatmaps.Drawables.Cards.Buttons
             };
             favouriteRequest.Failure += e =>
             {
-                Logger.Error(e, $"Failed to {actionType.ToString().ToLowerInvariant()} beatmap: {e.Message}");
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = e.Message,
+                    Icon = FontAwesome.Solid.Times,
+                });
+
                 SetLoading(false);
             };
 

--- a/osu.Game/Screens/Ranking/FavouriteButton.cs
+++ b/osu.Game/Screens/Ranking/FavouriteButton.cs
@@ -12,6 +12,8 @@ using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
@@ -33,6 +35,9 @@ namespace osu.Game.Screens.Ranking
 
         [Resolved]
         private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private INotificationOverlay? notifications { get; set; }
 
         public FavouriteButton(BeatmapSetInfo beatmapSetInfo)
             : base(FontAwesome.Regular.Heart)
@@ -113,7 +118,11 @@ namespace osu.Game.Screens.Ranking
             };
             favouriteRequest.Failure += e =>
             {
-                Logger.Error(e, $"Failed to {actionType.ToString().ToLowerInvariant()} beatmap: {e.Message}");
+                notifications?.Post(new SimpleNotification
+                {
+                    Text = e.Message,
+                    Icon = FontAwesome.Solid.Times,
+                });
 
                 Schedule(() =>
                 {


### PR DESCRIPTION
See [sentry](https://sentry.ppy.sh/organizations/ppy/issues/2235/events/latest/?alert_rule_id=4&alert_timestamp=1780759539716&alert_type=email&environment=production&project=2&referrer=latest-event). Matches other implementations.