### PR TITLE
Improve chat /help command layout with multiline formatting

### DIFF
--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -414,13 +414,13 @@ namespace osu.Game.Online.Chat
                     target.AddNewMessages(new InfoMessage(
                         """
                         Supported commands:
-                            /help            - Displays all available commands.                        
-                            /me [action]     - Perform a third-person action.
-                            /join [channel]  - Joins the specified channel.
-                            /chat [user]     - Opens a new chat tab with the specified user.
-                            /np              - Print to chat the current song you are listening to or playing.
-                            /savelog         - Saves the current chat tab to a text file.
-                            /roll [2-100]    - Rolls a random number (multiplayer only).
+                        /help            - Displays all available commands.                        
+                        /me [action]     - Perform a third-person action.
+                        /join [channel]  - Joins the specified channel.
+                        /chat [user]     - Opens a new chat tab with the specified user.
+                        /np              - Print to chat the current song you are listening to or playing.
+                        /savelog         - Saves the current chat tab to a text file.
+                        /roll [2-100]    - Rolls a random number (multiplayer only).
                         """
                     ));
                     break;

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -414,13 +414,13 @@ namespace osu.Game.Online.Chat
                     target.AddNewMessages(new InfoMessage(
                         """
                         Supported commands:
-                        • /help
-                        • /me [action]
-                        • /join [channel]
-                        • /chat [user]
-                        • /np
-                        • /savelog
-                        • /roll [2-100] (multiplayer only)
+                          /help - Displays all available commands.                        
+                          /me [action] - Perform a third-person action.
+                          /join [channel] - Joins the specified channel.
+                          /chat [user] - Opens a new chat tab with the specified user.
+                          /np - Print to chat the current song you are listening to or playing.
+                          /savelog - Saves the current chat tab to a text file.
+                          /roll [2-100] - Rolls a random number (multiplayer only).
                         """
                     ));
                     break;

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -412,14 +412,16 @@ namespace osu.Game.Online.Chat
 
                 case @"help":
                     target.AddNewMessages(new InfoMessage(
-                        "Supported commands:\n" +
-                        " /help\n" +
-                        " /me [action]\n" +
-                        " /join [channel]\n" +
-                        " /chat [user]\n" +
-                        " /np\n" +
-                        " /savelog\n" +
-                        " /roll [2-100] (multiplayer only)"
+                        """
+                        Supported commands:
+                        • /help
+                        • /me [action]
+                        • /join [channel]
+                        • /chat [user]
+                        • /np
+                        • /savelog
+                        • /roll [2-100] (multiplayer only)
+                        """
                     ));
                     break;
 

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -414,7 +414,7 @@ namespace osu.Game.Online.Chat
                     target.AddNewMessages(new InfoMessage(
                         """
                         Supported commands:
-                        /help            - Displays all available commands.                        
+                        /help            - Displays all available commands.
                         /me [action]     - Perform a third-person action.
                         /join [channel]  - Joins the specified channel.
                         /chat [user]     - Opens a new chat tab with the specified user.

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -414,13 +414,13 @@ namespace osu.Game.Online.Chat
                     target.AddNewMessages(new InfoMessage(
                         """
                         Supported commands:
-                          /help - Displays all available commands.                        
-                          /me [action] - Perform a third-person action.
-                          /join [channel] - Joins the specified channel.
-                          /chat [user] - Opens a new chat tab with the specified user.
-                          /np - Print to chat the current song you are listening to or playing.
-                          /savelog - Saves the current chat tab to a text file.
-                          /roll [2-100] - Rolls a random number (multiplayer only).
+                          /help            - Displays all available commands.                        
+                          /me [action]     - Perform a third-person action.
+                          /join [channel]  - Joins the specified channel.
+                          /chat [user]     - Opens a new chat tab with the specified user.
+                          /np              - Print to chat the current song you are listening to or playing.
+                          /savelog         - Saves the current chat tab to a text file.
+                          /roll [2-100]    - Rolls a random number (multiplayer only).
                         """
                     ));
                     break;

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -414,13 +414,13 @@ namespace osu.Game.Online.Chat
                     target.AddNewMessages(new InfoMessage(
                         """
                         Supported commands:
-                          /help            - Displays all available commands.                        
-                          /me [action]     - Perform a third-person action.
-                          /join [channel]  - Joins the specified channel.
-                          /chat [user]     - Opens a new chat tab with the specified user.
-                          /np              - Print to chat the current song you are listening to or playing.
-                          /savelog         - Saves the current chat tab to a text file.
-                          /roll [2-100]    - Rolls a random number (multiplayer only).
+                            /help            - Displays all available commands.                        
+                            /me [action]     - Perform a third-person action.
+                            /join [channel]  - Joins the specified channel.
+                            /chat [user]     - Opens a new chat tab with the specified user.
+                            /np              - Print to chat the current song you are listening to or playing.
+                            /savelog         - Saves the current chat tab to a text file.
+                            /roll [2-100]    - Rolls a random number (multiplayer only).
                         """
                     ));
                     break;

--- a/osu.Game/Online/Chat/ChannelManager.cs
+++ b/osu.Game/Online/Chat/ChannelManager.cs
@@ -411,7 +411,16 @@ namespace osu.Game.Online.Chat
                     break;
 
                 case @"help":
-                    target.AddNewMessages(new InfoMessage("Supported commands: /help, /me [action], /join [channel], /chat [user], /np, /savelog, /roll [2-100] (multiplayer only)"));
+                    target.AddNewMessages(new InfoMessage(
+                        "Supported commands:\n" +
+                        " /help\n" +
+                        " /me [action]\n" +
+                        " /join [channel]\n" +
+                        " /chat [user]\n" +
+                        " /np\n" +
+                        " /savelog\n" +
+                        " /roll [2-100] (multiplayer only)"
+                    ));
                     break;
 
                 default:


### PR DESCRIPTION
Improves `/help` chat command output by formatting the list of supported commands for better visibility.

 Reformatted the `/help` command output in `ChannelManager.cs` to display each supported command on a new line, making it easier for users to read and understand the available commands.