### PR TITLE
fix: LocalUserPlayingState misleading comment

### DIFF
--- a/osu.Game/Screens/Play/LocalUserPlayingState.cs
+++ b/osu.Game/Screens/Play/LocalUserPlayingState.cs
@@ -6,17 +6,18 @@ namespace osu.Game.Screens.Play
     public enum LocalUserPlayingState
     {
         /// <summary>
-        /// The local player is not current in gameplay. If watching a replay, gameplay always remains in this state.
+        /// The local player is not currently in gameplay or has failed but still at the gameplay screen.
+		/// If watching a replay, gameplay always remains in this state.
         /// </summary>
         NotPlaying,
 
         /// <summary>
-        /// The local player is in a break, paused, or failed but still at the gameplay screen.
+        /// The local player is in a break or paused.
         /// </summary>
         Break,
 
         /// <summary>
-        /// The local user is in active gameplay.
+        /// The local player is in active gameplay.
         /// </summary>
         Playing,
     }

--- a/osu.Game/Screens/Play/LocalUserPlayingState.cs
+++ b/osu.Game/Screens/Play/LocalUserPlayingState.cs
@@ -7,7 +7,7 @@ namespace osu.Game.Screens.Play
     {
         /// <summary>
         /// The local player is not currently in gameplay or has failed but still at the gameplay screen.
-		/// If watching a replay, gameplay always remains in this state.
+        /// If watching a replay, gameplay always remains in this state.
         /// </summary>
         NotPlaying,
 


### PR DESCRIPTION
Noticed that the comment in `LocalUserPlayingState.cs` is wrong. Failing but staying on the gameplay screen makes the state `NotPlaying` not `Break`

This snippet shows the logic (`!GameplayState.HasFailed` excludes it from `inGameplay`) and its in `osu.Game\Screens\Play\Player.cs`

```C#
private void updateGameplayState()
{
	bool inGameplay = !DrawableRuleset.HasReplayLoaded.Value && !GameplayState.HasPassed && !GameplayState.HasFailed;
	bool inBreak = breakTracker.IsBreakTime.Value || DrawableRuleset.IsPaused.Value;

	if (inGameplay)
		playingState.Value = inBreak ? LocalUserPlayingState.Break : LocalUserPlayingState.Playing;
	else
		playingState.Value = LocalUserPlayingState.NotPlaying;

	localUserPlaying.Value = playingState.Value == LocalUserPlayingState.Playing;
	OverlayActivationMode.Value = playingState.Value == LocalUserPlayingState.Playing ? OverlayActivation.Disabled : OverlayActivation.UserTriggered;
}
```