### PR TITLE
Avoid bindable overheads in `OsuHitObject.StackHeight` implementation

### DIFF
--- a/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
+++ b/osu.Game.Rulesets.Osu/Objects/OsuHitObject.cs
@@ -81,7 +81,25 @@ namespace osu.Game.Rulesets.Osu.Objects
 
         private HitObjectProperty<int> stackHeight;
 
-        public Bindable<int> StackHeightBindable => stackHeight.Bindable;
+        public Bindable<int> StackHeightBindable
+        {
+            get
+            {
+                if (stackHeight.BindableCreated)
+                    return stackHeight.Bindable;
+
+                stackHeight.Bindable.BindValueChanged(height =>
+                {
+                    foreach (var nested in NestedHitObjects)
+                    {
+                        if (nested is OsuHitObject osuHitObject)
+                            osuHitObject.StackHeight = height.NewValue;
+                    }
+                });
+
+                return stackHeight.Bindable;
+            }
+        }
 
         public int StackHeight
         {
@@ -153,18 +171,6 @@ namespace osu.Game.Rulesets.Osu.Objects
         {
             get => lastInCombo.Value;
             set => lastInCombo.Value = value;
-        }
-
-        protected OsuHitObject()
-        {
-            StackHeightBindable.BindValueChanged(height =>
-            {
-                foreach (var nested in NestedHitObjects)
-                {
-                    if (nested is OsuHitObject osuHitObject)
-                        osuHitObject.StackHeight = height.NewValue;
-                }
-            });
         }
 
         protected override void ApplyDefaultsToSelf(ControlPointInfo controlPointInfo, IBeatmapDifficultyInfo difficulty)

--- a/osu.Game/Rulesets/Objects/HitObjectProperty.cs
+++ b/osu.Game/Rulesets/Objects/HitObjectProperty.cs
@@ -27,6 +27,11 @@ namespace osu.Game.Rulesets.Objects
         public Bindable<T> Bindable => backingBindable ??= new Bindable<T>(defaultValue) { Value = backingValue };
 
         /// <summary>
+        /// Whether the backing bindable has already been created.
+        /// </summary>
+        public bool BindableCreated => backingBindable != null;
+
+        /// <summary>
         /// The current value, derived from and delegated to <see cref="Bindable"/> if initialised, or a temporary field otherwise.
         /// </summary>
         public T Value


### PR DESCRIPTION
We made this `HitObjectProperty` class quite a while back with the concept of avoiding bindable initialisation when they are never going to be used.

Unfortunately there are multiple cases where bindables are accessed to bind event flows which break this.

This one is easy to fix, so I've done so.

The other remaining case is more egregious and I can't thing of a ten-minute-fix for it. If anyone has ideas, please take a look:

https://github.com/ppy/osu/blob/8b542e5442f42ad132af0414a4f7191df9718a99/osu.Game/Rulesets/Objects/HitObject.cs#L123-L125