### PR TITLE
Extract "discrete adjustment control" for editor re-use

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneEditor.cs
@@ -44,10 +44,10 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
             AddStep("store composer", () => oldComposer = this.ChildrenOfType<HitObjectComposer>().Single());
             AddUntilStep("composer stored", () => oldComposer, () => Is.Not.Null);
             AddStep("switch to timing tab", () => InputManager.Key(Key.F3));
-            AddUntilStep("wait for loaded", () => this.ChildrenOfType<TimingAdjustButton>().ElementAtOrDefault(1), () => Is.Not.Null);
+            AddUntilStep("wait for loaded", () => this.ChildrenOfType<DiscreteAdjustmentControl<double>>().ElementAtOrDefault(1), () => Is.Not.Null);
             AddStep("change timing point BPM", () =>
             {
-                var bpmControl = this.ChildrenOfType<TimingAdjustButton>().ElementAt(1);
+                var bpmControl = this.ChildrenOfType<DiscreteAdjustmentControl<double>>().ElementAt(1);
                 InputManager.MoveMouseTo(bpmControl);
                 InputManager.Click(MouseButton.Left);
             });
@@ -61,12 +61,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
 
             AddStep("store composer", () => oldComposer = this.ChildrenOfType<HitObjectComposer>().Single());
             AddUntilStep("composer stored", () => oldComposer, () => Is.Not.Null);
-            AddStep("undo", () =>
-            {
-                InputManager.PressKey(Key.ControlLeft);
-                InputManager.Key(Key.Z);
-                InputManager.ReleaseKey(Key.ControlLeft);
-            });
+            AddStep("undo", () => Editor.Undo());
             AddUntilStep("composer reloaded", () =>
             {
                 var composer = this.ChildrenOfType<HitObjectComposer>().SingleOrDefault();

--- a/osu.Game.Tests/Visual/Editing/TestSceneFormDiscreteAdjustmentControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneFormDiscreteAdjustmentControl.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Screens.Edit;
+using osu.Game.Screens.Edit.Timing;
+using osu.Game.Tests.Visual.UserInterface;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.Editing
+{
+    public partial class TestSceneFormDiscreteAdjustmentControl : ThemeComparisonTestScene
+    {
+        [Cached]
+        private EditorBeatmap editorBeatmap { get; set; }
+
+        public TestSceneFormDiscreteAdjustmentControl()
+            : base(false)
+        {
+            editorBeatmap = new EditorBeatmap(CreateBeatmap(new OsuRuleset().RulesetInfo));
+        }
+
+        protected override Drawable CreateContent() => new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Child = new FormDiscreteAdjustmentControl<double>(0.05)
+            {
+                Caption = "Slider velocity",
+                Current = new BindableDouble(1)
+                {
+                    MinValue = 0.05,
+                    MaxValue = 10,
+                    Precision = 0.01,
+                },
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 0.2f,
+            }
+        };
+
+        [Test]
+        public void TestBehaviour()
+        {
+            AddStep("create content", () => CreateThemedContent(OverlayColourScheme.Aquamarine));
+            AddStep("click control", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<OsuTextBox>().Single());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("input 4", () => this.ChildrenOfType<OsuTextBox>().Single().Text = "4");
+            AddStep("commit", () => InputManager.Key(Key.Enter));
+            AddAssert("current is 4", () => this.ChildrenOfType<FormDiscreteAdjustmentControl<double>>().Single().Current.Value, () => Is.EqualTo(4));
+
+            AddStep("decrement by smallest step", () =>
+            {
+                var control = this.ChildrenOfType<DiscreteAdjustmentControl<double>>().Single();
+                InputManager.MoveMouseTo(control.ScreenSpaceDrawQuad.Centre - new Vector2(5, 0));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("current is 3.95", () => this.ChildrenOfType<FormDiscreteAdjustmentControl<double>>().Single().Current.Value, () => Is.EqualTo(3.95));
+
+            AddStep("increment by biggest step", () =>
+            {
+                var control = this.ChildrenOfType<DiscreteAdjustmentControl<double>>().Single();
+                InputManager.MoveMouseTo(control.ScreenSpaceDrawQuad.TopRight + new Vector2(-5, 5));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("current is 4.45", () => this.ChildrenOfType<FormDiscreteAdjustmentControl<double>>().Single().Current.Value, () => Is.EqualTo(4.45));
+
+            AddStep("start increment by biggest step", () =>
+            {
+                var control = this.ChildrenOfType<DiscreteAdjustmentControl<double>>().Single();
+                InputManager.MoveMouseTo(control.ScreenSpaceDrawQuad.TopRight + new Vector2(-5, 5));
+                InputManager.PressButton(MouseButton.Left);
+            });
+            AddUntilStep("current reached max", () => this.ChildrenOfType<FormDiscreteAdjustmentControl<double>>().Single().Current.Value, () => Is.EqualTo(10));
+            AddStep("release mouse", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddStep("change current externally", () => this.ChildrenOfType<FormDiscreteAdjustmentControl<double>>().Single().Current.Value = 4);
+            AddAssert("text box says 4", () => this.ChildrenOfType<OsuTextBox>().Single().Text, () => Is.EqualTo("4"));
+        }
+    }
+}

--- a/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
@@ -145,6 +145,20 @@ namespace osu.Game.Tests.Visual.Editing
                        .First()
                        .TriggerClick();
             });
+
+            AddStep("adjust offset", () =>
+            {
+                var adjustOffsetButton = control.ChildrenOfType<DiscreteAdjustmentControl<double>>().First();
+                InputManager.MoveMouseTo(adjustOffsetButton);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("adjust BPM", () =>
+            {
+                var adjustBPMButton = control.ChildrenOfType<DiscreteAdjustmentControl<double>>().Last();
+                InputManager.MoveMouseTo(adjustBPMButton);
+                InputManager.Click(MouseButton.Left);
+            });
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTapTimingControl.cs
@@ -145,20 +145,6 @@ namespace osu.Game.Tests.Visual.Editing
                        .First()
                        .TriggerClick();
             });
-
-            AddStep("adjust offset", () =>
-            {
-                var adjustOffsetButton = control.ChildrenOfType<TimingAdjustButton>().First();
-                InputManager.MoveMouseTo(adjustOffsetButton);
-                InputManager.Click(MouseButton.Left);
-            });
-
-            AddStep("adjust BPM", () =>
-            {
-                var adjustBPMButton = control.ChildrenOfType<TimingAdjustButton>().Last();
-                InputManager.MoveMouseTo(adjustBPMButton);
-                InputManager.Click(MouseButton.Left);
-            });
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneTimingScreen.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             AddStep("Adjust offset", () =>
             {
-                InputManager.MoveMouseTo(timingScreen.ChildrenOfType<TimingAdjustButton>().First().ScreenSpaceDrawQuad.Centre + new Vector2(20, 0));
+                InputManager.MoveMouseTo(timingScreen.ChildrenOfType<DiscreteAdjustmentControl<double>>().First().ScreenSpaceDrawQuad.Centre + new Vector2(20, 0));
                 InputManager.Click(MouseButton.Left);
             });
 

--- a/osu.Game/Extensions/NumberFormattingExtensions.cs
+++ b/osu.Game/Extensions/NumberFormattingExtensions.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Extensions
         {
             double floatValue = double.CreateTruncating(value);
 
-            decimal decimalPrecision = normalise(decimal.CreateTruncating(value), maxDecimalDigits);
+            decimal decimalPrecision = Normalise(decimal.CreateTruncating(value), maxDecimalDigits);
 
             // Find the number of significant digits (we could have less than maxDecimalDigits after normalize())
             int significantDigits = FormatUtils.FindPrecision(decimalPrecision);
@@ -48,7 +48,7 @@ namespace osu.Game.Extensions
         /// <param name="d">The decimal to normalize.</param>
         /// <param name="sd">The maximum number of decimal digits to keep. The final result may have fewer decimal digits than this value.</param>
         /// <returns>The normalised decimal.</returns>
-        private static decimal normalise(decimal d, int sd)
+        public static decimal Normalise(decimal d, int sd)
             => decimal.Parse(Math.Round(d, sd).ToString(string.Concat("0.", new string('#', sd)), CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -79,6 +79,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
         /// </summary>
         public int? LengthLimit { get; init; }
 
+        public bool SelectAllOnFocus { get; init; }
+
         private FormControlBackground background = null!;
         private InnerTextBox textBox = null!;
         private FormFieldCaption caption = null!;
@@ -129,6 +131,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             t.Width = 1;
                             t.PlaceholderText = PlaceholderText;
                             t.LengthLimit = LengthLimit;
+                            t.SelectAllOnFocus = SelectAllOnFocus;
                             t.Current = Current;
                             t.CommitOnFocusLost = true;
                             t.OnCommit += (textBox, newText) =>

--- a/osu.Game/Screens/Edit/Timing/DiscreteAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/DiscreteAdjustmentControl.cs
@@ -153,9 +153,9 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         Anchor = direction | Anchor.y1,
                         Origin = direction | Anchor.y1,
-                        Font = OsuFont.Default.With(size: 10, weight: FontWeight.Bold),
+                        Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold),
                         Text = $"{(Multiplier > 0 ? "+" : "")}{(amount * T.CreateTruncating(Multiplier)).ToStandardFormattedString(maxDecimalDigits: 2)}",
-                        Padding = new MarginPadding(2),
+                        Padding = new MarginPadding(4),
                         Alpha = 0,
                     }
                 };
@@ -205,14 +205,14 @@ namespace osu.Game.Screens.Edit.Timing
             public void Flash()
             {
                 box
-                    .FadeTo(0.4f, 20, Easing.OutQuint)
+                    .FadeTo(0.4f, 40, Easing.OutQuint)
                     .Then()
-                    .FadeTo(0.2f, 400, Easing.OutQuint);
+                    .FadeTo(0.2f, 700, Easing.OutPow10);
 
                 text
-                    .MoveToY(-5, 20, Easing.OutQuint)
+                    .MoveToX(Multiplier > 0 ? 10 : -10, 40, Easing.OutQuint)
                     .Then()
-                    .MoveToY(0, 400, Easing.OutQuint);
+                    .MoveToX(0, 700, Easing.OutBounce);
             }
         }
     }

--- a/osu.Game/Screens/Edit/Timing/DiscreteAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/DiscreteAdjustmentControl.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Linq;
+using System.Numerics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
@@ -18,11 +20,12 @@ namespace osu.Game.Screens.Edit.Timing
     /// <summary>
     /// A button with variable constant output based on hold position and length.
     /// </summary>
-    public partial class TimingAdjustButton : CompositeDrawable
+    public partial class DiscreteAdjustmentControl<T> : CompositeDrawable
+        where T : struct, INumber<T>, IMinMaxValue<T>, IMultiplyOperators<T, T, T>
     {
-        public Action<double>? Action;
+        public Action<T>? Action;
 
-        private readonly double adjustAmount;
+        private readonly T baseIncrement;
 
         private const int max_multiplier = 10;
         private const int adjust_levels = 4;
@@ -47,12 +50,13 @@ namespace osu.Game.Screens.Edit.Timing
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
 
-        public TimingAdjustButton(double adjustAmount)
+        public DiscreteAdjustmentControl(T baseIncrement)
         {
-            this.adjustAmount = adjustAmount;
+            this.baseIncrement = baseIncrement;
 
             CornerRadius = 5;
             Masking = true;
+            RelativeSizeAxes = Axes.Both;
 
             AddInternal(Content = new Container
             {
@@ -85,12 +89,12 @@ namespace osu.Game.Screens.Edit.Timing
         [BackgroundDependencyLoader]
         private void load()
         {
-            background.Colour = colourProvider.Background3;
+            background.Colour = colourProvider.Dark2;
 
             for (int i = 1; i <= adjust_levels; i++)
             {
-                Content.Add(new IncrementBox(i, adjustAmount));
-                Content.Add(new IncrementBox(-i, adjustAmount));
+                Content.Add(new IncrementBox(i, baseIncrement));
+                Content.Add(new IncrementBox(-i, baseIncrement));
             }
         }
 
@@ -102,17 +106,17 @@ namespace osu.Game.Screens.Edit.Timing
             if (hoveredBox == null)
                 return false;
 
-            Action?.Invoke(adjustAmount * hoveredBox.Multiplier);
+            Action?.Invoke(baseIncrement * T.CreateTruncating(hoveredBox.Multiplier));
 
             hoveredBox.Flash();
 
-            repeatBehaviour.SampleFrequencyModifier = (hoveredBox.Multiplier / max_multiplier) * 0.2;
+            repeatBehaviour.SampleFrequencyModifier = ((double)hoveredBox.Multiplier / max_multiplier) * 0.2;
             return true;
         }
 
         private partial class IncrementBox : CompositeDrawable
         {
-            public readonly float Multiplier;
+            public readonly int Multiplier;
 
             private readonly Box box;
             private readonly OsuSpriteText text;
@@ -120,7 +124,7 @@ namespace osu.Game.Screens.Edit.Timing
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
 
-            public IncrementBox(int index, double amount)
+            public IncrementBox(int index, T amount)
             {
                 Multiplier = Math.Sign(index) * convertMultiplier(index);
 
@@ -147,10 +151,10 @@ namespace osu.Game.Screens.Edit.Timing
                     },
                     text = new OsuSpriteText
                     {
-                        Anchor = direction,
-                        Origin = direction,
+                        Anchor = direction | Anchor.y1,
+                        Origin = direction | Anchor.y1,
                         Font = OsuFont.Default.With(size: 10, weight: FontWeight.Bold),
-                        Text = $"{(index > 0 ? "+" : "-")}{Math.Abs(Multiplier * amount)}",
+                        Text = $"{(Multiplier > 0 ? "+" : "")}{(amount * T.CreateTruncating(Multiplier)).ToStandardFormattedString(maxDecimalDigits: 2)}",
                         Padding = new MarginPadding(2),
                         Alpha = 0,
                     }
@@ -165,7 +169,7 @@ namespace osu.Game.Screens.Edit.Timing
                 box.Alpha = 0.1f;
             }
 
-            private float convertMultiplier(int m)
+            private int convertMultiplier(int m)
             {
                 switch (Math.Abs(m))
                 {

--- a/osu.Game/Screens/Edit/Timing/DiscreteAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/DiscreteAdjustmentControl.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Localisation;
 using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -30,19 +29,11 @@ namespace osu.Game.Screens.Edit.Timing
         private const int max_multiplier = 10;
         private const int adjust_levels = 4;
 
-        public Container Content { get; set; }
-
         private readonly Box background;
 
-        private readonly OsuSpriteText text;
-
-        public LocalisableString Text
-        {
-            get => text.Text;
-            set => text.Text = value;
-        }
-
         private readonly RepeatingButtonBehaviour repeatBehaviour;
+
+        private OsuSpriteText incrementText;
 
         [Resolved]
         private OverlayColourProvider colourProvider { get; set; } = null!;
@@ -58,32 +49,27 @@ namespace osu.Game.Screens.Edit.Timing
             Masking = true;
             RelativeSizeAxes = Axes.Both;
 
-            AddInternal(Content = new Container
+            InternalChildren = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                background = new Box
                 {
-                    background = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Depth = float.MaxValue
-                    },
-                    text = new OsuSpriteText
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        Font = OsuFont.Default.With(weight: FontWeight.SemiBold),
-                        Padding = new MarginPadding(5),
-                        Depth = float.MinValue
-                    }
+                    RelativeSizeAxes = Axes.Both,
+                    Depth = float.MaxValue
+                },
+                incrementText = new OsuSpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Font = OsuFont.Default.With(weight: FontWeight.SemiBold),
+                    Padding = new MarginPadding(5),
+                    Depth = float.MinValue
+                },
+                repeatBehaviour = new RepeatingButtonBehaviour(this)
+                {
+                    RepeatBegan = () => editorBeatmap.BeginChange(),
+                    RepeatEnded = () => editorBeatmap.EndChange()
                 }
-            });
-
-            AddInternal(repeatBehaviour = new RepeatingButtonBehaviour(this)
-            {
-                RepeatBegan = () => editorBeatmap.BeginChange(),
-                RepeatEnded = () => editorBeatmap.EndChange()
-            });
+            };
         }
 
         [BackgroundDependencyLoader]
@@ -93,8 +79,46 @@ namespace osu.Game.Screens.Edit.Timing
 
             for (int i = 1; i <= adjust_levels; i++)
             {
-                Content.Add(new IncrementBox(i, baseIncrement));
-                Content.Add(new IncrementBox(-i, baseIncrement));
+                AddInternal(new IncrementBox(i, baseIncrement));
+                AddInternal(new IncrementBox(-i, baseIncrement));
+            }
+
+            AddInternal(incrementText = new OsuSpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold),
+                Padding = new MarginPadding(4),
+                Alpha = 0,
+            });
+        }
+
+        private IncrementBox? hoveredBox => InternalChildren.OfType<IncrementBox>().FirstOrDefault(d => d.IsHovered);
+
+        private IncrementBox? lastHovered;
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (hoveredBox == lastHovered)
+                return;
+
+            lastHovered = hoveredBox;
+
+            if (lastHovered != null)
+            {
+                incrementText
+                    .MoveToX(Math.Sign(lastHovered.Multiplier) * Math.Abs(lastHovered.Index), 400, Easing.OutQuint)
+                    .FadeTo(0.8f, 200, Easing.OutQuint);
+
+                incrementText.Text = $"{(lastHovered.Multiplier > 0 ? "+" : "")}{(lastHovered.Amount * T.CreateTruncating(lastHovered.Multiplier)).ToStandardFormattedString(maxDecimalDigits: 2)}";
+            }
+            else
+            {
+                incrementText
+                    .MoveToX(0, 200, Easing.OutQuint)
+                    .FadeOut(200, Easing.OutQuint);
             }
         }
 
@@ -102,30 +126,40 @@ namespace osu.Game.Screens.Edit.Timing
 
         protected override bool OnClick(ClickEvent e)
         {
-            var hoveredBox = Content.OfType<IncrementBox>().FirstOrDefault(d => d.IsHovered);
-            if (hoveredBox == null)
-                return false;
+            if (hoveredBox is IncrementBox b)
+            {
+                Action?.Invoke(baseIncrement * T.CreateTruncating(b.Multiplier));
 
-            Action?.Invoke(baseIncrement * T.CreateTruncating(hoveredBox.Multiplier));
+                b.Flash();
 
-            hoveredBox.Flash();
+                incrementText
+                    .MoveToX(Math.Sign(b.Multiplier) * (Math.Abs(b.Index) * 5))
+                    .MoveToX(Math.Sign(b.Multiplier) * Math.Abs(b.Index), 700, Easing.OutQuint);
 
-            repeatBehaviour.SampleFrequencyModifier = ((double)hoveredBox.Multiplier / max_multiplier) * 0.2;
-            return true;
+                incrementText.FadeTo(1).FadeTo(0.8f, 1400, Easing.OutQuint);
+
+                repeatBehaviour.SampleFrequencyModifier = ((double)b.Multiplier / max_multiplier) * 0.2;
+                return true;
+            }
+
+            return false;
         }
 
         private partial class IncrementBox : CompositeDrawable
         {
+            public readonly T Amount;
             public readonly int Multiplier;
+            public readonly float Index;
 
             private readonly Box box;
-            private readonly OsuSpriteText text;
 
             [Resolved]
             private OverlayColourProvider colourProvider { get; set; } = null!;
 
             public IncrementBox(int index, T amount)
             {
+                Index = index;
+                Amount = amount;
                 Multiplier = Math.Sign(index) * convertMultiplier(index);
 
                 float ratio = (float)index / adjust_levels;
@@ -149,15 +183,6 @@ namespace osu.Game.Screens.Edit.Timing
                         RelativeSizeAxes = Axes.Both,
                         Blending = BlendingParameters.Additive
                     },
-                    text = new OsuSpriteText
-                    {
-                        Anchor = direction | Anchor.y1,
-                        Origin = direction | Anchor.y1,
-                        Font = OsuFont.Default.With(size: 14, weight: FontWeight.Bold),
-                        Text = $"{(Multiplier > 0 ? "+" : "")}{(amount * T.CreateTruncating(Multiplier)).ToStandardFormattedString(maxDecimalDigits: 2)}",
-                        Padding = new MarginPadding(4),
-                        Alpha = 0,
-                    }
                 };
             }
 
@@ -187,18 +212,14 @@ namespace osu.Game.Screens.Edit.Timing
             protected override bool OnHover(HoverEvent e)
             {
                 box.Colour = colourProvider.Colour0;
-
                 box.FadeTo(0.2f, 100, Easing.OutQuint);
-                text.FadeIn(100, Easing.OutQuint);
                 return true;
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
                 box.Colour = colourProvider.Background1;
-
                 box.FadeTo(0.1f, 500, Easing.OutQuint);
-                text.FadeOut(100, Easing.OutQuint);
                 base.OnHoverLost(e);
             }
 
@@ -208,11 +229,6 @@ namespace osu.Game.Screens.Edit.Timing
                     .FadeTo(0.4f, 40, Easing.OutQuint)
                     .Then()
                     .FadeTo(0.2f, 700, Easing.OutPow10);
-
-                text
-                    .MoveToX(Multiplier > 0 ? 10 : -10, 40, Easing.OutQuint)
-                    .Then()
-                    .MoveToX(0, 700, Easing.OutBounce);
             }
         }
     }

--- a/osu.Game/Screens/Edit/Timing/FormDiscreteAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/FormDiscreteAdjustmentControl.cs
@@ -1,0 +1,302 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
+using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
+using osu.Game.Extensions;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    public partial class FormDiscreteAdjustmentControl<T> : CompositeDrawable, IHasCurrentValue<T>, IFormControl
+        where T : struct, INumber<T>, IMinMaxValue<T>, IMultiplyOperators<T, T, T>, IParsable<T>
+    {
+        public Bindable<T> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        private readonly BindableNumberWithCurrent<T> current = new BindableNumberWithCurrent<T>();
+
+        private readonly DiscreteAdjustmentControl<T> adjustmentControl;
+
+        private CompositeDrawable? tabbableContentContainer;
+
+        public CompositeDrawable? TabbableContentContainer
+        {
+            set
+            {
+                tabbableContentContainer = value;
+
+                if (textBox.IsNotNull())
+                    textBox.TabbableContentContainer = tabbableContentContainer;
+            }
+        }
+
+        private LocalisableString caption;
+
+        /// <summary>
+        /// Caption describing this slider bar, displayed on top of the controls.
+        /// </summary>
+        public LocalisableString Caption
+        {
+            get => caption;
+            set
+            {
+                caption = value;
+
+                if (IsLoaded)
+                    captionText.Caption = value;
+            }
+        }
+
+        /// <summary>
+        /// Hint text containing an extended description of this slider bar, displayed in a tooltip when hovering the caption.
+        /// </summary>
+        public LocalisableString HintText { get; init; }
+
+        private Func<T, LocalisableString> labelFormat;
+
+        /// <summary>
+        /// The string formatting function to use for the value label.
+        /// </summary>
+        public Func<T, LocalisableString> LabelFormat
+        {
+            get => labelFormat;
+            set
+            {
+                labelFormat = value;
+
+                if (IsLoaded)
+                    updateValueDisplay();
+            }
+        }
+
+        /// <summary>
+        /// The string formatting function to use for the slider's tooltip text.
+        /// If not provided, <see cref="LabelFormat"/> is used.
+        /// </summary>
+        public Func<T, LocalisableString> TooltipFormat { get; init; }
+
+        private FormControlBackground background = null!;
+        private FormTextBox.InnerTextBox textBox = null!;
+        private OsuSpriteText valueLabel = null!;
+        private FormFieldCaption captionText = null!;
+        private IFocusManager focusManager = null!;
+        private InputManager inputManager = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private readonly Bindable<Language> currentLanguage = new Bindable<Language>();
+
+        public bool TakeFocus() => GetContainingFocusManager()?.ChangeFocus(textBox) == true;
+
+        public FormDiscreteAdjustmentControl(T baseIncrement)
+        {
+            labelFormat ??= DefaultLabelFormat;
+            TooltipFormat ??= v => LabelFormat(v);
+
+            adjustmentControl = new DiscreteAdjustmentControl<T>(baseIncrement);
+
+            current.ValueChanged += e =>
+            {
+                ValueChanged?.Invoke();
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuGame? game)
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChildren = new Drawable[]
+            {
+                background = new FormControlBackground(),
+                new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Padding = new MarginPadding
+                    {
+                        Vertical = 5,
+                        Left = 9,
+                        Right = 5,
+                    },
+                    Children = new Drawable[]
+                    {
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new osuTK.Vector2(0f, 4f),
+                            Width = 0.5f,
+                            Padding = new MarginPadding
+                            {
+                                Right = 10,
+                                Vertical = 4,
+                            },
+                            Children = new Drawable[]
+                            {
+                                captionText = new FormFieldCaption
+                                {
+                                    TooltipText = HintText,
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.X,
+                                    AutoSizeAxes = Axes.Y,
+                                    Children = new Drawable[]
+                                    {
+                                        textBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            // the textbox is hidden when the control is unfocused,
+                                            // but clicking on the label should reach the textbox,
+                                            // therefore make it always present.
+                                            AlwaysPresent = true,
+                                            CommitOnFocusLost = true,
+                                            SelectAllOnFocus = true,
+                                            OnInputError = background.FlashOnInputError,
+                                            TabbableContentContainer = tabbableContentContainer,
+                                        },
+                                        valueLabel = new TruncatingSpriteText
+                                        {
+                                            RelativeSizeAxes = Axes.X,
+                                            Padding = new MarginPadding { Right = 5 },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                        adjustmentControl.With(s =>
+                        {
+                            s.Anchor = Anchor.CentreRight;
+                            s.Origin = Anchor.CentreRight;
+                            s.Width = 0.5f;
+                            s.Action = change => Current.Value += change;
+                        })
+                    },
+                },
+            };
+
+            if (game != null)
+                currentLanguage.BindTo(game.CurrentLanguage);
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            captionText.Caption = caption;
+
+            focusManager = GetContainingFocusManager()!;
+            inputManager = GetContainingInputManager()!;
+
+            textBox.Focused.BindValueChanged(_ => updateState());
+            textBox.OnCommit += textCommitted;
+
+            currentLanguage.BindValueChanged(_ => Schedule(updateValueDisplay));
+            current.BindValueChanged(_ =>
+            {
+                updateState();
+                updateValueDisplay();
+            }, true);
+        }
+
+        private void textCommitted(TextBox t, bool isNew)
+        {
+            background.FlashOnCommit();
+
+            try
+            {
+                if (T.TryParse(t.Text, null, out T parsed))
+                    Current.Value = parsed;
+            }
+            catch
+            {
+                // TriggerChange below will restore the previous text value on failure.
+            }
+
+            // This is run regardless of parsing success as the parsed number may not actually trigger a change
+            // due to bindable clamping. Even in such a case we want to update the textbox to a sane visual state.
+            Current.TriggerChange();
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            updateState();
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            base.OnHoverLost(e);
+            updateState();
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (!Current.Disabled)
+                focusManager.ChangeFocus(textBox);
+            return true;
+        }
+
+        private void updateState()
+        {
+            textBox.ReadOnly = Current.Disabled;
+            textBox.Alpha = textBox.Focused.Value ? 1 : 0;
+            valueLabel.Alpha = textBox.Focused.Value ? 0 : 1;
+
+            captionText.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
+            textBox.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
+            valueLabel.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
+
+            if (Current.Disabled)
+                background.VisualStyle = VisualStyle.Disabled;
+            else if (textBox.Focused.Value)
+                background.VisualStyle = VisualStyle.Focused;
+            else if (IsHovered || adjustmentControl.Contains(inputManager.CurrentState.Mouse.Position))
+                background.VisualStyle = VisualStyle.Hovered;
+            else
+                background.VisualStyle = VisualStyle.Normal;
+        }
+
+        private void updateValueDisplay()
+        {
+            textBox.Text = Current.Value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS);
+            valueLabel.Text = LabelFormat(Current.Value);
+        }
+
+        public LocalisableString DefaultLabelFormat(T value) => value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS);
+
+        public IEnumerable<LocalisableString> FilterTerms => new[] { Caption, HintText };
+
+        public event Action? ValueChanged;
+
+        public bool IsDefault => Current.IsDefault;
+
+        public void SetDefault() => Current.SetDefault();
+
+        public bool IsDisabled => Current.Disabled;
+
+        public float MainDrawHeight => DrawHeight;
+    }
+}

--- a/osu.Game/Screens/Edit/Timing/FormDiscreteAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/FormDiscreteAdjustmentControl.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Numerics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -281,7 +282,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void updateValueDisplay()
         {
-            textBox.Text = Current.Value.ToStandardFormattedString(OsuSliderBar<T>.MAX_DECIMAL_DIGITS);
+            textBox.Text = NumberFormattingExtensions.Normalise(decimal.CreateTruncating(Current.Value), OsuSliderBar<T>.MAX_DECIMAL_DIGITS).ToString(CultureInfo.CurrentCulture);
             valueLabel.Text = LabelFormat(Current.Value);
         }
 

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.ControlPoints;
@@ -16,7 +17,7 @@ namespace osu.Game.Screens.Edit.Timing
 {
     internal partial class GroupSection : CompositeDrawable
     {
-        private LabelledTextBox textBox = null!;
+        private FormDiscreteAdjustmentControl<double> adjustmentControl = null!;
 
         private OsuButton button = null!;
 
@@ -53,10 +54,10 @@ namespace osu.Game.Screens.Edit.Timing
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        textBox = new LabelledTextBox
+                        adjustmentControl = new FormDiscreteAdjustmentControl<double>(1)
                         {
-                            Label = "Time",
-                            SelectAllOnFocus = true,
+                            Caption = "Time",
+                            LabelFormat = v => v.ToLocalisableString(@"N0"),
                         },
                         button = new RoundedButton
                         {
@@ -68,38 +69,22 @@ namespace osu.Game.Screens.Edit.Timing
                 },
             };
 
-            textBox.OnCommit += (sender, isNew) =>
-            {
-                if (!isNew)
-                    return;
-
-                if (double.TryParse(sender.Text, out double newTime))
-                {
-                    changeSelectedGroupTime(newTime);
-                }
-                else
-                {
-                    SelectedGroup.TriggerChange();
-                }
-            };
-
             SelectedGroup.BindValueChanged(group =>
             {
                 if (group.NewValue == null)
                 {
-                    textBox.Text = string.Empty;
-
-                    // cannot use textBox.Current.Disabled due to https://github.com/ppy/osu-framework/issues/3919
-                    textBox.ReadOnly = true;
+                    adjustmentControl.Current.Disabled = true;
                     button.Enabled.Value = false;
                     return;
                 }
 
-                textBox.ReadOnly = false;
+                adjustmentControl.Current.Disabled = false;
                 button.Enabled.Value = true;
 
-                textBox.Text = $"{group.NewValue.Time:n0}";
+                adjustmentControl.Current.Value = group.NewValue.Time;
             }, true);
+
+            adjustmentControl.Current.BindValueChanged(_ => changeSelectedGroupTime(adjustmentControl.Current.Value));
         }
 
         private void changeSelectedGroupTime(in double time)

--- a/osu.Game/Screens/Edit/Timing/GroupSection.cs
+++ b/osu.Game/Screens/Edit/Timing/GroupSection.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.ControlPoints;
@@ -17,7 +16,7 @@ namespace osu.Game.Screens.Edit.Timing
 {
     internal partial class GroupSection : CompositeDrawable
     {
-        private FormDiscreteAdjustmentControl<double> adjustmentControl = null!;
+        private FormTextBox textBox = null!;
 
         private OsuButton button = null!;
 
@@ -54,10 +53,10 @@ namespace osu.Game.Screens.Edit.Timing
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        adjustmentControl = new FormDiscreteAdjustmentControl<double>(1)
+                        textBox = new FormTextBox
                         {
                             Caption = "Time",
-                            LabelFormat = v => v.ToLocalisableString(@"N0"),
+                            SelectAllOnFocus = true,
                         },
                         button = new RoundedButton
                         {
@@ -69,22 +68,38 @@ namespace osu.Game.Screens.Edit.Timing
                 },
             };
 
+            textBox.OnCommit += (sender, isNew) =>
+            {
+                if (!isNew)
+                    return;
+
+                if (double.TryParse(sender.Text, out double newTime))
+                {
+                    changeSelectedGroupTime(newTime);
+                }
+                else
+                {
+                    SelectedGroup.TriggerChange();
+                }
+            };
+
             SelectedGroup.BindValueChanged(group =>
             {
                 if (group.NewValue == null)
                 {
-                    adjustmentControl.Current.Disabled = true;
+                    textBox.Current.Value = string.Empty;
+
+                    // cannot use textBox.Current.Disabled due to https://github.com/ppy/osu-framework/issues/3919
+                    textBox.ReadOnly = true;
                     button.Enabled.Value = false;
                     return;
                 }
 
-                adjustmentControl.Current.Disabled = false;
+                textBox.ReadOnly = false;
                 button.Enabled.Value = true;
 
-                adjustmentControl.Current.Value = group.NewValue.Time;
+                textBox.Current.Value = $"{group.NewValue.Time:n0}";
             }, true);
-
-            adjustmentControl.Current.BindValueChanged(_ => changeSelectedGroupTime(adjustmentControl.Current.Value));
         }
 
         private void changeSelectedGroupTime(in double time)

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -30,11 +30,19 @@ namespace osu.Game.Screens.Edit.Timing
         private OsuConfigManager configManager { get; set; } = null!;
 
         [Resolved]
-        private Bindable<ControlPointGroup> selectedGroup { get; set; } = null!;
+        private Bindable<ControlPointGroup?> selectedGroup { get; set; } = null!;
+
+        private readonly BindableNumberWithCurrent<double> currentBeatLength = new BindableNumberWithCurrent<double>(TimingControlPoint.DEFAULT_BEAT_LENGTH)
+        {
+            MinValue = 6,
+            MaxValue = 60000
+        };
 
         private readonly BindableBool isHandlingTapping = new BindableBool();
 
         private MetronomeDisplay metronome = null!;
+        private FormDiscreteAdjustmentControl<double> offsetControl = null!;
+        private FormDiscreteAdjustmentControl<double> bpmControl = null!;
 
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
@@ -61,6 +69,8 @@ namespace osu.Game.Screens.Edit.Timing
                     RowDimensions = new[]
                     {
                         new Dimension(GridSizeMode.Absolute, 200),
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension(GridSizeMode.AutoSize),
                         new Dimension(GridSizeMode.Absolute, TapButton.SIZE + padding),
                     },
                     Content = new[]
@@ -89,6 +99,26 @@ namespace osu.Game.Screens.Edit.Timing
                                     }
                                 },
                             }
+                        },
+                        new Drawable[]
+                        {
+                            offsetControl = new FormDiscreteAdjustmentControl<double>(1)
+                            {
+                                Caption = "Offset",
+                                Current = new BindableDouble
+                                {
+                                    Precision = 1,
+                                },
+                                Margin = new MarginPadding { Bottom = padding },
+                            },
+                        },
+                        new Drawable[]
+                        {
+                            bpmControl = new FormDiscreteAdjustmentControl<double>(0.1)
+                            {
+                                Caption = "BPM",
+                                Margin = new MarginPadding { Bottom = padding },
+                            },
                         },
                         new Drawable[]
                         {
@@ -139,6 +169,11 @@ namespace osu.Game.Screens.Edit.Timing
                     }
                 },
             };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
 
             isHandlingTapping.BindValueChanged(handling =>
             {
@@ -147,6 +182,28 @@ namespace osu.Game.Screens.Edit.Timing
                 if (handling.NewValue)
                     start();
             }, true);
+
+            currentBeatLength.BindValueChanged(_ => bpmControl.Current.Value = 60000 / currentBeatLength.Value);
+            selectedGroup.BindValueChanged(_ => onGroupChanged(), true);
+
+            offsetControl.Current.BindValueChanged(setOffset);
+            bpmControl.Current.BindValueChanged(setBpm);
+        }
+
+        private bool changingGroup;
+
+        private void onGroupChanged()
+        {
+            if (selectedGroup.Value == null)
+                return;
+
+            changingGroup = true;
+
+            offsetControl.Current.Value = selectedGroup.Value.Time;
+            if (selectedGroup.Value.ControlPoints.OfType<TimingControlPoint>().FirstOrDefault() is TimingControlPoint timingControlPoint)
+                currentBeatLength.Current = timingControlPoint.BeatLengthBindable;
+
+            changingGroup = false;
         }
 
         private void start()
@@ -167,8 +224,11 @@ namespace osu.Game.Screens.Edit.Timing
             editorClock.Seek(selectedGroup.Value.Time);
         }
 
-        private void adjustOffset(double adjust)
+        private void setOffset(ValueChangedEvent<double> offsetChange)
         {
+            if (changingGroup)
+                return;
+
             if (selectedGroup.Value == null)
                 return;
 
@@ -180,13 +240,13 @@ namespace osu.Game.Screens.Edit.Timing
             beatmap.BeginChange();
             beatmap.ControlPointInfo.RemoveGroup(selectedGroup.Value);
 
-            double newOffset = selectedGroup.Value.Time + adjust;
+            double newOffset = offsetChange.NewValue;
 
             foreach (var cp in currentGroupItems)
             {
                 if (cp is TimingControlPoint tp)
                 {
-                    TimingSectionAdjustments.AdjustHitObjectOffset(beatmap, tp, adjust);
+                    TimingSectionAdjustments.AdjustHitObjectOffset(beatmap, tp, offsetChange.NewValue - offsetChange.OldValue);
                     beatmap.UpdateAllHitObjects();
                 }
 
@@ -201,15 +261,18 @@ namespace osu.Game.Screens.Edit.Timing
                 editorClock.Seek(newOffset);
         }
 
-        private void adjustBpm(double adjust)
+        private void setBpm(ValueChangedEvent<double> bpmChange)
         {
+            if (changingGroup)
+                return;
+
             var timing = selectedGroup.Value?.ControlPoints.OfType<TimingControlPoint>().FirstOrDefault();
 
             if (timing == null)
                 return;
 
             double oldBeatLength = timing.BeatLength;
-            timing.BeatLength = 60000 / (timing.BPM + adjust);
+            timing.BeatLength = 60000 / bpmChange.NewValue;
 
             if (configManager.Get<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges))
             {
@@ -218,6 +281,8 @@ namespace osu.Game.Screens.Edit.Timing
                 beatmap.UpdateAllHitObjects();
                 beatmap.EndChange();
             }
+
+            beatmap.SaveState();
         }
 
         private partial class InlineButton : OsuButton

--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
-using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
@@ -38,7 +37,7 @@ namespace osu.Game.Screens.Edit.Timing
         private MetronomeDisplay metronome = null!;
 
         [BackgroundDependencyLoader]
-        private void load(OverlayColourProvider colourProvider, OsuColour colours)
+        private void load(OverlayColourProvider colourProvider)
         {
             const float padding = 10;
 
@@ -62,7 +61,6 @@ namespace osu.Game.Screens.Edit.Timing
                     RowDimensions = new[]
                     {
                         new Dimension(GridSizeMode.Absolute, 200),
-                        new Dimension(GridSizeMode.Absolute, 50),
                         new Dimension(GridSizeMode.Absolute, TapButton.SIZE + padding),
                     },
                     Content = new[]
@@ -91,33 +89,6 @@ namespace osu.Game.Screens.Edit.Timing
                                     }
                                 },
                             }
-                        },
-                        new Drawable[]
-                        {
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Padding = new MarginPadding { Bottom = padding, Horizontal = padding },
-                                Children = new Drawable[]
-                                {
-                                    new TimingAdjustButton(1)
-                                    {
-                                        Text = "Offset",
-                                        RelativeSizeAxes = Axes.Both,
-                                        Size = new Vector2(0.48f, 1),
-                                        Action = adjustOffset,
-                                    },
-                                    new TimingAdjustButton(0.1)
-                                    {
-                                        Anchor = Anchor.TopRight,
-                                        Origin = Anchor.TopRight,
-                                        Text = "BPM",
-                                        RelativeSizeAxes = Axes.Both,
-                                        Size = new Vector2(0.48f, 1),
-                                        Action = adjustBpm,
-                                    }
-                                }
-                            },
                         },
                         new Drawable[]
                         {

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
@@ -15,11 +14,8 @@ namespace osu.Game.Screens.Edit.Timing
 {
     internal partial class TimingSection : Section<TimingControlPoint>
     {
-        private readonly BindableNumberWithCurrent<double> currentBeatLength = new BindableNumberWithCurrent<double>();
-
         private LabelledTimeSignature timeSignature = null!;
         private LabelledSwitchButton omitBarLine = null!;
-        private FormDiscreteAdjustmentControl<double> bpmAdjustmentBox = null!;
 
         [Resolved]
         private OsuConfigManager configManager { get; set; } = null!;
@@ -34,11 +30,6 @@ namespace osu.Game.Screens.Edit.Timing
                     Label = EditorStrings.AdjustExistingObjectsOnTimingChanges,
                     FixedLabelWidth = 220,
                     Current = configManager.GetBindable<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges),
-                },
-                bpmAdjustmentBox = new FormDiscreteAdjustmentControl<double>(1)
-                {
-                    Caption = "BPM",
-                    LabelFormat = v => v.ToLocalisableString(@"N2"),
                 },
                 new TapTimingControl(),
                 timeSignature = new LabelledTimeSignature
@@ -55,35 +46,6 @@ namespace osu.Game.Screens.Edit.Timing
 
             omitBarLine.Current.BindValueChanged(_ => saveChanges());
             timeSignature.Current.BindValueChanged(_ => saveChanges());
-
-            bpmAdjustmentBox.Current.BindValueChanged(val =>
-            {
-                if (val.NewValue < 0)
-                {
-                    bpmAdjustmentBox.Current.Value = val.OldValue;
-                    return;
-                }
-
-                currentBeatLength.Value = BeatLengthToBpm(val.NewValue);
-            });
-            currentBeatLength.BindValueChanged(val =>
-            {
-                if (ControlPoint.Value == null)
-                    return;
-
-                bpmAdjustmentBox.Current.Value = BeatLengthToBpm(val.NewValue);
-
-                if (isRebinding)
-                    return;
-
-                if (val.OldValue != val.NewValue && configManager.Get<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges))
-                {
-                    Beatmap.BeginChange();
-                    TimingSectionAdjustments.SetHitObjectBPM(Beatmap, ControlPoint.Value, val.OldValue);
-                    Beatmap.UpdateAllHitObjects();
-                    Beatmap.EndChange();
-                }
-            }, true);
 
             void saveChanges()
             {
@@ -107,7 +69,6 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 isRebinding = true;
 
-                currentBeatLength.Current = point.NewValue.BeatLengthBindable;
                 timeSignature.Current = point.NewValue.TimeSignatureBindable;
                 omitBarLine.Current = point.NewValue.OmitFirstBarLineBindable;
 

--- a/osu.Game/Screens/Edit/Timing/TimingSection.cs
+++ b/osu.Game/Screens/Edit/Timing/TimingSection.cs
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
@@ -15,9 +15,11 @@ namespace osu.Game.Screens.Edit.Timing
 {
     internal partial class TimingSection : Section<TimingControlPoint>
     {
+        private readonly BindableNumberWithCurrent<double> currentBeatLength = new BindableNumberWithCurrent<double>();
+
         private LabelledTimeSignature timeSignature = null!;
         private LabelledSwitchButton omitBarLine = null!;
-        private BPMTextBox bpmTextEntry = null!;
+        private FormDiscreteAdjustmentControl<double> bpmAdjustmentBox = null!;
 
         [Resolved]
         private OsuConfigManager configManager { get; set; } = null!;
@@ -33,8 +35,12 @@ namespace osu.Game.Screens.Edit.Timing
                     FixedLabelWidth = 220,
                     Current = configManager.GetBindable<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges),
                 },
+                bpmAdjustmentBox = new FormDiscreteAdjustmentControl<double>(1)
+                {
+                    Caption = "BPM",
+                    LabelFormat = v => v.ToLocalisableString(@"N2"),
+                },
                 new TapTimingControl(),
-                bpmTextEntry = new BPMTextBox(),
                 timeSignature = new LabelledTimeSignature
                 {
                     Label = "Time Signature"
@@ -47,25 +53,42 @@ namespace osu.Game.Screens.Edit.Timing
         {
             base.LoadComplete();
 
-            bpmTextEntry.Current.BindValueChanged(_ => saveChanges());
             omitBarLine.Current.BindValueChanged(_ => saveChanges());
             timeSignature.Current.BindValueChanged(_ => saveChanges());
+
+            bpmAdjustmentBox.Current.BindValueChanged(val =>
+            {
+                if (val.NewValue < 0)
+                {
+                    bpmAdjustmentBox.Current.Value = val.OldValue;
+                    return;
+                }
+
+                currentBeatLength.Value = BeatLengthToBpm(val.NewValue);
+            });
+            currentBeatLength.BindValueChanged(val =>
+            {
+                if (ControlPoint.Value == null)
+                    return;
+
+                bpmAdjustmentBox.Current.Value = BeatLengthToBpm(val.NewValue);
+
+                if (isRebinding)
+                    return;
+
+                if (val.OldValue != val.NewValue && configManager.Get<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges))
+                {
+                    Beatmap.BeginChange();
+                    TimingSectionAdjustments.SetHitObjectBPM(Beatmap, ControlPoint.Value, val.OldValue);
+                    Beatmap.UpdateAllHitObjects();
+                    Beatmap.EndChange();
+                }
+            }, true);
 
             void saveChanges()
             {
                 if (!isRebinding) ChangeHandler?.SaveState();
             }
-
-            bpmTextEntry.OnCommit = (oldBeatLength, _) =>
-            {
-                if (!configManager.Get<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges) || ControlPoint.Value == null)
-                    return;
-
-                Beatmap.BeginChange();
-                TimingSectionAdjustments.SetHitObjectBPM(Beatmap, ControlPoint.Value, oldBeatLength);
-                Beatmap.UpdateAllHitObjects();
-                Beatmap.EndChange();
-            };
         }
 
         private bool isRebinding;
@@ -84,7 +107,7 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 isRebinding = true;
 
-                bpmTextEntry.Bindable = point.NewValue.BeatLengthBindable;
+                currentBeatLength.Current = point.NewValue.BeatLengthBindable;
                 timeSignature.Current = point.NewValue.TimeSignatureBindable;
                 omitBarLine.Current = point.NewValue.OmitFirstBarLineBindable;
 
@@ -102,57 +125,6 @@ namespace osu.Game.Screens.Edit.Timing
                 TimeSignature = reference.TimeSignature,
                 OmitFirstBarLine = reference.OmitFirstBarLine,
             };
-        }
-
-        private partial class BPMTextBox : LabelledTextBox
-        {
-            public new Action<double, double>? OnCommit { get; set; }
-
-            private readonly BindableNumber<double> beatLengthBindable = new TimingControlPoint().BeatLengthBindable;
-
-            public BPMTextBox()
-            {
-                Label = "BPM";
-                SelectAllOnFocus = true;
-
-                base.OnCommit += (_, isNew) =>
-                {
-                    if (!isNew) return;
-
-                    double oldBeatLength = beatLengthBindable.Value;
-
-                    try
-                    {
-                        if (double.TryParse(Current.Value, out double doubleVal) && doubleVal > 0)
-                            beatLengthBindable.Value = BeatLengthToBpm(doubleVal);
-                    }
-                    catch
-                    {
-                        // TriggerChange below will restore the previous text value on failure.
-                    }
-
-                    // This is run regardless of parsing success as the parsed number may not actually trigger a change
-                    // due to bindable clamping. Even in such a case we want to update the textbox to a sane visual state.
-                    beatLengthBindable.TriggerChange();
-                    OnCommit?.Invoke(oldBeatLength, beatLengthBindable.Value);
-                };
-
-                beatLengthBindable.BindValueChanged(val =>
-                {
-                    Current.Value = BeatLengthToBpm(val.NewValue).ToString("N2");
-                }, true);
-            }
-
-            public Bindable<double> Bindable
-            {
-                get => beatLengthBindable;
-                set
-                {
-                    // incoming will be beat length, not bpm
-                    beatLengthBindable.UnbindBindings();
-                    beatLengthBindable.BindTo(value);
-                }
-            }
         }
 
         public static double BeatLengthToBpm(double beatLength) => 60000 / beatLength;


### PR DESCRIPTION
https://github.com/user-attachments/assets/e92d3817-38df-4a50-a4c9-f1e15250973c

The eventual goal to this is to use this new control in place of the slider velocity sliders.

This new control has also been applied to the timing screen.

<img width="346" height="732" alt="Screenshot 2026-06-25 at 09 27 48" src="https://github.com/user-attachments/assets/4d645d96-4f37-4dc9-b8a1-2dadd2673d8c" />

---

This, and subsequent changes I have queued as proofs-of-concept, are intended to supersede and close https://github.com/ppy/osu/pull/37753.

Naming is not great, open to better propositions.