### PR TITLE
Replace flawed BeatmapSet availability with Beatmap availability

### DIFF
--- a/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
@@ -115,7 +115,7 @@ namespace osu.Game.Tests.Online
         [Test]
         public void TestBeatmapDownloadingFlow()
         {
-            AddUntilStep("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapSet));
+            AddUntilStep("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapInfo));
             addAvailabilityCheckStep("state not downloaded", BeatmapAvailability.NotDownloaded);
 
             AddStep("start downloading", () => beatmapDownloader.Download(testBeatmapSet));
@@ -129,7 +129,7 @@ namespace osu.Game.Tests.Online
 
             AddStep("allow importing", () => beatmaps.AllowImport.Set());
             AddUntilStep("wait for import", () => beatmaps.CurrentImport != null);
-            AddUntilStep("ensure beatmap available", () => beatmaps.IsAvailableLocally(testBeatmapSet));
+            AddUntilStep("ensure beatmap available", () => beatmaps.IsAvailableLocally(testBeatmapInfo));
             addAvailabilityCheckStep("state is locally available", BeatmapAvailability.LocallyAvailable);
         }
 

--- a/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
+++ b/osu.Game.Tests/Online/TestScenePlaylistsBeatmapAvailabilityTracker.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Tests.Online
         {
             AddStep("allow importing", () => beatmaps.AllowImport.Set());
 
-            AddUntilStep("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapSet));
+            AddUntilStep("ensure beatmap unavailable", () => !beatmaps.IsAvailableLocally(testBeatmapInfo));
             addAvailabilityCheckStep("state not downloaded", BeatmapAvailability.NotDownloaded);
 
             AddStep("start downloading", () => beatmapDownloader.Download(testBeatmapSet));

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -660,8 +660,6 @@ namespace osu.Game.Beatmaps
             remove => workingBeatmapCache.OnInvalidated -= value;
         }
 
-        public override bool IsAvailableLocally(BeatmapSetInfo model) => Realm.Run(realm => realm.All<BeatmapSetInfo>().Any(s => s.OnlineID == model.OnlineID && !s.DeletePending));
-
         public bool IsAvailableLocally(IBeatmapInfo model)
         {
             return Realm.Run(r => r.All<BeatmapInfo>()

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -660,6 +660,11 @@ namespace osu.Game.Beatmaps
             remove => workingBeatmapCache.OnInvalidated -= value;
         }
 
+        public override bool IsAvailableLocally(BeatmapSetInfo model)
+        {
+            throw new InvalidOperationException($"Use overload with {nameof(IBeatmapInfo)} parameter instead.");
+        }
+
         public bool IsAvailableLocally(IBeatmapInfo model)
         {
             return Realm.Run(r => r.All<BeatmapInfo>()

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallengeIntro.cs
@@ -338,7 +338,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
 
             if (config.Get<bool>(OsuSetting.AutomaticallyDownloadMissingBeatmaps))
             {
-                if (!beatmapManager.IsAvailableLocally(new BeatmapSetInfo { OnlineID = beatmap.BeatmapSet!.OnlineID }))
+                if (!beatmapManager.IsAvailableLocally(beatmap))
                     beatmapDownloader.Download(beatmap.BeatmapSet!, config.Get<bool>(OsuSetting.PreferNoVideo));
             }
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Match/MultiplayerSpectateButton.cs
@@ -13,6 +13,7 @@ using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osuTK;
@@ -154,7 +155,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Match
                     if (beatmapSet == null)
                         return;
 
-                    if (beatmaps.IsAvailableLocally(new BeatmapSetInfo { OnlineID = beatmapSet.OnlineID }))
+                    if (beatmaps.IsAvailableLocally(new APIBeatmap { OnlineID = item.BeatmapID }))
                         return;
 
                     beatmapDownloader.Download(beatmapSet);

--- a/osu.Game/Screens/Play/SoloSpectatorScreen.cs
+++ b/osu.Game/Screens/Play/SoloSpectatorScreen.cs
@@ -61,7 +61,7 @@ namespace osu.Game.Screens.Play
 
         private ScheduledDelegate? beatmapFetchCallback;
 
-        private APIBeatmapSet? beatmapSet;
+        private APIBeatmap? beatmap;
 
         public SoloSpectatorScreen(APIUser targetUser)
             : base(targetUser.Id)
@@ -245,29 +245,28 @@ namespace osu.Game.Screens.Play
 
             beatmapLookupCache.GetBeatmapAsync(state.BeatmapID.Value).ContinueWith(t => beatmapFetchCallback = Schedule(() =>
             {
-                var beatmap = t.GetResultSafely();
+                beatmap = t.GetResultSafely();
 
                 if (beatmap?.BeatmapSet == null)
                     return;
 
-                beatmapSet = beatmap.BeatmapSet;
-                beatmapPanelContainer.Child = new BeatmapCardNormal(beatmapSet, allowExpansion: false);
+                beatmapPanelContainer.Child = new BeatmapCardNormal(beatmap.BeatmapSet, allowExpansion: false);
                 checkForAutomaticDownload();
             }));
         }
 
         private void checkForAutomaticDownload()
         {
-            if (beatmapSet == null)
+            if (beatmap?.BeatmapSet == null)
                 return;
 
             if (!automaticDownload.Current.Value)
                 return;
 
-            if (beatmaps.IsAvailableLocally(new BeatmapSetInfo { OnlineID = beatmapSet.OnlineID }))
+            if (beatmaps.IsAvailableLocally(beatmap))
                 return;
 
-            beatmapDownloader.Download(beatmapSet);
+            beatmapDownloader.Download(beatmap.BeatmapSet);
         }
 
         public override bool OnExiting(ScreenExitEvent e)


### PR DESCRIPTION
Found this while fixing another issue...

`IsAvailableLocally(BeatmapSetInfo model)` is flawed in all current usages because it checks whether the set is available but does not verify the state that it's in. This could cause issues when a beatmap has been locally modified.