### PR TITLE
Use constant difficulty for single-note rhythm islands

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                         else
                         {
                             // constant difficulty for single-note islands
-                            rhythmComplexitySum += 0.4;
+                            rhythmComplexitySum += 0.7 * currHistoricalDecay;
                         }
 
                         startRatio = effectiveRatio;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -17,7 +17,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
         private const double rhythm_overall_multiplier = 0.95;
-        private const double rhythm_ratio_multiplier = 26.0;
+        private const double rhythm_ratio_multiplier = 30.0;
 
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
@@ -160,7 +160,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                         double doubletapness = prevObj.GetDoubletapness(currObj);
                         effectiveRatio *= 1 - doubletapness * 0.75;
 
-                        rhythmComplexitySum += Math.Sqrt(effectiveRatio * startRatio) * currHistoricalDecay;
+                        if (island.DeltaCount > 1)
+                            rhythmComplexitySum += Math.Sqrt(effectiveRatio * startRatio) * currHistoricalDecay;
 
                         startRatio = effectiveRatio;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                         else
                         {
                             // constant difficulty for single-note islands
-                            rhythmComplexitySum += 0.5;
+                            rhythmComplexitySum += 0.4;
                         }
 
                         startRatio = effectiveRatio;

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
     {
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
-        private const double rhythm_overall_multiplier = 0.95;
+        private const double rhythm_overall_multiplier = 1.0;
         private const double rhythm_ratio_multiplier = 30.0;
 
         /// <summary>

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Speed/RhythmEvaluator.cs
@@ -16,8 +16,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
     {
         private const int history_time_max = 5 * 1000; // 5 seconds
         private const int history_objects_max = 32;
-        private const double rhythm_overall_multiplier = 1.0;
-        private const double rhythm_ratio_multiplier = 30.0;
+        private const double rhythm_overall_multiplier = 0.95;
+        private const double rhythm_ratio_multiplier = 26.0;
 
         /// <summary>
         /// Calculates a rhythm multiplier for the difficulty of the tap associated with historic data of the current <see cref="OsuDifficultyHitObject"/>.
@@ -161,7 +161,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Speed
                         effectiveRatio *= 1 - doubletapness * 0.75;
 
                         if (island.DeltaCount > 1)
+                        {
                             rhythmComplexitySum += Math.Sqrt(effectiveRatio * startRatio) * currHistoricalDecay;
+                        }
+                        else
+                        {
+                            // constant difficulty for single-note islands
+                            rhythmComplexitySum += 0.5;
+                        }
 
                         startRatio = effectiveRatio;
 


### PR DESCRIPTION
Intended as a fix to the timing changes mid-stream, but also buffs complex triples slightly as well