### PR TITLE
Use markdown container for changelog entry description

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneChangelogOverlay.cs
@@ -202,6 +202,39 @@ namespace osu.Game.Tests.Visual.Online
             });
         }
 
+        [Test]
+        public void TestMarkdown()
+        {
+            showBuild(() => new APIChangelogBuild
+            {
+                Version = "2026.620.0",
+                DisplayVersion = "2026.620.0",
+                CreatedAt = new DateTime(2026, 6, 20),
+                UpdateStream = new APIUpdateStream
+                {
+                    Name = "Test",
+                    DisplayName = "Test"
+                },
+                ChangelogEntries = new List<APIChangelogEntry>
+                {
+                    new APIChangelogEntry
+                    {
+                        Category = "Markdown",
+                        Title = "Testing markdown container in changelog",
+                        Message = @"This paragraph [has a link](https://osu.ppy.sh) to osu! website.
+
+![](https://i.ppy.sh/e8b1f3cafa284aa347dd96b3977ceedd0e42d3c0/68747470733a2f2f6f73752e7070792e73682f77696b692f696d616765732f7368617265642f6e6577732f323032362d30362d30332d6d6f642d6d756c7469706c696572732d7375727665792d726573756c74732f6d6f642d6d756c7469706c696572732e706e673f32)
+
+There is mod multiplayer image above.
+
+<video width=""80%"" controls><source src=""https://github.com/user-attachments/assets/2a511e0d-51f8-4abf-a3ab-de0992618b6b"" type=""video/mp4"" preload=""none""></video>
+
+Paragraph above only contains html video and should not be rendered."
+                    }
+                }
+            });
+        }
+
         private void showBuild(Func<APIChangelogBuild> build)
         {
             AddStep("set up build", () => requestedBuild = build.Invoke());

--- a/osu.Game/Online/API/Requests/Responses/APIChangelogEntry.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIChangelogEntry.cs
@@ -34,6 +34,9 @@ namespace osu.Game.Online.API.Requests.Responses
         [JsonProperty("title")]
         public string Title { get; set; }
 
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
         [JsonProperty("message_html")]
         public string MessageHtml { get; set; }
 

--- a/osu.Game/Overlays/Changelog/ChangelogEntry.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogEntry.cs
@@ -185,7 +185,7 @@ namespace osu.Game.Overlays.Changelog
             {
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
-                DocumentMargin = new MarginPadding(0),
+                DocumentMargin = new MarginPadding { Bottom = 10 },
                 DocumentPadding = new MarginPadding(0),
                 Text = entry.Message,
             };

--- a/osu.Game/Overlays/Changelog/ChangelogEntry.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogEntry.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Net;
-using System.Text.RegularExpressions;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -180,21 +178,17 @@ namespace osu.Game.Overlays.Changelog
 
         private Drawable createMessage()
         {
-            if (string.IsNullOrEmpty(entry.MessageHtml))
+            if (string.IsNullOrEmpty(entry.Message))
                 return Empty();
 
-            var message = new TextFlowContainer
+            var message = new ChangelogMarkdownContainer
             {
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
+                DocumentMargin = new MarginPadding(0),
+                DocumentPadding = new MarginPadding(0),
+                Text = entry.Message,
             };
-
-            // todo: use markdown parsing once API returns markdown
-            message.AddText(WebUtility.HtmlDecode(Regex.Replace(entry.MessageHtml, @"<(.|\n)*?>", string.Empty)), t =>
-            {
-                t.Font = fontMedium;
-                t.Colour = colourProvider.Foreground1;
-            });
 
             return message;
         }

--- a/osu.Game/Overlays/Changelog/ChangelogMarkdownContainer.cs
+++ b/osu.Game/Overlays/Changelog/ChangelogMarkdownContainer.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics.Containers.Markdown;
+using osu.Game.Graphics.Sprites;
+
+namespace osu.Game.Overlays.Changelog
+{
+    public partial class ChangelogMarkdownContainer : OsuMarkdownContainer
+    {
+        public override SpriteText CreateSpriteText() => new OsuSpriteText
+        {
+            Font = base.CreateSpriteText().Font.With(size: 12)
+        };
+
+        protected override void AddMarkdownComponent(IMarkdownObject markdownObject, FillFlowContainer container, int level)
+        {
+            switch (markdownObject)
+            {
+                case ParagraphBlock paragraphBlock:
+                    if (paragraphBlock.Inline.FirstChild is HtmlInline firstChild &&
+                        paragraphBlock.Inline.LastChild is HtmlInline lastChild &&
+                        firstChild.Tag.Contains("video") && lastChild.Tag.Contains("video"))
+                    {
+                        // Don't render paragraph that only contains HTML video
+                        return;
+                    }
+
+                    break;
+            }
+
+            base.AddMarkdownComponent(markdownObject, container, level);
+        }
+    }
+}


### PR DESCRIPTION
I notice there is not mod multiplier image in the lazer changelog and then found this todo to use markdown container in changelog entry.