### PR TITLE
Fix `AudioOffsetAdjustControl`'s members are not displaying separately

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
@@ -20,7 +20,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections.Audio
 {
-    public partial class AudioOffsetAdjustControl : CompositeDrawable
+    public partial class AudioOffsetAdjustControl : FillFlowContainer
     {
         public Bindable<double> Current
         {
@@ -48,56 +48,51 @@ namespace osu.Game.Overlays.Settings.Sections.Audio
 
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
-            InternalChild = new FillFlowContainer
+            Direction = FillDirection.Vertical;
+            Spacing = new Vector2(SettingsSection.ITEM_SPACING_V2);
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.X,
-                AutoSizeAxes = Axes.Y,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(SettingsSection.ITEM_SPACING_V2),
-                Children = new Drawable[]
+                new SettingsItemV2(new FormSliderBar<double>
                 {
-                    new SettingsItemV2(new FormSliderBar<double>
+                    Caption = AudioSettingsStrings.AudioOffset,
+                    RelativeSizeAxes = Axes.X,
+                    Current = { BindTarget = Current },
+                    KeyboardStep = 1,
+                    LabelFormat = v => $"{v:N0} ms",
+                    TooltipFormat = BeatmapOffsetControl.GetOffsetExplanatoryText,
+                }),
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = SettingsPanel.CONTENT_PADDING,
+                    Children = new Drawable[]
                     {
-                        Caption = AudioSettingsStrings.AudioOffset,
-                        RelativeSizeAxes = Axes.X,
-                        Current = { BindTarget = Current },
-                        KeyboardStep = 1,
-                        LabelFormat = v => $"{v:N0} ms",
-                        TooltipFormat = BeatmapOffsetControl.GetOffsetExplanatoryText,
-                    }),
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
-                        Padding = SettingsPanel.CONTENT_PADDING,
-                        Children = new Drawable[]
+                        notchContainer = new Container<Circle>
                         {
-                            notchContainer = new Container<Circle>
+                            RelativeSizeAxes = Axes.X,
+                            Width = 0.5f,
+                            Height = 10,
+                            Anchor = Anchor.TopRight,
+                            Origin = Anchor.TopRight,
+                            Padding = new MarginPadding
                             {
-                                RelativeSizeAxes = Axes.X,
-                                Width = 0.5f,
-                                Height = 10,
-                                Anchor = Anchor.TopRight,
-                                Origin = Anchor.TopRight,
-                                Padding = new MarginPadding
-                                {
-                                    Horizontal = FormSliderBar<double>.InnerSlider.NUB_WIDTH / 2
-                                },
+                                Horizontal = FormSliderBar<double>.InnerSlider.NUB_WIDTH / 2
                             },
-                            hintNote = new SettingsNote { RelativeSizeAxes = Axes.X },
-                        }
-                    },
-                    applySuggestion = new RoundedButton
+                        },
+                        hintNote = new SettingsNote { RelativeSizeAxes = Axes.X },
+                    }
+                },
+                applySuggestion = new RoundedButton
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Text = AudioSettingsStrings.ApplySuggestedOffset,
+                    Padding = SettingsPanel.CONTENT_PADDING,
+                    Action = () =>
                     {
-                        RelativeSizeAxes = Axes.X,
-                        Text = AudioSettingsStrings.ApplySuggestedOffset,
-                        Padding = SettingsPanel.CONTENT_PADDING,
-                        Action = () =>
-                        {
-                            if (SuggestedOffset.Value.HasValue)
-                                current.Value = SuggestedOffset.Value.Value;
-                            hitErrorTracker.ClearHistory();
-                        }
+                        if (SuggestedOffset.Value.HasValue)
+                            current.Value = SuggestedOffset.Value.Value;
+                        hitErrorTracker.ClearHistory();
                     }
                 }
             };


### PR DESCRIPTION
children of `CompositeDrawable` can't be used in searching process (see `osu-framework`'s [code](https://github.com/ppy/osu-framework/blob/a8f24f1cdebe84031c71f2e185818455863a08c1/osu.Framework/Graphics/Containers/SearchContainer.cs#L127-L157)), so i decided to make `AudioOffsetAdjustControl` inherit from `FillFlowContainer` to fix this

incorrect filtering occurred in Russian and Japanese, where the words in the section header and slider's caption did not match

| master | pr |
|-|-|
| <img width="602" height="858" alt="image" src="https://github.com/user-attachments/assets/f201026b-4d48-44d1-95f5-30592c26fa58" /> | <img width="602" height="858" alt="image" src="https://github.com/user-attachments/assets/f0a9ed3b-8cdd-47fa-ad17-e04fdb5c6280" /> |

