### PR TITLE
Add flow for re-sending replay frames that spectator did not receive at end of play

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/MultiplayerGameplayLeaderboardTestScene.cs
@@ -246,7 +246,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                         break;
                 }
 
-                spectatorClient.Raise(s => s.OnNewFrames -= null, userId, new FrameDataBundle(header, new[] { new LegacyReplayFrame(Time.Current, 0, 0, ReplayButtonState.None) }));
+                spectatorClient.Raise(s => s.OnNewFrames -= null, userId, new FrameDataBundle(header, new[] { new LegacyReplayFrame(Time.Current, 0, 0, ReplayButtonState.None) }, null));
             }
         }
     }

--- a/osu.Game/Online/Spectator/CompleteReplayRequest.cs
+++ b/osu.Game/Online/Spectator/CompleteReplayRequest.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace osu.Game.Online.Spectator
+{
+    /// <summary>
+    /// Sent by the server to retrieve frame bundles that the client sent but never reached the server, if any.
+    /// </summary>
+    /// <param name="ScoreTokenId">The ID of the score token associated with the score with missing bundles.</param>
+    /// <param name="FrameBundleSequenceNumbers">The sequence numbers of frame bundles that the server never received.</param>
+    [Serializable]
+    [MessagePackObject]
+    public record CompleteReplayRequest(
+        [property: Key(0)] long ScoreTokenId,
+        [property: Key(1)] IEnumerable<long> FrameBundleSequenceNumbers
+    );
+}

--- a/osu.Game/Online/Spectator/CompleteReplayResponse.cs
+++ b/osu.Game/Online/Spectator/CompleteReplayResponse.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using MessagePack;
+
+namespace osu.Game.Online.Spectator
+{
+    /// <summary>
+    /// Response to <see cref="CompleteReplayRequest"/>.
+    /// </summary>
+    /// <param name="FrameBundles">
+    /// The frame bundles requested by sequence number in the corresponding <see cref="CompleteReplayRequest"/>.
+    /// Can be blank (contain no frames) if the client does not have the frames available any more.
+    /// </param>
+    [Serializable]
+    [MessagePackObject]
+    public record CompleteReplayResponse(
+        [property: Key(0)] IEnumerable<FrameDataBundle> FrameBundles
+    );
+}

--- a/osu.Game/Online/Spectator/FrameDataBundle.cs
+++ b/osu.Game/Online/Spectator/FrameDataBundle.cs
@@ -21,6 +21,13 @@ namespace osu.Game.Online.Spectator
         [Key(1)]
         public IList<LegacyReplayFrame> Frames { get; set; }
 
+        /// <summary>
+        /// The sequence number of this frame bundle.
+        /// Used to determine ordering of frame bundles, and for server-side checks that server received all frame bundles it was supposed to.
+        /// </summary>
+        [Key(2)]
+        public long? SequenceNumber { get; set; }
+
         public FrameDataBundle(ScoreInfo score, ScoreProcessor scoreProcessor, IList<LegacyReplayFrame> frames)
         {
             Frames = frames;
@@ -28,10 +35,11 @@ namespace osu.Game.Online.Spectator
         }
 
         [JsonConstructor]
-        public FrameDataBundle(FrameHeader header, IList<LegacyReplayFrame> frames)
+        public FrameDataBundle(FrameHeader header, IList<LegacyReplayFrame> frames, long? sequenceNumber)
         {
             Header = header;
             Frames = frames;
+            SequenceNumber = sequenceNumber;
         }
     }
 }

--- a/osu.Game/Online/Spectator/ISpectatorClient.cs
+++ b/osu.Game/Online/Spectator/ISpectatorClient.cs
@@ -49,5 +49,12 @@ namespace osu.Game.Online.Spectator
         /// </summary>
         /// <param name="userId">The ID of the user who ended watching.</param>
         Task UserEndedWatching(int userId);
+
+        /// <summary>
+        /// Called by the server in response to <see cref="ISpectatorServer.EndPlaySession"/>.
+        /// Using data provided in <see cref="SpectatorState"/>, this gives the server a last chance to retrieve any <see cref="FrameDataBundle"/>s
+        /// that it may not have received due to connection drop-outs or similar.
+        /// </summary>
+        Task<CompleteReplayResponse> CompleteReplay(CompleteReplayRequest request);
     }
 }

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -42,6 +42,7 @@ namespace osu.Game.Online.Spectator
                     connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserBeganPlaying), ((ISpectatorClient)this).UserBeganPlaying);
                     connection.On<int, FrameDataBundle>(nameof(ISpectatorClient.UserSentFrames), ((ISpectatorClient)this).UserSentFrames);
                     connection.On<int, SpectatorState>(nameof(ISpectatorClient.UserFinishedPlaying), ((ISpectatorClient)this).UserFinishedPlaying);
+                    connection.On<CompleteReplayRequest, CompleteReplayResponse>(nameof(ISpectatorClient.CompleteReplay), ((ISpectatorClient)this).CompleteReplay);
                     connection.On<int, long>(nameof(ISpectatorClient.UserScoreProcessed), ((ISpectatorClient)this).UserScoreProcessed);
                     connection.On<SpectatorUser[]>(nameof(ISpectatorClient.UserStartedWatching), ((ISpectatorClient)this).UserStartedWatching);
                     connection.On<int>(nameof(ISpectatorClient.UserEndedWatching), ((ISpectatorClient)this).UserEndedWatching);

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
@@ -89,8 +90,10 @@ namespace osu.Game.Online.Spectator
         private Score? currentScore;
         private long? currentScoreToken;
         private ScoreProcessor? currentScoreProcessor;
+        private long currentFrameBundleSequenceNumber;
 
         private readonly Queue<FrameDataBundle> pendingFrameBundles = new Queue<FrameDataBundle>();
+        private readonly Dictionary<long, List<FrameDataBundle>> allFrameBundles = new Dictionary<long, List<FrameDataBundle>>();
 
         private readonly List<LegacyReplayFrame> pendingFrames = new List<LegacyReplayFrame>();
 
@@ -284,6 +287,8 @@ namespace osu.Game.Online.Spectator
                 if (pendingFrames.Count > 0)
                     purgePendingFrames();
 
+                currentState.LastFrameBundleSequenceNumber = currentFrameBundleSequenceNumber;
+
                 clearScoreState();
 
                 if (state.HasPassed)
@@ -305,6 +310,9 @@ namespace osu.Game.Online.Spectator
             currentScore = score;
             currentScoreToken = scoreToken;
             currentScoreProcessor = state.ScoreProcessor;
+            currentFrameBundleSequenceNumber = 0;
+            if (scoreToken != null)
+                allFrameBundles[scoreToken.Value] = new List<FrameDataBundle>();
         }
 
         private void clearScoreState()
@@ -315,6 +323,22 @@ namespace osu.Game.Online.Spectator
             currentScore = null;
             currentScoreProcessor = null;
             currentScoreToken = null;
+            currentFrameBundleSequenceNumber = 0;
+        }
+
+        public Task<CompleteReplayResponse> CompleteReplay(CompleteReplayRequest completeReplayRequest)
+        {
+            if (!allFrameBundles.Remove(completeReplayRequest.ScoreTokenId, out var frameBundlesForScoreToken))
+                return Task.FromResult(new CompleteReplayResponse([]));
+
+            var sequenceNumberSet = completeReplayRequest.FrameBundleSequenceNumbers.ToHashSet();
+            if (sequenceNumberSet.Count == 0)
+                return Task.FromResult(new CompleteReplayResponse([]));
+
+            var bundles = frameBundlesForScoreToken.Where(b => b.SequenceNumber != null && sequenceNumberSet.Contains(b.SequenceNumber.Value))
+                                                   .OrderBy(b => b.SequenceNumber)
+                                                   .ToArray();
+            return Task.FromResult(new CompleteReplayResponse(bundles));
         }
 
         public virtual void WatchUser(int userId)
@@ -389,7 +413,16 @@ namespace osu.Game.Online.Spectator
             Debug.Assert(currentScoreProcessor != null);
 
             var frames = pendingFrames.ToArray();
-            var bundle = new FrameDataBundle(currentScore.ScoreInfo, currentScoreProcessor, frames);
+            var bundle = new FrameDataBundle(currentScore.ScoreInfo, currentScoreProcessor, frames)
+            {
+                SequenceNumber = Interlocked.Increment(ref currentFrameBundleSequenceNumber)
+            };
+
+            if (currentScoreToken != null)
+            {
+                Debug.Assert(allFrameBundles.ContainsKey(currentScoreToken.Value));
+                allFrameBundles[currentScoreToken.Value].Add(bundle);
+            }
 
             pendingFrames.Clear();
             lastPurgeTime = Time.Current;

--- a/osu.Game/Online/Spectator/SpectatorState.cs
+++ b/osu.Game/Online/Spectator/SpectatorState.cs
@@ -33,6 +33,13 @@ namespace osu.Game.Online.Spectator
         [Key(4)]
         public Dictionary<HitResult, int> MaximumStatistics { get; set; } = new Dictionary<HitResult, int>();
 
+        /// <summary>
+        /// The sequence number of the last frame bundle in the replay.
+        /// Only available in <see cref="ISpectatorServer.EndPlaySession"/> invocations.
+        /// </summary>
+        [Key(5)]
+        public long? LastFrameBundleSequenceNumber { get; set; }
+
         public bool Equals(SpectatorState other)
         {
             if (ReferenceEquals(null, other)) return false;


### PR DESCRIPTION
RFC. Lightly tested full-stack with 2 PCs to simulate real drop-offs, but probably still needs some further testing.

Compatibility matrix:

|            | old client | new client |
| :--------: | :--------: | :--------: |
| **old server** |   🟠[^1]   |   🟠[^1]   |
| **new server** |   🟠[^2]   |   🟢[^3]   |

[^1]: Operations will succeed, but the server never attempts to retrieve any dropped frames because it is not aware of the new flow, so the resulting replay will be incomplete.
[^2]: Operations will succeed, but the server will not attempt to use the new flow to retrieve any dropped frames, because the client will not send `LastFrameBundleSequenceNumber`, so the resulting replay will be incomplete.
[^3]: Operations will succeed. The server will attempt to retrieve dropped frames in a once-off operation at the end of gameplay.

This implements the proposal first outlined in https://github.com/ppy/osu-server-spectator/issues/244#issuecomment-4430057245.

With this change, if a player's connection drops out during a play but then recovers before the end of the play, the server will re-request any frame bundles that it has not received thus far.

The client caches all frame bundles it sends out until the end of the play and the request for any missing frame bundles from the server. The frame bundles for past plays are purged only when the server invokes `CompleteReplay()`. (If the server determines that it has received all frame bundles, it will still invoke `CompleteReplay()`, but with an empty list of bundle sequence numbers.)

I expect this caching strategy to be controversial, so I am listening to counterproposals (LRU / limited capacity queue? timed expiry? something else?)