### PR TITLE
Fix overlap on `RankingInformationDisplay`

### DIFF
--- a/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
+++ b/osu.Game/Overlays/Mods/RankingInformationDisplay.cs
@@ -32,6 +32,7 @@ namespace osu.Game.Overlays.Mods
         private readonly BindableWithCurrent<double> current = new BindableWithCurrent<double>();
 
         private const float transition_duration = 200;
+        private const Easing transition_easing = Easing.OutQuint;
 
         private RollingCounter<double> counter = null!;
 
@@ -69,9 +70,11 @@ namespace osu.Game.Overlays.Mods
             {
                 new Container
                 {
-                    Width = 50,
                     RelativeSizeAxes = Axes.Y,
-                    Margin = new MarginPadding(10),
+                    AutoSizeAxes = Axes.X,
+                    AutoSizeDuration = transition_duration,
+                    AutoSizeEasing = transition_easing,
+                    Margin = new MarginPadding { Horizontal = 9, Vertical = 10 },
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Child = rankedText = new TextWithTooltip


### PR DESCRIPTION
works correctly with language change

padding was taken based on the original dimensions
| master | PR |
|-|-|
| <img width="800" height="300" alt="osu_2026-06-19_20-10-14" src="https://github.com/user-attachments/assets/8a34a9dd-306a-406f-b888-0d02da785732" /> | <img width="800" height="300" alt="osu_2026-06-19_20-25-45" src="https://github.com/user-attachments/assets/891fbdf9-ac37-4600-b2d7-7913027eefa8" /> |

master:

https://github.com/user-attachments/assets/f2162227-08c8-49fd-b10a-aa0313c0de1e

PR:

https://github.com/user-attachments/assets/5880de6e-ccca-45c6-a411-9c2ad8ce2ffc