### PR TITLE
Fix duplicates of `[General]` section getting concatenated to `skin.ini` on every skin rename

### DIFF
--- a/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
+++ b/osu.Game.Tests/Skins/IO/ImportSkinTest.cs
@@ -295,6 +295,44 @@ namespace osu.Game.Tests.Skins.IO
             });
         });
 
+        [Test]
+        public Task TestExportRenameThenImportClassicSkin() => runSkinTest(async osu =>
+        {
+            var skinManager = osu.Dependencies.Get<SkinManager>();
+
+            skinManager.CurrentSkinInfo.Value = skinManager.DefaultClassicSkin.SkinInfo;
+
+            skinManager.EnsureMutableSkin();
+            skinManager.Rename(skinManager.CurrentSkinInfo.Value, "breadsticks");
+
+            MemoryStream exportStream = new MemoryStream();
+
+            Guid originalSkinId = skinManager.CurrentSkinInfo.Value.ID;
+
+            await skinManager.CurrentSkinInfo.Value.PerformRead(async s =>
+            {
+                Assert.That(s.Protected, Is.False);
+                Assert.That(s.CreateInstance(skinManager), Is.TypeOf<DefaultLegacySkin>());
+
+                await new LegacySkinExporter(osu.Dependencies.Get<Storage>()).ExportToStreamAsync(skinManager.CurrentSkinInfo.Value, exportStream);
+
+                Assert.That(exportStream.Length, Is.GreaterThan(0));
+            });
+
+            // ReSharper disable once MethodHasAsyncOverload
+            osu.Dependencies.Get<RealmAccess>().Write(r => r.Remove(r.Find<SkinInfo>(originalSkinId)!));
+
+            var imported = await skinManager.Import(new ImportTask(exportStream, "breadsticks.osk"));
+
+            imported.PerformRead(s =>
+            {
+                Assert.That(s.Protected, Is.False);
+                Assert.That(s.ID, Is.Not.EqualTo(originalSkinId));
+                Assert.That(s.CreateInstance(skinManager), Is.TypeOf<DefaultLegacySkin>());
+                Assert.That(s.Name, Is.EqualTo("breadsticks"));
+            });
+        });
+
         #endregion
 
         [Test]

--- a/osu.Game/Skinning/DefaultLegacySkin.cs
+++ b/osu.Game/Skinning/DefaultLegacySkin.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Skinning
             Configuration.ConfigDictionary[nameof(SkinConfiguration.LegacySetting.AllowSliderBallTint)] = @"true";
 
             Configuration.LegacyVersion = 2.7m;
+            Configuration.IsLatestVersion = true;
         }
     }
 }

--- a/osu.Game/Skinning/LegacySkinDecoder.cs
+++ b/osu.Game/Skinning/LegacySkinDecoder.cs
@@ -39,7 +39,10 @@ namespace osu.Game.Skinning
                                     skin.IsLatestVersion = true;
                                 }
                                 else if (decimal.TryParse(pair.Value, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out decimal version))
+                                {
                                     skin.LegacyVersion = version;
+                                    skin.IsLatestVersion = false;
+                                }
 
                                 return;
                         }
@@ -64,6 +67,7 @@ namespace osu.Game.Skinning
         {
             var config = base.CreateTemplateObject();
             config.LegacyVersion = 1.0m;
+            config.IsLatestVersion = false;
             return config;
         }
     }

--- a/osu.Game/Skinning/LegacySkinEncoder.cs
+++ b/osu.Game/Skinning/LegacySkinEncoder.cs
@@ -13,9 +13,9 @@ namespace osu.Game.Skinning
 {
     public class LegacySkinEncoder
     {
-        private readonly LegacySkin skin;
+        private readonly Skin skin;
 
-        public LegacySkinEncoder(LegacySkin skin)
+        public LegacySkinEncoder(Skin skin)
         {
             this.skin = skin;
         }
@@ -25,8 +25,8 @@ namespace osu.Game.Skinning
             // https://github.com/peppy/osu-stable-reference/blob/0b8b19af621dbb282773c22b36cc0453942b98d8/osu!/Graphics/Skinning/SkinOsu.cs#L147-L192
 
             writeSectionHeader(textWriter, LegacyDecoder<SkinConfiguration>.Section.General);
-            writeValue(textWriter, @"Name", skin.SkinInfo.PerformRead(s => s.Name));
-            writeValue(textWriter, @"Author", skin.SkinInfo.PerformRead(s => s.Creator));
+            writeValue(textWriter, @"Name", skin.Configuration.SkinInfo.Name);
+            writeValue(textWriter, @"Author", skin.Configuration.SkinInfo.Creator);
 
             // the reason why the keys are manually enumerated here rather than just iterating over `skin.Configuration.ConfigDictionary`
             // is that the skin decoder generally just dumps anything and everything that looks like a variable, from *any* section, into `ConfigDictionary`.
@@ -84,7 +84,7 @@ namespace osu.Game.Skinning
             writeGenericColour(textWriter, skin.Configuration.CustomColours, @"HyperDashFruit");
 
             // https://github.com/peppy/osu-stable-reference/blob/0b8b19af621dbb282773c22b36cc0453942b98d8/osu!/Graphics/Skinning/SkinMania.cs#L201-L230
-            foreach (var (keys, maniaConfig) in skin.ManiaConfigurations)
+            foreach (var (keys, maniaConfig) in (skin as LegacySkin)?.ManiaConfigurations ?? [])
             {
                 textWriter.WriteLine();
                 writeSectionHeader(textWriter, LegacyDecoder<SkinConfiguration>.Section.Mania);

--- a/osu.Game/Skinning/Skin.cs
+++ b/osu.Game/Skinning/Skin.cs
@@ -112,6 +112,7 @@ namespace osu.Game.Skinning
                     // generally won't be hit as we always write a `skin.ini` on import, but best be safe than sorry.
                     // see https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/Graphics/Skinning/SkinManager.cs#L297-L298
                     LegacyVersion = SkinConfiguration.LATEST_VERSION,
+                    IsLatestVersion = true,
                 };
             }
 

--- a/osu.Game/Skinning/SkinImporter.cs
+++ b/osu.Game/Skinning/SkinImporter.cs
@@ -162,72 +162,36 @@ namespace osu.Game.Skinning
 
         public void UpdateSkinIniMetadata(SkinInfo item, Realm realm)
         {
-            string nameLine = @$"Name: {item.Name}";
-            string authorLine = @$"Author: {item.Creator}";
-
-            List<string> newLines = new List<string>
-            {
-                @"// The following content was automatically added by osu! in order to use metadata that more closely matches user expectations.",
-                @"[General]",
-                nameLine,
-                authorLine,
-            };
-
             var existingFile = item.GetFile(@"skin.ini");
 
+            // create a working instance of the skin.
+            // this implicitly decodes all contents of `skin.ini` into `skin.Configuration` and others.
+            // of note, `item` and `skin.Configuration.SkinInfo` are not the same object.
+            var skin = createInstance(item);
+
+            // `skin.Configuration.SkinInfo` will be in a post-decoding state,
+            // which means it will potentially be in a different state than `item`.
+            // write changes from `item` to `skin.SkinInfo` to definitively apply them.
+            skin.Configuration.SkinInfo.Name = item.Name;
+            skin.Configuration.SkinInfo.Creator = item.Creator;
+
+            using var outStream = new MemoryStream();
+
+            // now with the skin having the updated metadata, write out the full `skin.ini`.
+            using (var outWriter = new StreamWriter(outStream, Encoding.UTF8, 1024, true))
+            {
+                var encoder = new LegacySkinEncoder(skin);
+                encoder.Encode(outWriter);
+            }
+
             if (existingFile == null)
-            {
-                // skins without a skin.ini are supposed to import using the "latest version" spec, unless we're making a copy of the retro skin which specifies 1.0.
-                // see https://github.com/peppy/osu-stable-reference/blob/1531237b63392e82c003c712faa028406073aa8f/osu!/Graphics/Skinning/SkinManager.cs#L297-L298
-                decimal version = item.InstantiationInfo == typeof(RetroSkin).GetInvariantInstantiationInfo() ? 1.0M : SkinConfiguration.LATEST_VERSION;
-                newLines.Add(FormattableString.Invariant($"Version: {version}"));
-
-                // In the case a skin doesn't have a skin.ini yet, let's create one.
-                writeNewSkinIni();
-            }
+                modelManager.AddFile(item, outStream, @"skin.ini", realm);
             else
-            {
-                using (Stream stream = new MemoryStream())
-                {
-                    using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
-                    {
-                        using (var existingStream = Files.Storage.GetStream(existingFile.File.GetStoragePath()))
-                        using (var sr = new StreamReader(existingStream))
-                        {
-                            string? line;
-                            while ((line = sr.ReadLine()) != null)
-                                sw.WriteLine(line);
-                        }
-
-                        sw.WriteLine();
-
-                        foreach (string line in newLines)
-                            sw.WriteLine(line);
-                    }
-
-                    modelManager.ReplaceFile(existingFile, stream, realm);
-                }
-            }
+                modelManager.ReplaceFile(existingFile, outStream, realm);
 
             // The hash is already populated at this point in import.
             // As we have changed files, it needs to be recomputed.
             item.Hash = ComputeHash(item);
-
-            void writeNewSkinIni()
-            {
-                using (Stream stream = new MemoryStream())
-                {
-                    using (var sw = new StreamWriter(stream, Encoding.UTF8, 1024, true))
-                    {
-                        foreach (string line in newLines)
-                            sw.WriteLine(line);
-                    }
-
-                    modelManager.AddFile(item, stream, @"skin.ini", realm);
-                }
-
-                item.Hash = ComputeHash(item);
-            }
         }
 
         private Skin createInstance(SkinInfo item) => item.CreateInstance(skinResources);


### PR DESCRIPTION
## [Fix up possible shortcomings related to treatment of `IsLatestVersion` flag](https://github.com/ppy/osu/commit/5f20e25fcd3fcf524b17d225551a3e09dd502231)
Noticed in passing.

## [Adjust legacy skin encoder](https://github.com/ppy/osu/commit/a703aca6fac278b91c6fe3eadd867474a846d32c) 
- Accept `Skin` instead of `LegacySkin` for easier integration.
- Write out name & creator from `Configuration.SkinInfo` rather than going through a `Live<SkinInfo>` instance. This helps with not having to do some very dumb `PerformRead()` games later.

## [Fix duplicates of `[General]` section getting concatenated to `skin.ini` on every skin rename](https://github.com/ppy/osu/commit/97932356009a5fa6e185f97f79ac9cd86b892431) 
Closes https://github.com/ppy/osu/issues/35503.