### PR TITLE
Restore alt-scroll volume control in the editor

### DIFF
--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -60,6 +60,9 @@ namespace osu.Game.Rulesets.Edit
         [Resolved]
         private OnScreenDisplay? onScreenDisplay { get; set; }
 
+        [Resolved]
+        private HitObjectComposer hitObjectComposer { get; set; } = null!;
+
         public readonly Bindable<TernaryState> DistanceSnapToggle = new Bindable<TernaryState>();
 
         private bool distanceSnapMomentary;
@@ -209,6 +212,9 @@ namespace osu.Game.Rulesets.Edit
 
             if (altPressed && !distanceSnapMomentary)
             {
+                if (!isMouseOverPlayfield())
+                    return;
+
                 distanceSnapStateBeforeMomentaryToggle = DistanceSnapToggle.Value;
                 DistanceSnapToggle.Value = DistanceSnapToggle.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
                 distanceSnapMomentary = true;
@@ -222,6 +228,8 @@ namespace osu.Game.Rulesets.Edit
                 distanceSnapMomentary = false;
             }
         }
+
+        private bool isMouseOverPlayfield() => hitObjectComposer.IsMouseOverComposePlayfield;
 
         public virtual bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
         {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -349,6 +349,16 @@ namespace osu.Game.Rulesets.Edit
                                       && !RightToolbox.Contains(InputManager.CurrentState.Mouse.Position);
         }
 
+        /// <summary>
+        /// Whether the cursor is over the main compose playfield area (excluding toolboxes).
+        /// </summary>
+        public override bool IsMouseOverComposePlayfield =>
+            InputManager != null
+            && Playfield.ReceivePositionalInputAt(InputManager.CurrentState.Mouse.Position)
+            && PlayfieldContentContainer.Contains(InputManager.CurrentState.Mouse.Position)
+            && !LeftToolbox.Contains(InputManager.CurrentState.Mouse.Position)
+            && !RightToolbox.Contains(InputManager.CurrentState.Mouse.Position);
+
         public override Playfield Playfield => drawableRulesetWrapper.Playfield;
 
         public override IEnumerable<DrawableHitObject> HitObjects => drawableRulesetWrapper.Playfield.AllHitObjects;
@@ -605,6 +615,11 @@ namespace osu.Game.Rulesets.Edit
         /// Whether the user's cursor is currently in an area of the <see cref="HitObjectComposer"/> that is valid for placement.
         /// </summary>
         public abstract bool CursorInPlacementArea { get; }
+
+        /// <summary>
+        /// Whether the cursor is over the main compose playfield area (excluding toolboxes).
+        /// </summary>
+        public abstract bool IsMouseOverComposePlayfield { get; }
 
         /// <summary>
         /// Returns a string representing the current selection.

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -215,6 +215,9 @@ namespace osu.Game.Screens.Edit
         [Resolved(canBeNull: true)]
         private OnScreenDisplay onScreenDisplay { get; set; }
 
+        [Resolved(canBeNull: true)]
+        private VolumeOverlay volumeOverlay { get; set; }
+
         private Bindable<float> editorBackgroundDim;
         private Bindable<bool> editorShowStoryboard;
         private Bindable<bool> editorHitMarkers;
@@ -738,7 +741,15 @@ namespace osu.Game.Screens.Edit
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            if (e.ControlPressed || e.AltPressed || e.SuperPressed)
+            if (e.AltPressed)
+            {
+                if (shouldAdjustVolumeOnScroll(e))
+                    return volumeOverlay?.Adjust(GlobalAction.IncreaseVolume, e.ScrollDelta.Y, e.IsPrecise) ?? false;
+
+                return false;
+            }
+
+            if (e.ControlPressed || e.SuperPressed)
                 return false;
 
             const double precision = 1;
@@ -767,6 +778,22 @@ namespace osu.Game.Screens.Edit
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Whether an alt-scroll should adjust the global volume.
+        /// In compose mode, this is only allowed when the cursor is outside of the playfield (where distance snap is adjusted instead in stable).
+        /// </summary>
+        private bool shouldAdjustVolumeOnScroll(ScrollEvent e)
+        {
+            if (e.ScrollDelta.Y == 0)
+                return false;
+
+            if (Mode.Value != EditorScreenMode.Compose || currentScreen == null)
+                return true;
+
+            var composer = currentScreen.Dependencies.Get<HitObjectComposer>();
+            return composer is not { IsLoaded: true } || !composer.IsMouseOverComposePlayfield;
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)


### PR DESCRIPTION
## Summary

In stable you can alt-scroll to change volume while mapping, as long as your cursor isn't over the playfield. Lazer lost that somewhere along the way and it's been annoying.

This brings it back. The logic is pretty simple:

- **Cursor over the playfield** — editor behaviour stays as-is. Holding alt still momentarily toggles distance snap, ctrl+alt+scroll still changes distance spacing.
- **Cursor outside the playfield** (toolboxes, timeline, margins) — alt+scroll adjusts volume again, same as everywhere else in the game.

The distance snap button was also lighting up when you held alt outside the playfield, which felt wrong. It now only reacts when you're actually over the compose area, not the side panels.