### PR TITLE
Fix slider body fade in/out transforms with Hidden mod not matching stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (hitObject)
                 {
                     case Slider:
-                        return (fadeOutStartTime - fadeOutDuration, longFadeDuration - fadeOutDuration);
+                        return (fadeOutStartTime + fadeOutDuration, longFadeDuration - fadeOutDuration);
 
                     case SliderTick:
                         double tickFadeOutDuration = Math.Min(hitObject.TimePreempt - DrawableSliderTick.ANIM_DURATION, 1000);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -167,6 +167,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (hitObject)
                 {
                     case Slider:
+                        // Offset (by fadeOutDuration) to make slider body begin fading out after head fades out like Stable
                         return (fadeOutStartTime + fadeOutDuration, longFadeDuration - fadeOutDuration);
 
                     case SliderTick:

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -167,7 +167,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (hitObject)
                 {
                     case Slider:
-                        return (fadeOutStartTime, longFadeDuration);
+                        return (fadeOutStartTime - fadeOutDuration, longFadeDuration - fadeOutDuration);
 
                     case SliderTick:
                         double tickFadeOutDuration = Math.Min(hitObject.TimePreempt - DrawableSliderTick.ANIM_DURATION, 1000);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -41,7 +41,12 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             static void applyFadeInAdjustment(OsuHitObject osuObject)
             {
-                osuObject.TimeFadeIn = osuObject.TimePreempt * FADE_IN_DURATION_MULTIPLIER;
+                if (osuObject is Slider)
+                    // Something Like this
+                    osuObject.TimeFadeIn = osuObject.TimePreempt * (FADE_IN_DURATION_MULTIPLIER + FADE_OUT_DURATION_MULTIPLIER);
+                else
+                    osuObject.TimeFadeIn = osuObject.TimePreempt * FADE_IN_DURATION_MULTIPLIER;
+
                 foreach (var nested in osuObject.NestedHitObjects.OfType<OsuHitObject>())
                     applyFadeInAdjustment(nested);
             }
@@ -167,8 +172,7 @@ namespace osu.Game.Rulesets.Osu.Mods
                 switch (hitObject)
                 {
                     case Slider:
-                        // Offset (by fadeOutDuration) to make slider body begin fading out after head fades out like Stable
-                        return (fadeOutStartTime + fadeOutDuration, longFadeDuration - fadeOutDuration);
+                        return (fadeOutStartTime, longFadeDuration);
 
                     case SliderTick:
                         double tickFadeOutDuration = Math.Min(hitObject.TimePreempt - DrawableSliderTick.ANIM_DURATION, 1000);

--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -41,10 +41,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
             static void applyFadeInAdjustment(OsuHitObject osuObject)
             {
-                if (osuObject is Slider)
-                    // Something Like this
-                    osuObject.TimeFadeIn = osuObject.TimePreempt * (FADE_IN_DURATION_MULTIPLIER + FADE_OUT_DURATION_MULTIPLIER);
-                else
+                // Sliders retain their default TimeFadeIn to match Stable
+                if (osuObject is not Slider)
                     osuObject.TimeFadeIn = osuObject.TimePreempt * FADE_IN_DURATION_MULTIPLIER;
 
                 foreach (var nested in osuObject.NestedHitObjects.OfType<OsuHitObject>())


### PR DESCRIPTION
Fixes issue [#37532 ](https://github.com/ppy/osu/issues/37532)
Since slider body should start fading after head disappears and slider body fades in at same time as head, offset body fade out start by head fade out duration and decrease long duration by the same amount

First ever open-source contribution, yay (I HAVE SAVED HD)

https://github.com/user-attachments/assets/be44a6d6-4d89-49a0-a3db-f57daac6ac12