### PR TITLE
Add localisation support to "Daily Challenge"

### DIFF
--- a/osu.Game/Localisation/DailyChallengeStatsDisplayStrings.cs
+++ b/osu.Game/Localisation/DailyChallengeStatsDisplayStrings.cs
@@ -19,6 +19,13 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString UnitWeek(LocalisableString count) => new TranslatableString(getKey(@"unit_week"), @"{0}w", count);
 
+        /// <summary>
+        /// "Daily
+        /// Challenge"
+        /// </summary>
+        public static LocalisableString DailyChallengeTitle => new TranslatableString(getKey(@"daily_challenge_title"), @"Daily
+Challenge");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -129,9 +129,7 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 },
             };
 
-            // can't use this because osu-web does weird stuff with \\n.
-            // Text = UsersStrings.ShowDailyChallengeTitle.,
-            label.AddParagraph("Daily\nChallenge");
+            label.AddParagraph(DailyChallengeStatsDisplayStrings.DailyChallengeTitle);
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
personally, i think this is fine, since another bug with "valuew" & "valued" in `osu-localisation-analyser` led to the same workaround

as an alternative solution i can suggest creating a separate rule in `osu-localisation-analyser` to replace "\n" character with actual line break, or adding more correct processing of these characters in `osu-framework` [as discussed here](https://github.com/ppy/osu/pull/32909#issuecomment-2823118496)