### PR TITLE
Allow using slider velocity control in toolbox to adjust velocity of selection

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
@@ -7,7 +7,6 @@ using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Objects;
@@ -137,7 +136,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
         [Test]
         public void TestVelocityToolbox()
         {
-            ExpandableSlider<double> velocitySlider = null!;
+            OsuSliderVelocityToolboxGroup.ExpandableSliderVelocityControl velocitySlider = null!;
             ExpandableButton useLastSliderButton = null!;
 
             AddStep("enter editor", () => Game.ScreenStack.Push(new EditorLoader()));
@@ -145,7 +144,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("retrieve controls", () =>
             {
                 var toolbox = this.ChildrenOfType<OsuSliderVelocityToolboxGroup>().Single();
-                velocitySlider = toolbox.ChildrenOfType<ExpandableSlider<double>>().Single();
+                velocitySlider = toolbox.ChildrenOfType<OsuSliderVelocityToolboxGroup.ExpandableSliderVelocityControl>().Single();
                 useLastSliderButton = toolbox.ChildrenOfType<ExpandableButton>().Single();
             });
 
@@ -192,6 +191,25 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             AddStep("expand right toolbox", () => InputManager.MoveMouseTo(this.ChildrenOfType<ExpandingToolboxContainer>().Last()));
             AddUntilStep("wait for expand", () => useLastSliderButton.Expanded.Value, () => Is.True);
             AddAssert("use last slider button disabled", () => useLastSliderButton.Enabled.Value, () => Is.False);
+
+            AddStep("select fourth slider", () => editorBeatmap.SelectedHitObjects.Add(editorBeatmap.HitObjects[3]));
+            AddAssert("velocity slider at 3x", () => velocitySlider.Current.Value, () => Is.EqualTo(3));
+            AddStep("set 1.5x velocity", () => velocitySlider.Current.Value = 1.5);
+            AddAssert("fourth slider has 1.5x velocity", () => ((Slider)editorBeatmap.HitObjects[3]).SliderVelocityMultiplier, () => Is.EqualTo(1.5));
+
+            AddStep("select first and last slider", () =>
+            {
+                editorBeatmap.SelectedHitObjects.Clear();
+                editorBeatmap.SelectedHitObjects.Add(editorBeatmap.HitObjects[0]);
+                editorBeatmap.SelectedHitObjects.Add(editorBeatmap.HitObjects[^1]);
+            });
+            AddAssert("velocity slider at 1x", () => velocitySlider.Current.Value, () => Is.EqualTo(1));
+            AddStep("set 5x velocity", () => velocitySlider.Current.Value = 5);
+            AddAssert("first slider has 5x velocity", () => ((Slider)editorBeatmap.HitObjects[0]).SliderVelocityMultiplier, () => Is.EqualTo(5));
+            AddAssert("last slider has 5x velocity", () => ((Slider)editorBeatmap.HitObjects[^1]).SliderVelocityMultiplier, () => Is.EqualTo(5));
+
+            AddStep("clear selection", () => editorBeatmap.SelectedHitObjects.Clear());
+            AddAssert("velocity slider at 2x", () => velocitySlider.Current.Value, () => Is.EqualTo(2));
 
             void placeSlider()
             {

--- a/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuSliderVelocityToolboxGroup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -10,21 +11,16 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit;
-using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
     public partial class OsuSliderVelocityToolboxGroup : EditorToolboxGroup
     {
-        /// <summary>
-        /// Whether the last slider's velocity should be used (if available).
-        /// </summary>
-        private bool useLastSliderVelocity;
-
         /// <summary>
         /// The slider velocity to be used for new object placements.
         /// </summary>
@@ -37,8 +33,10 @@ namespace osu.Game.Rulesets.Osu.Edit
             MaxValue = 10,
         };
 
-        private ExpandableSlider<double> slider = null!;
+        private ExpandableSliderVelocityControl sliderControl = null!;
         private ExpandableButton useLastSliderButton = null!;
+
+        private readonly BindableList<HitObject> selectedHitObjects = new BindableList<HitObject>();
 
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
@@ -46,9 +44,36 @@ namespace osu.Game.Rulesets.Osu.Edit
         [Resolved]
         private EditorClock editorClock { get; set; } = null!;
 
-        private bool syncingBindables;
         private double lastClockPosition = double.NegativeInfinity;
-        private readonly Cached<Slider?> sliderVelocitySourceObject = new Cached<Slider?>();
+
+        private bool syncingBindables;
+
+        /// <summary>
+        /// This <see cref="Cached"/> is used to track whether the "source" of slider velocity is valid.
+        /// That means:
+        /// <list type="bullet">
+        /// <item>
+        /// When there are no objects with velocity selected, the presumed "source" of slider velocity is
+        /// the last slider preceding the editor's current playback position (if one exists).
+        /// </item>
+        /// <item>When there are objects with velocity selected, they are the presumed "source" of slider velocity.</item>
+        /// </list>
+        /// Any event that may affect the readout of slider velocity from the "source" of slider velocity as defined above
+        /// should invalidate this <see cref="Cached"/>.
+        /// </summary>
+        private readonly Cached sliderVelocitySource = new Cached();
+
+        /// <summary>
+        /// This flag is used to track whether the <see cref="sliderControl"/>
+        /// is currently decoupled from and overriding the <see cref="sliderVelocitySource"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is only supported when there are no objects with velocity selected.
+        /// In that scenario, this flag supports the behaviour of being able to select a slider velocity manually via <see cref="sliderControl"/>
+        /// independent of the last slider preceding the editor's current playback position.
+        /// <see cref="useLastSliderButton"/> is used to clear this flag.
+        /// </remarks>
+        private bool overridingSliderVelocitySource;
 
         public OsuSliderVelocityToolboxGroup()
             : base("velocity")
@@ -58,10 +83,10 @@ namespace osu.Game.Rulesets.Osu.Edit
         [BackgroundDependencyLoader]
         private void load()
         {
-            Spacing = new Vector2(5);
+            Spacing = new osuTK.Vector2(5);
             Children = new Drawable[]
             {
-                slider = new ExpandableSlider<double>
+                sliderControl = new ExpandableSliderVelocityControl
                 {
                     ExpandedLabelText = "Slider velocity",
                     Current = new BindableDouble(1)
@@ -71,14 +96,15 @@ namespace osu.Game.Rulesets.Osu.Edit
                         MaxValue = 10,
                     },
                     KeyboardStep = 0.1f,
+                    TransferValueOnCommit = true,
                 },
                 useLastSliderButton = new ExpandableButton
                 {
                     RelativeSizeAxes = Axes.X,
                     Action = () =>
                     {
-                        useLastSliderVelocity = true;
-                        sliderVelocitySourceObject.Invalidate();
+                        overridingSliderVelocitySource = false;
+                        sliderVelocitySource.Invalidate();
                     },
                 }
             };
@@ -88,66 +114,85 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
             base.LoadComplete();
 
-            // set unconditionally to true initially.
-            // if there is no object available to get the slider velocity from, the code in `Update()` will handle that.
-            useLastSliderVelocity = true;
-
-            sliderVelocity.BindValueChanged(_ => updateSliderFromVelocity(), true);
-            slider.Current.BindValueChanged(_ =>
+            sliderVelocity.BindValueChanged(_ => updateSliderControlFromVelocity(), true);
+            sliderControl.Current.BindValueChanged(_ =>
             {
-                updateVelocityFromSlider();
+                updateVelocityFromSliderControl();
                 updateContractedText();
             });
             updateContractedText();
-            useLastSliderButton.Expanded.BindValueChanged(_ => sliderVelocitySourceObject.Invalidate());
+            useLastSliderButton.Expanded.BindValueChanged(_ => sliderVelocitySource.Invalidate());
 
             editorBeatmap.HitObjectAdded += invalidateSliderVelocitySourceObject;
             editorBeatmap.HitObjectUpdated += invalidateSliderVelocitySourceObject;
             editorBeatmap.HitObjectRemoved += invalidateSliderVelocitySourceObject;
+            selectedHitObjects.BindTo(editorBeatmap.SelectedHitObjects);
+            selectedHitObjects.BindCollectionChanged((_, _) => sliderVelocitySource.Invalidate());
         }
 
         private void updateContractedText()
         {
-            slider.ContractedLabelText = LocalisableString.Interpolate($@"SV: {slider.Current.Value.ToLocalisableString("N2")}x");
+            sliderControl.ContractedLabelText = LocalisableString.Interpolate($@"SV: {sliderControl.Current.Value.ToLocalisableString("N2")}x");
         }
 
         /// <summary>
-        /// Updates the displayed value of this toolbox's slider from a change to <see cref="SliderVelocity"/>
+        /// Updates the displayed value of this toolbox's <see cref="sliderControl"/> from a change to <see cref="SliderVelocity"/>
         /// (which is the source-of-truth used for new object placements).
-        /// This is only relevant when <see cref="useLastSliderVelocity"/> is true,
-        /// in which case this code is responsible for propagating the velocity from <see cref="sliderVelocitySourceObject"/> to the slider.
+        /// This is only relevant when <see cref="overridingSliderVelocitySource"/> is false,
+        /// in which case this code is responsible for propagating the velocity from <see cref="sliderVelocitySource"/> to the slider.
         /// </summary>
-        private void updateSliderFromVelocity()
+        private void updateSliderControlFromVelocity()
         {
             if (syncingBindables)
                 return;
 
-            if (!useLastSliderVelocity)
+            if (overridingSliderVelocitySource)
                 return;
 
             syncingBindables = true;
-            slider.Current.Value = sliderVelocity.Value;
+            sliderControl.Current.Value = sliderVelocity.Value;
             syncingBindables = false;
         }
 
         /// <summary>
-        /// Updates the value of <see cref="SliderVelocity"/> from a change to the slider's state.
-        /// This change is assumed to be user-provoked, and therefore <see cref="useLastSliderVelocity"/> is switched unconditionally off
-        /// as the presumed intent is to override the velocity from <see cref="sliderVelocitySourceObject"/>.
+        /// Updates the value of <see cref="SliderVelocity"/> from a user-provoked change to the <see cref="sliderControl"/>'s state.
         /// </summary>
-        private void updateVelocityFromSlider()
+        private void updateVelocityFromSliderControl()
         {
             if (syncingBindables)
                 return;
 
             syncingBindables = true;
-            useLastSliderVelocity = false;
-            sliderVelocity.Value = slider.Current.Value;
+
+            var selectedSliders = selectedHitObjects.OfType<Slider>().ToList();
+
+            if (selectedSliders.Any())
+            {
+                Debug.Assert(!overridingSliderVelocitySource);
+
+                editorBeatmap.BeginChange();
+
+                foreach (var selectedSlider in selectedSliders)
+                {
+                    selectedSlider.SliderVelocityMultiplier = sliderControl.Current.Value;
+                    editorBeatmap.Update(selectedSlider);
+                }
+
+                editorBeatmap.EndChange();
+
+                sliderControl.IsMultipleValues = false;
+            }
+            else
+            {
+                overridingSliderVelocitySource = true;
+                sliderVelocity.Value = sliderControl.Current.Value;
+            }
+
             syncingBindables = false;
-            sliderVelocitySourceObject.Invalidate();
+            sliderVelocitySource.Invalidate();
         }
 
-        private void invalidateSliderVelocitySourceObject(HitObject _) => sliderVelocitySourceObject.Invalidate();
+        private void invalidateSliderVelocitySourceObject(HitObject _) => sliderVelocitySource.Invalidate();
 
         protected override void Update()
         {
@@ -155,47 +200,62 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             if (editorClock.CurrentTime != lastClockPosition)
             {
-                sliderVelocitySourceObject.Invalidate();
+                sliderVelocitySource.Invalidate();
                 lastClockPosition = editorClock.CurrentTime;
             }
 
-            // Three possible causes of invalidation:
-            // - The user seeked the clock, which means a different velocity source object needs to be used.
-            // - Some change to the beatmap was made, which means the previously-used velocity source object may no longer be the most relevant one.
+            // Four possible causes of invalidation:
+            // - The user has selected some objects from the beatmap, in which case the velocity from the selected objects (if any)
+            //   should take absolute precedence.
+            // - The user seeked the clock, which means that the last slider to read the velocity from in "use last slider velocity" mode might have changed.
+            // - Some change to the beatmap was made, which means the displayed velocity may no longer match the source objects in underlying beatmap
+            //   (this applies when some objects are selected *and* when none are selected).
             // - The user is interacting with the toolbox in a way that requires a visual state update
             //   (hovered to expand it, clicked the button to use last slider's velocity, or dragged the manual velocity slider).
-            //   This is a procedural one, because `sliderVelocitySourceObject` will have been pointing at the correct object already,
+            //   This is a procedural one, because `sliderVelocitySource` will have been re-validated correctly already in that case,
             //   but to decrease unnecessary work being done every frame, the invalidation is explicitly re-triggered to update the toolbox state.
-            if (!sliderVelocitySourceObject.IsValid)
+            if (!sliderVelocitySource.IsValid)
             {
-                var lastSlider = getLastSlider();
-                sliderVelocitySourceObject.Value = lastSlider;
+                var selectedSliderVelocities = selectedHitObjects.OfType<Slider>().Select(s => s.SliderVelocityMultiplier).Distinct().ToList();
 
-                if (lastSlider == null)
+                if (selectedSliderVelocities.Count > 0)
                 {
+                    overridingSliderVelocitySource = false;
+
                     useLastSliderButton.Enabled.Value = false;
-                    useLastSliderButton.ExpandedLabelText = "No sliders to get velocity from";
+                    useLastSliderButton.ExpandedLabelText = "Adjusting velocity of selection";
                     useLastSliderButton.ContractedLabelText = default;
+
+                    sliderControl.IsMultipleValues = selectedSliderVelocities.Count > 1;
+                    sliderVelocity.Value = selectedSliderVelocities.Count == 1 ? selectedSliderVelocities[0] : 1;
                 }
                 else
                 {
-                    useLastSliderButton.Enabled.Value = useLastSliderButton.Expanded.Value && !useLastSliderVelocity;
-                    useLastSliderButton.ExpandedLabelText = useLastSliderVelocity
-                        ? "Using last slider's velocity"
-                        : LocalisableString.Interpolate($@"Use last slider's velocity ({lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x)");
-                    useLastSliderButton.ContractedLabelText = $@"current {lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x";
-                    if (useLastSliderVelocity)
-                        sliderVelocity.Value = lastSlider.SliderVelocityMultiplier;
-                }
-            }
-        }
+                    var lastSlider = editorBeatmap
+                                     .HitObjects
+                                     .OfType<Slider>()
+                                     .LastOrDefault(h => h.StartTime <= editorClock.CurrentTime);
 
-        private Slider? getLastSlider()
-        {
-            return editorBeatmap
-                   .HitObjects
-                   .OfType<Slider>()
-                   .LastOrDefault(h => h.StartTime <= editorClock.CurrentTime);
+                    if (lastSlider == null)
+                    {
+                        useLastSliderButton.Enabled.Value = false;
+                        useLastSliderButton.ExpandedLabelText = "No sliders to get velocity from";
+                        useLastSliderButton.ContractedLabelText = default;
+                    }
+                    else
+                    {
+                        useLastSliderButton.Enabled.Value = useLastSliderButton.Expanded.Value && overridingSliderVelocitySource;
+                        useLastSliderButton.ExpandedLabelText = overridingSliderVelocitySource
+                            ? LocalisableString.Interpolate($@"Use last slider's velocity ({lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x)")
+                            : "Using last slider's velocity";
+                        useLastSliderButton.ContractedLabelText = $@"current {lastSlider.SliderVelocityMultiplier.ToLocalisableString("N2")}x";
+                        if (!overridingSliderVelocitySource)
+                            sliderVelocity.Value = lastSlider.SliderVelocityMultiplier;
+                    }
+                }
+
+                sliderVelocitySource.Validate();
+            }
         }
 
         protected override void Dispose(bool isDisposing)
@@ -208,6 +268,59 @@ namespace osu.Game.Rulesets.Osu.Edit
             }
 
             base.Dispose(isDisposing);
+        }
+
+        internal partial class ExpandableSliderVelocityControl : ExpandableSlider<double, SliderVelocityControl>
+        {
+            public bool IsMultipleValues
+            {
+                set => Slider.IsMultipleValues = value;
+            }
+
+            public bool TransferValueOnCommit
+            {
+                get => Slider.TransferValueOnCommit;
+                set => Slider.TransferValueOnCommit = value;
+            }
+        }
+
+        internal partial class SliderVelocityControl : FormSliderBar<double>
+        {
+            private bool isMultipleValues;
+
+            /// <summary>
+            /// This is a hack to allow the text box to show an indication that multiple slider velocity values are active
+            /// when the selection contains multiple objects with different velocities.
+            /// </summary>
+            public bool IsMultipleValues
+            {
+                get => isMultipleValues;
+                set
+                {
+                    if (isMultipleValues == value)
+                        return;
+
+                    isMultipleValues = value;
+                    updateLabelFormat();
+                }
+            }
+
+            private void updateLabelFormat()
+            {
+                LabelFormat = isMultipleValues
+                    ? static _ => "(multiple)"
+                    : v => LocalisableString.Interpolate($"{v:0.00}x");
+            }
+
+            public SliderVelocityControl()
+            {
+                updateLabelFormat();
+
+                // The `IsMultipleValues` / `updateLabelFormat()` hack above to jam an indicator of multiple active values does not work for tooltip
+                // because the tooltip machinery framework-side is too smart for it (the tooltip text is only regenerated on direct changes to `Current`).
+                // Just disable it to hide the skeleton. It's of little use anyhow.
+                TooltipFormat = _ => default;
+            }
         }
     }
 }

--- a/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
+++ b/osu.Game/Graphics/UserInterface/ExpandableSlider.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Graphics.UserInterface
         where TSlider : FormSliderBar<T>, new()
     {
         private readonly OsuSpriteText contractedLabel;
-        private readonly TSlider slider;
+        protected readonly TSlider Slider;
 
         /// <summary>
         /// The label text to display when this slider is in a contracted state.
@@ -39,14 +39,14 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         public LocalisableString ExpandedLabelText
         {
-            get => slider.Caption;
-            set => slider.Caption = value;
+            get => Slider.Caption;
+            set => Slider.Caption = value;
         }
 
         public Bindable<T> Current
         {
-            get => slider.Current;
-            set => slider.Current = value;
+            get => Slider.Current;
+            set => Slider.Current = value;
         }
 
         /// <summary>
@@ -54,8 +54,8 @@ namespace osu.Game.Graphics.UserInterface
         /// </summary>
         public float KeyboardStep
         {
-            get => slider.KeyboardStep;
-            set => slider.KeyboardStep = value;
+            get => Slider.KeyboardStep;
+            set => Slider.KeyboardStep = value;
         }
 
         public BindableBool Expanded { get; } = new BindableBool();
@@ -75,7 +75,7 @@ namespace osu.Game.Graphics.UserInterface
                 Children = new Drawable[]
                 {
                     contractedLabel = new OsuSpriteText(),
-                    slider = new TSlider
+                    Slider = new TSlider
                     {
                         RelativeSizeAxes = Axes.X,
                     },
@@ -99,13 +99,13 @@ namespace osu.Game.Graphics.UserInterface
             {
                 contractedLabel.FadeTo(v.NewValue ? 0 : 1);
 
-                slider.FadeTo(v.NewValue ? Current.Disabled ? 0.3f : 1f : 0f, 500, Easing.OutQuint);
-                slider.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
+                Slider.FadeTo(v.NewValue ? Current.Disabled ? 0.3f : 1f : 0f, 500, Easing.OutQuint);
+                Slider.BypassAutoSizeAxes = !v.NewValue ? Axes.Y : Axes.None;
             }, true);
 
             Current.BindDisabledChanged(disabled =>
             {
-                slider.Alpha = Expanded.Value ? disabled ? 0.3f : 1 : 0f;
+                Slider.Alpha = Expanded.Value ? disabled ? 0.3f : 1 : 0f;
             });
         }
     }

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -110,10 +110,22 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public bool PlaySamplesOnAdjust { get; init; } = true;
 
+        private Func<T, LocalisableString> labelFormat;
+
         /// <summary>
         /// The string formatting function to use for the value label.
         /// </summary>
-        public Func<T, LocalisableString> LabelFormat { get; init; }
+        public Func<T, LocalisableString> LabelFormat
+        {
+            get => labelFormat;
+            set
+            {
+                labelFormat = value;
+
+                if (IsLoaded)
+                    updateValueDisplay();
+            }
+        }
 
         /// <summary>
         /// The string formatting function to use for the slider's tooltip text.
@@ -136,7 +148,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
         public FormSliderBar()
         {
-            LabelFormat ??= defaultLabelFormat;
+            labelFormat ??= DefaultLabelFormat;
             TooltipFormat ??= v => LabelFormat(v);
 
             // the reason why this slider is created in constructor rather than in BDL like the rest of drawable hierarchy is as follows:
@@ -422,7 +434,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             valueLabel.Text = LabelFormat(currentNumberInstantaneous.Value);
         }
 
-        private LocalisableString defaultLabelFormat(T value) => currentNumberInstantaneous.Value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS, DisplayAsPercentage);
+        public LocalisableString DefaultLabelFormat(T value) => value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS, DisplayAsPercentage);
 
         public partial class InnerSlider : OsuSliderBar<T>
         {


### PR DESCRIPTION
https://github.com/user-attachments/assets/8d5f94b2-d7b6-4418-a8c2-2fb85aa77bb3

---

RFC

I have received information from @peppy that in the course of preparations for the next lazer changelog video, @pishifat has expressed dissatisfaction with the operation of the slider velocity control added in https://github.com/ppy/osu/pull/37746. If I understood correctly, the issue was that the slider velocity control in question did not attempt to interact with the current selection of objects. @peppy has requested me to attempt to fix it before the next lazer release.

This PR contains an implementation of allowing the slider velocity control to adjust the velocity of all selected sliders, if any.

I am not particularly happy with the resulting code for this feature, but I also do not have many better ideas. Despite my attempts at streamlining the logic after the initial pass, the implementation is still tricky because it attempts to do much magic, both in trying to achieve unobtrusive operation and sufficiently informative visual state.

There are subtle details that may turn out to be unsatisfactory to mappers in practice. For one instance, the following flow may be of concern:

1. Start with no selection. In this state the velocity control follows the last slider by default.
2. Choose a velocity value manually.
3. Select an object.
4. Deselect the object.
5. The velocity value chosen in (2) is dropped.

Such behaviours can be brought back if desired, but at cost of further additional complexity of the logic of the feature.