### PR TITLE
Fix external imports during downloads breaking online play availability

### DIFF
--- a/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
@@ -167,6 +167,27 @@ namespace osu.Game.Tests.Online
             addAvailabilityCheckStep("locally available after re-import", BeatmapAvailability.LocallyAvailable);
         }
 
+        [Test]
+        public void TestManualExternalImportDuringDownload()
+        {
+            AddStep("allow importing", () => beatmaps.AllowImport.Set());
+
+            AddUntilStep("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapSet));
+            addAvailabilityCheckStep("state not downloaded", BeatmapAvailability.NotDownloaded);
+
+            AddStep("start downloading", () => beatmapDownloader.Download(testBeatmapSet));
+            addAvailabilityCheckStep("state downloading", () => BeatmapAvailability.Downloading(0.0f));
+
+            AddStep("import beatmap externally", () => beatmaps.Import(TestResources.GetQuickTestBeatmapForImport()).WaitSafely());
+            addAvailabilityCheckStep("state locally available", BeatmapAvailability.LocallyAvailable);
+
+            AddStep("set progress 40%", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet)!).SetProgress(0.4f));
+            addAvailabilityCheckStep("state locally available", BeatmapAvailability.LocallyAvailable);
+
+            AddStep("finish download", () => ((TestDownloadRequest)beatmapDownloader.GetExistingDownload(testBeatmapSet)!).TriggerSuccess(testBeatmapFile));
+            addAvailabilityCheckStep("state locally available", BeatmapAvailability.LocallyAvailable);
+        }
+
         private void addAvailabilityCheckStep(string description, Func<BeatmapAvailability> expected)
         {
             AddUntilStep(description, () => availabilityTracker.Availability.Value.Equals(expected.Invoke()));

--- a/osu.Game/Online/BeatmapDownloadTracker.cs
+++ b/osu.Game/Online/BeatmapDownloadTracker.cs
@@ -46,7 +46,13 @@ namespace osu.Game.Online
             realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapSetInfo>().Where(s => s.OnlineID == onlineId && !s.DeletePending), (items, _) =>
             {
                 if (items.Any())
-                    Schedule(() => UpdateState(DownloadState.LocallyAvailable));
+                {
+                    Schedule(() =>
+                    {
+                        UpdateState(DownloadState.LocallyAvailable);
+                        attachDownload(null);
+                    });
+                }
                 else
                 {
                     Schedule(() =>
@@ -100,7 +106,8 @@ namespace osu.Game.Online
             }
             else
             {
-                UpdateState(DownloadState.NotDownloaded);
+                if (State.Value == DownloadState.Downloading)
+                    UpdateState(DownloadState.NotDownloaded);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/37530
Fixes https://github.com/ppy/osu/discussions/37710
Fixes https://github.com/ppy/osu/issues/37354
Possibly also fixes https://github.com/ppy/osu/issues/37433
Supersedes https://github.com/ppy/osu/pull/37946

The failure process is: start download -> external import -> finish download. When the download finishes, another import is tried (state changes from `LocallyAvailable` to `Importing`) but then skipped because the game already has the beatmap loaded. The realm callback never fires to change it back into the correct `LocallyAvailable` state.

Detaching the download once the `LocallyAvailable` state is entered fixes this.

Ranked play is the worst offender because it relies on this functionality as part of its core loop, but this could also affect multiplayer where beatmap availability _is_ [validated](https://github.com/ppy/osu-server-spectator/blob/master/osu.Server.Spectator/Extensions/MultiplayerRoomUserExtensions.cs) against.