### PR TITLE
Add environment variable to allow overriding WebSocket server port

### DIFF
--- a/osu.Desktop/IPC/OsuWebSocketProvider.cs
+++ b/osu.Desktop/IPC/OsuWebSocketProvider.cs
@@ -27,7 +27,7 @@ namespace osu.Desktop.IPC
         [BackgroundDependencyLoader]
         private void load(SessionStatics sessionStatics)
         {
-            server = new WebSocketServer(49727);
+            server = new WebSocketServer(48727);
             server.StartAsync().FireAndForget(onError: ex => Logger.Error(ex, "Failed to start websocket"));
 
             sessionStatics.BindWith(Static.LastLocalUserScore, lastLocalScore);

--- a/osu.Desktop/IPC/OsuWebSocketProvider.cs
+++ b/osu.Desktop/IPC/OsuWebSocketProvider.cs
@@ -27,6 +27,8 @@ namespace osu.Desktop.IPC
         [BackgroundDependencyLoader]
         private void load(SessionStatics sessionStatics)
         {
+            // This port should not be between 49152 and 65535 as it will likely result in errors for Windows users.
+            // See https://github.com/dotnet/runtime/issues/115088#issuecomment-2887081086 for additional context.
             server = new WebSocketServer(48727);
             server.StartAsync().FireAndForget(onError: ex => Logger.Error(ex, "Failed to start websocket"));
 

--- a/osu.Desktop/IPC/OsuWebSocketProvider.cs
+++ b/osu.Desktop/IPC/OsuWebSocketProvider.cs
@@ -27,9 +27,12 @@ namespace osu.Desktop.IPC
         [BackgroundDependencyLoader]
         private void load(SessionStatics sessionStatics)
         {
-            // This port should not be between 49152 and 65535 as it will likely result in errors for Windows users.
-            // See https://github.com/dotnet/runtime/issues/115088#issuecomment-2887081086 for additional context.
-            server = new WebSocketServer(48727);
+            int port = 49727;
+
+            if (int.TryParse(Environment.GetEnvironmentVariable("OSU_WEBSOCKET_SERVER_PORT"), out int portOverride))
+                port = portOverride;
+
+            server = new WebSocketServer(port);
             server.StartAsync().FireAndForget(onError: ex => Logger.Error(ex, "Failed to start websocket"));
 
             sessionStatics.BindWith(Static.LastLocalUserScore, lastLocalScore);


### PR DESCRIPTION
Name of variable is `OSU_WEBSOCKET_SERVER_PORT`. To be used on machines wherein the default port of 49727 is not available.