### PR TITLE
Introduce `SettingsFilterableGroup` to store inseparable settings

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
+++ b/osu.Game/Overlays/Settings/Sections/Audio/AudioOffsetAdjustControl.cs
@@ -20,7 +20,7 @@ using osuTK;
 
 namespace osu.Game.Overlays.Settings.Sections.Audio
 {
-    public partial class AudioOffsetAdjustControl : CompositeDrawable
+    public partial class AudioOffsetAdjustControl : SettingsFilterableGroup
     {
         public Bindable<double> Current
         {

--- a/osu.Game/Overlays/Settings/Sections/SkinSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/SkinSection.cs
@@ -33,8 +33,6 @@ namespace osu.Game.Overlays.Settings.Sections
 {
     public partial class SkinSection : SettingsSection
     {
-        private SkinDropdown skinDropdown;
-
         public override LocalisableString Header => SkinSettingsStrings.SkinSectionHeader;
 
         public override Drawable CreateIcon() => new SpriteIcon
@@ -44,42 +42,12 @@ namespace osu.Game.Overlays.Settings.Sections
 
         public override IEnumerable<LocalisableString> FilterTerms => base.FilterTerms.Concat(new LocalisableString[] { "skins" });
 
-        private readonly List<Live<SkinInfo>> dropdownItems = new List<Live<SkinInfo>>();
-
-        [Resolved]
-        private SkinManager skins { get; set; }
-
-        [Resolved]
-        private RealmAccess realm { get; set; }
-
-        private IDisposable realmSubscription;
-
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load([CanBeNull] SkinEditorOverlay skinEditor)
         {
             Children = new Drawable[]
             {
-                new SettingsItemV2(skinDropdown = new SkinDropdown
-                {
-                    AlwaysShowSearchBar = true,
-                    AllowNonContiguousMatching = true,
-                    Caption = SkinSettingsStrings.CurrentSkin,
-                    Current = skins.CurrentSkinInfo,
-                }),
-                new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Horizontal,
-                    Padding = SettingsPanel.CONTENT_PADDING,
-                    Children = new Drawable[]
-                    {
-                        // This is all super-temporary until we move skin settings to their own panel / overlay.
-                        new RenameSkinButton { Padding = new MarginPadding { Right = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
-                        new ExportSkinButton { Padding = new MarginPadding { Horizontal = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
-                        new DeleteSkinButton { Padding = new MarginPadding { Left = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
-                    }
-                },
+                new CurrentSkinSettingsGroup(),
                 new SettingsButtonV2
                 {
                     Text = SkinSettingsStrings.SkinLayoutEditor,
@@ -88,45 +56,98 @@ namespace osu.Game.Overlays.Settings.Sections
             };
         }
 
-        protected override void LoadComplete()
+        public partial class CurrentSkinSettingsGroup : SettingsFilterableGroup
         {
-            base.LoadComplete();
+            private SkinDropdown skinDropdown;
 
-            realmSubscription = realm.RegisterForNotifications(_ => realm.Realm.All<SkinInfo>()
-                                                                         .Where(s => !s.DeletePending)
-                                                                         .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
+            private readonly List<Live<SkinInfo>> dropdownItems = new List<Live<SkinInfo>>();
 
-            skinDropdown.Current.BindValueChanged(skin =>
+            [Resolved]
+            private SkinManager skins { get; set; }
+
+            [Resolved]
+            private RealmAccess realm { get; set; }
+
+            private IDisposable realmSubscription;
+
+            [BackgroundDependencyLoader]
+            private void load()
             {
-                if (skin.NewValue.ID == SkinInfo.RANDOM_SKIN)
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+                InternalChild = new FillFlowContainer
                 {
-                    // before selecting random, set the skin back to the previous selection.
-                    // this is done because at this point it will be random_skin_info, and would
-                    // cause SelectRandomSkin to be unable to skip the previous selection.
-                    skins.CurrentSkinInfo.Value = skin.OldValue;
-                    skins.SelectRandomSkin();
-                }
-            });
-        }
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(ITEM_SPACING_V2),
+                    Children = new Drawable[]
+                    {
+                        new SettingsItemV2(skinDropdown = new SkinDropdown
+                        {
+                            AlwaysShowSearchBar = true,
+                            AllowNonContiguousMatching = true,
+                            Caption = SkinSettingsStrings.CurrentSkin,
+                            Current = skins.CurrentSkinInfo,
+                        }),
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Padding = SettingsPanel.CONTENT_PADDING,
+                            Children = new Drawable[]
+                            {
+                                // This is all super-temporary until we move skin settings to their own panel / overlay.
+                                new RenameSkinButton { Padding = new MarginPadding { Right = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
+                                new ExportSkinButton { Padding = new MarginPadding { Horizontal = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
+                                new DeleteSkinButton { Padding = new MarginPadding { Left = 2.5f }, RelativeSizeAxes = Axes.X, Width = 1 / 3f },
+                            }
+                        },
+                    },
+                };
+            }
 
-        private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes)
-        {
-            // This can only mean that realm is recycling, else we would see the protected skins.
-            // Because we are using `Live<>` in this class, we don't need to worry about this scenario too much.
-            if (!sender.Any())
-                return;
-            // For simplicity repopulate the full list.
-            dropdownItems.Clear();
-            dropdownItems.AddRange(skins.GetAllUsableSkins());
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
 
-            Schedule(() => skinDropdown.Items = dropdownItems);
-        }
+                realmSubscription = realm.RegisterForNotifications(_ => realm.Realm.All<SkinInfo>()
+                                                                             .Where(s => !s.DeletePending)
+                                                                             .OrderBy(s => s.Name, StringComparer.OrdinalIgnoreCase), skinsChanged);
 
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
+                skinDropdown.Current.BindValueChanged(skin =>
+                {
+                    if (skin.NewValue.ID == SkinInfo.RANDOM_SKIN)
+                    {
+                        // before selecting random, set the skin back to the previous selection.
+                        // this is done because at this point it will be random_skin_info, and would
+                        // cause SelectRandomSkin to be unable to skip the previous selection.
+                        skins.CurrentSkinInfo.Value = skin.OldValue;
+                        skins.SelectRandomSkin();
+                    }
+                });
+            }
 
-            realmSubscription?.Dispose();
+            private void skinsChanged(IRealmCollection<SkinInfo> sender, ChangeSet changes)
+            {
+                // This can only mean that realm is recycling, else we would see the protected skins.
+                // Because we are using `Live<>` in this class, we don't need to worry about this scenario too much.
+                if (!sender.Any())
+                    return;
+                // For simplicity repopulate the full list.
+                dropdownItems.Clear();
+                dropdownItems.AddRange(skins.GetAllUsableSkins());
+
+                Schedule(() => skinDropdown.Items = dropdownItems);
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                base.Dispose(isDisposing);
+
+                realmSubscription?.Dispose();
+            }
         }
 
         private partial class SkinDropdown : FormDropdown<Live<SkinInfo>>

--- a/osu.Game/Overlays/Settings/SettingsFilterableGroup.cs
+++ b/osu.Game/Overlays/Settings/SettingsFilterableGroup.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Localisation;
+
+namespace osu.Game.Overlays.Settings
+{
+    public abstract partial class SettingsFilterableGroup : CompositeDrawable, IFilterable
+    {
+        public IEnumerable<LocalisableString> FilterTerms => InternalChildren.SelectMany(getFilterTerms);
+
+        public bool MatchingFilter
+        {
+            set => this.FadeTo(value ? 1 : 0);
+        }
+
+        public bool FilteringActive { get; set; }
+
+        private IEnumerable<LocalisableString> getFilterTerms(Drawable drawable)
+        {
+            var filterTerms = new List<LocalisableString>();
+
+            if (drawable is IContainerEnumerable<Drawable> container)
+                filterTerms.AddRange(container.Children.SelectMany(getFilterTerms));
+
+            if (drawable is IFilterable filterable)
+                filterTerms.AddRange(filterable.FilterTerms);
+
+            return filterTerms.AsEnumerable();
+        }
+    }
+}


### PR DESCRIPTION
- closes https://github.com/ppy/osu/issues/35917
- addresses https://github.com/ppy/osu/pull/36119
- supersedes and closes https://github.com/ppy/osu/pull/37183
- supersedes and closes https://github.com/ppy/osu/pull/38113

this PR allows `SettingsFilterableGroup` to be used to create groups of settings that should not exist individually

for example, in the case where there is a dropdown for selecting an element, and below it there is a button that allows you to perform some action on this element, the ability to separately display this button without specifying the context on which this action will be performed can be misleading to the user, see https://github.com/ppy/osu/issues/35917#issuecomment-3641101985

to make the search work correctly, i decided to create a `CompositeDrawable` interlayer, which will contain all the `FilterTerms` of the children, and which would not be a inheritor of `Container` so that [its children could not be used by the search logic separately](https://github.com/ppy/osu-framework/blob/a8f24f1cdebe84031c71f2e185818455863a08c1/osu.Framework/Graphics/Containers/SearchContainer.cs#L127-L157)

this PR also fixes another issue with the separate display of `AudioOffsetAdjustControl`'s settings, see https://github.com/ppy/osu/pull/38113

| master | PR |
|-|-|
| <img width="602" height="858" alt="image" src="https://github.com/user-attachments/assets/d56b7186-4efa-4509-a3ae-a71926443a09" /> | <img width="602" height="900" alt="image" src="https://github.com/user-attachments/assets/656a616a-169b-4c72-b5eb-9b244e7f5591" /> |
| <img width="602" height="858" alt="image" src="https://github.com/user-attachments/assets/7d15aba2-b546-4507-af78-90cea2629540" /> | <img width="602" height="900" alt="image" src="https://github.com/user-attachments/assets/6c7570fe-3062-4694-8503-8cd06a5ef313" /> |