### PR TITLE
Make bananas not affect hyperdash state in the osu!catch ruleset

### DIFF
--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -237,8 +237,7 @@ namespace osu.Game.Rulesets.Catch.UI
                     Drop();
             }
 
-            // tiny droplet or banana doesn't affect hyperdash state.
-            // banana is relevant in special "2b" cases.
+            // tiny droplet or banana doesn't affect hyperdash state
             if (hitObject is TinyDroplet or Banana) return;
 
             // if a hyper fruit was already handled this frame, just go where it says to go.

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -237,8 +237,8 @@ namespace osu.Game.Rulesets.Catch.UI
                     Drop();
             }
 
-            // tiny droplets and bananas don't affect hyperdash state.
-            // bananas are relevant in special "2b" cases.
+            // tiny droplet or banana doesn't affect hyperdash state.
+            // banana is relevant in special "2b" cases.
             if (hitObject is TinyDroplet or Banana) return;
 
             // if a hyper fruit was already handled this frame, just go where it says to go.

--- a/osu.Game.Rulesets.Catch/UI/Catcher.cs
+++ b/osu.Game.Rulesets.Catch/UI/Catcher.cs
@@ -237,8 +237,9 @@ namespace osu.Game.Rulesets.Catch.UI
                     Drop();
             }
 
-            // droplet doesn't affect hyperdash state
-            if (hitObject is TinyDroplet) return;
+            // tiny droplets and bananas don't affect hyperdash state.
+            // bananas are relevant in special "2b" cases.
+            if (hitObject is TinyDroplet or Banana) return;
 
             // if a hyper fruit was already handled this frame, just go where it says to go.
             // this special-cases some aspire maps that have doubled-up objects (one hyper, one not) at the same time instant.


### PR DESCRIPTION
**Note: This bug can actually affect non-Aspire maps if a hyper fruit appears before a banana shower and its hyper target is the fruit after the banana shower!**

https://github.com/user-attachments/assets/48fedf29-16df-4d7c-94af-47251542d95b

With the [Aspire event](https://osu.ppy.sh/home/news/2026-06-14-aspire-6) coming back after like 6 years, I'd say this bug I am reporting here and its fix is _quite_ urgent for osu!catch Aspire maps especially if done early in the case somebody is considering using this as a gimmick whether accidental or not. If this fix is not applied, hyper fruits will continue to not match in certain Aspire maps between osu!stable and osu!lazer, and this can possibly have unintended consequences during voting when both osu!stable and osu!lazer players have played with fundamentally different hypers.

Here are GIFs somebody provided to me showcasing the issue.

osu!stable - bananas right as they are caught or missed do not forcefully unhyper the catcher before the hyper target:
<img width="1371" height="774" alt="bananaBlock-stable" src="https://github.com/user-attachments/assets/4e0b2504-2699-4f24-a8cb-c6a19ded8a8a" />

osu!lazer - bananas right as they are caught or missed do forcefully unhyper the catcher before the hyper target:
<img width="1371" height="774" alt="bananaBlock-lazer" src="https://github.com/user-attachments/assets/b8dd8063-4522-4f1e-9e5f-e39f04d776d7" />

Bananas have the power to stop the catcher from being hyper if they are caught or missed during a section where the catcher is to be hyper until the hyper dash target is caught or missed. As I catch the hyper fruit and am dashing to the next fruit, as soon as the banana is caught or missed, the catcher returns to a default hyperless state prematurely, and I'm not able to use the hyper from the hyper fruit in full. It can make the next fruit impossible to catch meanwhile in osu!stable, there is no problem.

I believe osu!stable's behavior regarding this is preferred.