### PR TITLE
Add button to lock tablet area to playable area

### DIFF
--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -133,6 +133,18 @@ namespace osu.Game.Tests.Visual.Settings
             AddStep("enable lock to usable area", () => settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value = true);
             AddAssert("offset is clamped again", () => tabletHandler.AreaOffset.Value == tabletHandler.AreaSize.Value / 2);
             ensureValid();
+
+            AddStep("rotate 45", () => tabletHandler.Rotation.Value = 45);
+            AddAssert("lock is disabled automatically", () => !settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value);
+            ensureInvalid();
+
+            AddStep("attempt to enable lock", () => settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value = true);
+            AddAssert("lock remains disabled", () => !settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value);
+
+            AddStep("rotate to 0", () => tabletHandler.Rotation.Value = 0);
+            AddStep("enable lock again", () => settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value = true);
+            AddAssert("lock enabled successfully", () => settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value);
+            ensureValid();
         }
 
         private void ensureValid() => AddAssert("area valid", () => settings.AreaSelection.IsWithinBounds);

--- a/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
+++ b/osu.Game.Tests/Visual/Settings/TestSceneTabletSettings.cs
@@ -16,6 +16,8 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Settings.Sections.Input;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
 using osuTK;
 
 namespace osu.Game.Tests.Visual.Settings
@@ -117,12 +119,19 @@ namespace osu.Game.Tests.Visual.Settings
         }
 
         [Test]
-        public void TestOffsetValidity()
+        public void TestOffsetClamping()
         {
             ensureValid();
-            AddStep("move right", () => tabletHandler.AreaOffset.Value = Vector2.Zero);
+            AddStep("move outside bounds", () => tabletHandler.AreaOffset.Value = Vector2.Zero);
+            AddAssert("offset is clamped", () => tabletHandler.AreaOffset.Value == tabletHandler.AreaSize.Value / 2);
+            ensureValid();
+
+            AddStep("disable lock to usable area", () => settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value = false);
+            AddStep("move outside bounds", () => tabletHandler.AreaOffset.Value = Vector2.Zero);
             ensureInvalid();
-            AddStep("move back", () => tabletHandler.AreaOffset.Value = tabletHandler.AreaSize.Value / 2);
+
+            AddStep("enable lock to usable area", () => settings.ChildrenOfType<FormCheckBox>().First(c => c.Caption == TabletSettingsStrings.LockToUsableArea).Current.Value = true);
+            AddAssert("offset is clamped again", () => tabletHandler.AreaOffset.Value == tabletHandler.AreaSize.Value / 2);
             ensureValid();
         }
 

--- a/osu.Game/Localisation/TabletSettingsStrings.cs
+++ b/osu.Game/Localisation/TabletSettingsStrings.cs
@@ -35,6 +35,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ConformToCurrentGameAspectRatio => new TranslatableString(getKey(@"conform_to_current_game_aspect_ratio"), @"Conform to current game aspect ratio");
 
         /// <summary>
+        /// "Lock to usable area"
+        /// </summary>
+        public static LocalisableString LockToUsableArea => new TranslatableString(getKey(@"lock_to_usable_area"), @"Lock to usable area");
+
+        /// <summary>
         /// "X Offset"
         /// </summary>
         public static LocalisableString XOffset => new TranslatableString(getKey(@"x_offset"), @"X Offset");
@@ -58,11 +63,6 @@ namespace osu.Game.Localisation
         /// "Lock aspect ratio"
         /// </summary>
         public static LocalisableString LockAspectRatio => new TranslatableString(getKey(@"lock_aspect_ratio"), @"Lock aspect ratio");
-
-        /// <summary>
-        /// "Lock to usable area"
-        /// </summary>
-        public static LocalisableString LockToUsableArea => new TranslatableString(getKey(@"lock_to_usable_area"), @"Lock to usable area");
 
         /// <summary>
         /// "Tip pressure for click"

--- a/osu.Game/Localisation/TabletSettingsStrings.cs
+++ b/osu.Game/Localisation/TabletSettingsStrings.cs
@@ -60,6 +60,11 @@ namespace osu.Game.Localisation
         public static LocalisableString LockAspectRatio => new TranslatableString(getKey(@"lock_aspect_ratio"), @"Lock aspect ratio");
 
         /// <summary>
+        /// "Lock to usable area"
+        /// </summary>
+        public static LocalisableString LockToUsableArea => new TranslatableString(getKey(@"lock_to_usable_area"), @"Lock to usable area");
+
+        /// <summary>
         /// "Tip pressure for click"
         /// </summary>
         public static LocalisableString TipPressureForClick => new TranslatableString(getKey(@"tip_pressure_for_click"), "Tip pressure for click");

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -264,35 +264,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         protected override void OnDrag(DragEvent e)
         {
             var newPos = Position + e.Delta;
-
-            if (lockToUsableArea.Value && tabletHandler.Tablet.Value is TabletInfo tablet)
-            {
-                var size = tabletHandler.AreaSize.Value;
-                var tabletSize = tablet.Size;
-                float rotation = tabletHandler.Rotation.Value;
-
-                float rad = float.DegreesToRadians(rotation);
-                float cos = MathF.Abs(MathF.Cos(rad));
-                float sin = MathF.Abs(MathF.Sin(rad));
-
-                float maxX = (size.X / 2) * cos + (size.Y / 2) * sin;
-                float maxY = (size.X / 2) * sin + (size.Y / 2) * cos;
-
-                float minX = MathF.Min(maxX, tabletSize.X / 2);
-                float maxXRange = MathF.Max(tabletSize.X - maxX, tabletSize.X / 2);
-                float minY = MathF.Min(maxY, tabletSize.Y / 2);
-                float maxYRange = MathF.Max(tabletSize.Y - maxY, tabletSize.Y / 2);
-
-                newPos = new Vector2(
-                    Math.Clamp(newPos.X, minX, maxXRange),
-                    Math.Clamp(newPos.Y, minY, maxYRange)
-                );
-            }
-            else
-            {
-                newPos = Vector2.Clamp(newPos, Vector2.Zero, Parent!.Size);
-            }
-
+            newPos = lockToUsableArea.Value ? tabletHandler.ClampOffset(newPos) : Vector2.Clamp(newPos, Vector2.Zero, Parent!.Size);
             this.MoveTo(newPos);
         }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -24,6 +24,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
     {
         public bool IsWithinBounds { get; private set; }
 
+        public readonly BindableBool LockToUsableArea = new BindableBool(true);
+
         private readonly ITabletHandler handler;
 
         private Container tabletContainer;
@@ -84,7 +86,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = colourProvider.Background4,
                                 },
-                                usableAreaContainer = new UsableAreaContainer(handler)
+                                usableAreaContainer = new UsableAreaContainer(handler, LockToUsableArea)
                                 {
                                     Origin = Anchor.Centre,
                                     Children = new Drawable[]
@@ -246,10 +248,14 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
     public partial class UsableAreaContainer : Container
     {
+        private readonly ITabletHandler tabletHandler;
         private readonly Bindable<Vector2> areaOffset;
+        private readonly BindableBool lockToUsableArea;
 
-        public UsableAreaContainer(ITabletHandler tabletHandler)
+        public UsableAreaContainer(ITabletHandler tabletHandler, BindableBool lockToUsableArea)
         {
+            this.tabletHandler = tabletHandler;
+            this.lockToUsableArea = lockToUsableArea;
             areaOffset = tabletHandler.AreaOffset.GetBoundCopy();
         }
 
@@ -258,7 +264,36 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         protected override void OnDrag(DragEvent e)
         {
             var newPos = Position + e.Delta;
-            this.MoveTo(Vector2.Clamp(newPos, Vector2.Zero, Parent!.Size));
+
+            if (lockToUsableArea.Value && tabletHandler.Tablet.Value is TabletInfo tablet)
+            {
+                var size = tabletHandler.AreaSize.Value;
+                var tabletSize = tablet.Size;
+                float rotation = tabletHandler.Rotation.Value;
+
+                float rad = float.DegreesToRadians(rotation);
+                float cos = MathF.Abs(MathF.Cos(rad));
+                float sin = MathF.Abs(MathF.Sin(rad));
+
+                float maxX = (size.X / 2) * cos + (size.Y / 2) * sin;
+                float maxY = (size.X / 2) * sin + (size.Y / 2) * cos;
+
+                float minX = MathF.Min(maxX, tabletSize.X / 2);
+                float maxXRange = MathF.Max(tabletSize.X - maxX, tabletSize.X / 2);
+                float minY = MathF.Min(maxY, tabletSize.Y / 2);
+                float maxYRange = MathF.Max(tabletSize.Y - maxY, tabletSize.Y / 2);
+
+                newPos = new Vector2(
+                    Math.Clamp(newPos.X, minX, maxXRange),
+                    Math.Clamp(newPos.Y, minY, maxYRange)
+                );
+            }
+            else
+            {
+                newPos = Vector2.Clamp(newPos, Vector2.Zero, Parent!.Size);
+            }
+
+            this.MoveTo(newPos);
         }
 
         protected override void OnDragEnd(DragEndEvent e)

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletHandlerExtensions.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletHandlerExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Input.Handlers.Tablet;
+using osuTK;
+
+namespace osu.Game.Overlays.Settings.Sections.Input
+{
+    public static class TabletHandlerExtensions
+    {
+        public static Vector2 ClampOffset(this ITabletHandler handler, Vector2 offset)
+        {
+            if (handler.Tablet.Value == null)
+                return offset;
+
+            var size = handler.AreaSize.Value;
+            var tabletSize = handler.Tablet.Value.Size;
+
+            float rad = float.DegreesToRadians(handler.Rotation.Value);
+            float cos = MathF.Abs(MathF.Cos(rad));
+            float sin = MathF.Abs(MathF.Sin(rad));
+
+            float maxX = (size.X / 2) * cos + (size.Y / 2) * sin;
+            float maxY = (size.X / 2) * sin + (size.Y / 2) * cos;
+
+            float minX = MathF.Min(maxX, tabletSize.X / 2);
+            float maxXRange = MathF.Max(tabletSize.X - maxX, tabletSize.X / 2);
+            float minY = MathF.Min(maxY, tabletSize.Y / 2);
+            float maxYRange = MathF.Max(tabletSize.Y - maxY, tabletSize.Y / 2);
+
+            return new Vector2(
+                Math.Clamp(offset.X, minX, maxXRange),
+                Math.Clamp(offset.Y, minY, maxYRange)
+            );
+        }
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletHandlerExtensions.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletHandlerExtensions.cs
@@ -34,5 +34,24 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 Math.Clamp(offset.Y, minY, maxYRange)
             );
         }
+
+        public static bool CanFit(this ITabletHandler handler)
+        {
+            if (handler.Tablet.Value == null)
+                return true;
+
+            var size = handler.AreaSize.Value;
+            var tabletSize = handler.Tablet.Value.Size;
+
+            float rad = float.DegreesToRadians(handler.Rotation.Value);
+            float cos = MathF.Abs(MathF.Cos(rad));
+            float sin = MathF.Abs(MathF.Sin(rad));
+
+            float maxX = (size.X / 2) * cos + (size.Y / 2) * sin;
+            float maxY = (size.X / 2) * sin + (size.Y / 2) * cos;
+
+            const float lenience = 0.5f;
+            return maxX <= tabletSize.X / 2 + lenience && maxY <= tabletSize.Y / 2 + lenience;
+        }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -72,6 +73,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         };
 
         private readonly BindableBool aspectLock = new BindableBool();
+        private readonly BindableBool lockToUsableArea = new BindableBool(true);
 
         private ScheduledDelegate aspectRatioApplication;
 
@@ -161,6 +163,11 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         {
                             Padding = SettingsPanel.CONTENT_PADDING,
                         },
+                        new SettingsItemV2(new FormCheckBox
+                        {
+                            Caption = TabletSettingsStrings.LockToUsableArea,
+                            Current = lockToUsableArea,
+                        }),
                         new SettingsItemV2(new FormSliderBar<float>
                         {
                             TransferValueOnCommit = true,
@@ -200,14 +207,39 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.LoadComplete();
 
+            AreaSelection.LockToUsableArea.BindTo(lockToUsableArea);
+
+            lockToUsableArea.BindValueChanged(val => Schedule(() =>
+            {
+                if (val.NewValue)
+                {
+                    var clampedOffset = clampOffset(areaOffset.Value);
+                    if (clampedOffset != areaOffset.Value)
+                        areaOffset.Value = clampedOffset;
+                }
+            }));
+
             enabled.BindTo(tabletHandler.Enabled);
             enabled.BindValueChanged(_ => Scheduler.AddOnce(updateVisibility));
 
             rotation.BindTo(tabletHandler.Rotation);
+            rotation.BindValueChanged(val => Schedule(() =>
+            {
+                var clampedOffset = clampOffset(areaOffset.Value);
+                if (clampedOffset != areaOffset.Value)
+                    areaOffset.Value = clampedOffset;
+            }), true);
 
             areaOffset.BindTo(tabletHandler.AreaOffset);
             areaOffset.BindValueChanged(val => Schedule(() =>
             {
+                var clamped = clampOffset(val.NewValue);
+                if (clamped != val.NewValue)
+                {
+                    areaOffset.Value = clamped;
+                    return;
+                }
+
                 offsetX.Value = val.NewValue.X;
                 offsetY.Value = val.NewValue.Y;
             }), true);
@@ -218,6 +250,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             areaSize.BindTo(tabletHandler.AreaSize);
             areaSize.BindValueChanged(val => Schedule(() =>
             {
+                var clampedOffset = clampOffset(areaOffset.Value);
+                if (clampedOffset != areaOffset.Value)
+                    areaOffset.Value = clampedOffset;
+
                 sizeX.Value = val.NewValue.X;
                 sizeY.Value = val.NewValue.Y;
             }), true);
@@ -333,6 +369,32 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
             aspectRatioApplication?.Cancel();
             aspectLock.Value = true;
+        }
+
+        private Vector2 clampOffset(Vector2 offset)
+        {
+            if (tablet.Value == null || !lockToUsableArea.Value)
+                return offset;
+
+            var size = areaSize.Value;
+            var tabletSize = tablet.Value.Size;
+
+            float rad = float.DegreesToRadians(rotation.Value);
+            float cos = MathF.Abs(MathF.Cos(rad));
+            float sin = MathF.Abs(MathF.Sin(rad));
+
+            float maxX = (size.X / 2) * cos + (size.Y / 2) * sin;
+            float maxY = (size.X / 2) * sin + (size.Y / 2) * cos;
+
+            float minX = MathF.Min(maxX, tabletSize.X / 2);
+            float maxXRange = MathF.Max(tabletSize.X - maxX, tabletSize.X / 2);
+            float minY = MathF.Min(maxY, tabletSize.Y / 2);
+            float maxYRange = MathF.Max(tabletSize.Y - maxY, tabletSize.Y / 2);
+
+            return new Vector2(
+                Math.Clamp(offset.X, minX, maxXRange),
+                Math.Clamp(offset.Y, minY, maxYRange)
+            );
         }
 
         private void updateAspectRatio() => aspectRatio.Value = currentAspectRatio;

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -213,9 +213,16 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             {
                 if (val.NewValue)
                 {
-                    var clampedOffset = clampOffset(areaOffset.Value);
-                    if (clampedOffset != areaOffset.Value)
-                        areaOffset.Value = clampedOffset;
+                    if (tabletHandler.CanFit())
+                    {
+                        var clampedOffset = clampOffset(areaOffset.Value);
+                        if (clampedOffset != areaOffset.Value)
+                            areaOffset.Value = clampedOffset;
+                    }
+                    else
+                    {
+                        lockToUsableArea.Value = false;
+                    }
                 }
             }));
 
@@ -225,9 +232,19 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             rotation.BindTo(tabletHandler.Rotation);
             rotation.BindValueChanged(val => Schedule(() =>
             {
-                var clampedOffset = clampOffset(areaOffset.Value);
-                if (clampedOffset != areaOffset.Value)
-                    areaOffset.Value = clampedOffset;
+                if (lockToUsableArea.Value)
+                {
+                    if (tabletHandler.CanFit())
+                    {
+                        var clampedOffset = clampOffset(areaOffset.Value);
+                        if (clampedOffset != areaOffset.Value)
+                            areaOffset.Value = clampedOffset;
+                    }
+                    else
+                    {
+                        lockToUsableArea.Value = false;
+                    }
+                }
             }), true);
 
             areaOffset.BindTo(tabletHandler.AreaOffset);
@@ -250,9 +267,19 @@ namespace osu.Game.Overlays.Settings.Sections.Input
             areaSize.BindTo(tabletHandler.AreaSize);
             areaSize.BindValueChanged(val => Schedule(() =>
             {
-                var clampedOffset = clampOffset(areaOffset.Value);
-                if (clampedOffset != areaOffset.Value)
-                    areaOffset.Value = clampedOffset;
+                if (lockToUsableArea.Value)
+                {
+                    if (tabletHandler.CanFit())
+                    {
+                        var clampedOffset = clampOffset(areaOffset.Value);
+                        if (clampedOffset != areaOffset.Value)
+                            areaOffset.Value = clampedOffset;
+                    }
+                    else
+                    {
+                        lockToUsableArea.Value = false;
+                    }
+                }
 
                 sizeX.Value = val.NewValue.X;
                 sizeY.Value = val.NewValue.Y;

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -373,28 +373,10 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private Vector2 clampOffset(Vector2 offset)
         {
-            if (tablet.Value == null || !lockToUsableArea.Value)
+            if (!lockToUsableArea.Value)
                 return offset;
 
-            var size = areaSize.Value;
-            var tabletSize = tablet.Value.Size;
-
-            float rad = float.DegreesToRadians(rotation.Value);
-            float cos = MathF.Abs(MathF.Cos(rad));
-            float sin = MathF.Abs(MathF.Sin(rad));
-
-            float maxX = (size.X / 2) * cos + (size.Y / 2) * sin;
-            float maxY = (size.X / 2) * sin + (size.Y / 2) * cos;
-
-            float minX = MathF.Min(maxX, tabletSize.X / 2);
-            float maxXRange = MathF.Max(tabletSize.X - maxX, tabletSize.X / 2);
-            float minY = MathF.Min(maxY, tabletSize.Y / 2);
-            float maxYRange = MathF.Max(tabletSize.Y - maxY, tabletSize.Y / 2);
-
-            return new Vector2(
-                Math.Clamp(offset.X, minX, maxXRange),
-                Math.Clamp(offset.Y, minY, maxYRange)
-            );
+            return tabletHandler.ClampOffset(offset);
         }
 
         private void updateAspectRatio() => aspectRatio.Value = currentAspectRatio;

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;


### PR DESCRIPTION
Added a button in the input section of the tablet settings "Lock to usable area".

notes:
This toggle allows the player to lock the tablet area to the playable area.
It will also snap to the nearest point if enabled, while the current tablet area is outside the current playable area.
If its impossible to snap to the nearest point, due to the area being rotated and too big at the same time, the button wont be able to be toggled.
It also disables itself when the user rotates the area and its impossible to be kept on for the same reason as before.

Demonstration:

https://github.com/user-attachments/assets/33286bf8-7343-4b70-b10f-8e4acb109677


