### PR TITLE
Use discrete adjustment control in slider velocity adjustment popover in top timeline

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneSliderVelocityAdjust.cs
@@ -35,7 +35,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
 
         private DifficultyPointPiece difficultyPointPiece => blueprint.ChildrenOfType<DifficultyPointPiece>().First();
 
-        private IndeterminateSliderWithTextBoxInput<double> velocityTextBox => Game.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().First().ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().First();
+        private SliderVelocityAdjustmentControl velocityControl => Game.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().First().ChildrenOfType<SliderVelocityAdjustmentControl>().First();
 
         protected override IBeatmap CreateBeatmap(RulesetInfo ruleset) => new TestBeatmap(ruleset, false);
 
@@ -70,7 +70,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             if (adjustVelocity)
             {
                 AddStep("open velocity adjust panel", () => difficultyPointPiece.TriggerClick());
-                AddStep("change velocity", () => velocityTextBox.Current.Value = 2);
+                AddStep("change velocity", () => velocityControl.Current.Value = 2);
 
                 AddAssert("velocity adjusted", () => slider!.Velocity,
                     () => Is.EqualTo(velocity!.Value * 2).Within(Precision.DOUBLE_EPSILON));
@@ -118,7 +118,7 @@ namespace osu.Game.Rulesets.Osu.Tests.Editor
             });
 
             AddStep("open velocity adjust panel", () => difficultyPointPiece.TriggerClick());
-            AddStep("change velocity", () => velocityTextBox.Current.Value = 2);
+            AddStep("change velocity", () => velocityControl.Current.Value = 2);
 
             AddAssert("velocity adjusted", () => slider!.Velocity, () => Is.EqualTo(velocityBefore!.Value * 2).Within(Precision.DOUBLE_EPSILON));
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -155,7 +155,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void velocityPopoverHasFocus() => AddUntilStep("velocity popover textbox focused", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
+            var slider = popover?.ChildrenOfType<SliderVelocityAdjustmentControl>().Single();
             var textbox = slider?.ChildrenOfType<OsuTextBox>().Single();
 
             return textbox?.HasFocus == true;
@@ -164,17 +164,17 @@ namespace osu.Game.Tests.Visual.Editing
         private void velocityPopoverHasSingleValue(double velocity) => AddUntilStep($"velocity popover has {velocity}", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
+            var control = popover?.ChildrenOfType<SliderVelocityAdjustmentControl>().Single();
 
-            return slider?.Current.Value == velocity;
+            return control?.Current.Value == velocity && !control.IsMultipleValues;
         });
 
         private void velocityPopoverHasIndeterminateValue() => AddUntilStep("velocity popover has indeterminate value", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
+            var control = popover?.ChildrenOfType<SliderVelocityAdjustmentControl>().Single();
 
-            return slider != null && slider.Current.Value == null;
+            return control != null && control.IsMultipleValues;
         });
 
         private void dismissPopover()
@@ -187,7 +187,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void setVelocityViaPopover(double velocity) => AddStep($"set {velocity} via popover", () =>
         {
             var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().Single();
-            var slider = popover.ChildrenOfType<IndeterminateSliderWithTextBoxInput<double>>().Single();
+            var slider = popover.ChildrenOfType<SliderVelocityAdjustmentControl>().Single();
             slider.Current.Value = velocity;
         });
 

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -59,7 +59,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             private readonly HitObject hitObject;
 
-            private IndeterminateSliderWithTextBoxInput<double> sliderVelocitySlider;
+            private SliderVelocityAdjustmentControl adjustmentControl;
 
             [Resolved(canBeNull: true)]
             private EditorBeatmap beatmap { get; set; }
@@ -76,28 +76,20 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 {
                     new FillFlowContainer
                     {
-                        Width = 200,
+                        Width = 250,
                         Direction = FillDirection.Vertical,
                         AutoSizeAxes = Axes.Y,
                         Spacing = new Vector2(0, 15),
                         Children = new Drawable[]
                         {
-                            sliderVelocitySlider = new IndeterminateSliderWithTextBoxInput<double>("Velocity", new BindableDouble(1)
-                            {
-                                Precision = 0.01,
-                                MinValue = 0.1,
-                                MaxValue = 10
-                            })
-                            {
-                                KeyboardStep = 0.1f
-                            },
+                            adjustmentControl = new SliderVelocityAdjustmentControl(),
                             new OsuTextFlowContainer
                             {
                                 AutoSizeAxes = Axes.Y,
                                 RelativeSizeAxes = Axes.X,
                                 Text = "Hold shift while dragging the end of an object to adjust velocity while snapping."
                             },
-                            new SliderVelocityInspector(sliderVelocitySlider.Current),
+                            new SliderVelocityInspector(adjustmentControl.Current),
                         }
                     }
                 };
@@ -116,39 +108,42 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     // there may be legacy control points, which contain infinite precision for compatibility reasons (see LegacyDifficultyControlPoint).
                     // generally that level of precision could only be set by externally editing the .osu file, so at the point
                     // a user is looking to update this within the editor it should be safe to obliterate this additional precision.
-                    sliderVelocitySlider.Current.Value = selectedPointBindable.Value;
+                    adjustmentControl.Current.Value = selectedPointBindable.Value;
+                }
+                else
+                {
+                    adjustmentControl.IsMultipleValues = true;
                 }
 
-                sliderVelocitySlider.Current.BindValueChanged(val =>
+                adjustmentControl.Current.BindValueChanged(val =>
                 {
-                    if (val.NewValue == null)
-                        return;
-
                     beatmap.BeginChange();
 
                     foreach (var h in relevantObjects)
                     {
-                        ((IHasSliderVelocity)h).SliderVelocityMultiplier = val.NewValue.Value;
+                        ((IHasSliderVelocity)h).SliderVelocityMultiplier = val.NewValue;
                         beatmap.Update(h);
                     }
 
                     beatmap.EndChange();
+
+                    adjustmentControl.IsMultipleValues = false;
                 });
             }
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                ScheduleAfterChildren(() => GetContainingFocusManager()!.ChangeFocus(sliderVelocitySlider));
+                ScheduleAfterChildren(() => adjustmentControl.TakeFocus());
             }
         }
     }
 
     internal partial class SliderVelocityInspector : EditorInspector
     {
-        private readonly Bindable<double?> current;
+        private readonly Bindable<double> current;
 
-        public SliderVelocityInspector(Bindable<double?> current)
+        public SliderVelocityInspector(Bindable<double> current)
         {
             this.current = current;
         }

--- a/osu.Game/Screens/Edit/Timing/FormDiscreteAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/FormDiscreteAdjustmentControl.cs
@@ -44,8 +44,8 @@ namespace osu.Game.Screens.Edit.Timing
             {
                 tabbableContentContainer = value;
 
-                if (textBox.IsNotNull())
-                    textBox.TabbableContentContainer = tabbableContentContainer;
+                if (TextBox.IsNotNull())
+                    TextBox.TabbableContentContainer = tabbableContentContainer;
             }
         }
 
@@ -88,14 +88,8 @@ namespace osu.Game.Screens.Edit.Timing
             }
         }
 
-        /// <summary>
-        /// The string formatting function to use for the slider's tooltip text.
-        /// If not provided, <see cref="LabelFormat"/> is used.
-        /// </summary>
-        public Func<T, LocalisableString> TooltipFormat { get; init; }
-
         private FormControlBackground background = null!;
-        private FormTextBox.InnerTextBox textBox = null!;
+        internal FormTextBox.InnerTextBox TextBox { get; private set; } = null!;
         private OsuSpriteText valueLabel = null!;
         private FormFieldCaption captionText = null!;
         private IFocusManager focusManager = null!;
@@ -106,16 +100,13 @@ namespace osu.Game.Screens.Edit.Timing
 
         private readonly Bindable<Language> currentLanguage = new Bindable<Language>();
 
-        public bool TakeFocus() => GetContainingFocusManager()?.ChangeFocus(textBox) == true;
-
         public FormDiscreteAdjustmentControl(T baseIncrement)
         {
             labelFormat ??= DefaultLabelFormat;
-            TooltipFormat ??= v => LabelFormat(v);
 
             adjustmentControl = new DiscreteAdjustmentControl<T>(baseIncrement);
 
-            current.ValueChanged += e =>
+            current.ValueChanged += _ =>
             {
                 ValueChanged?.Invoke();
             };
@@ -166,7 +157,7 @@ namespace osu.Game.Screens.Edit.Timing
                                     AutoSizeAxes = Axes.Y,
                                     Children = new Drawable[]
                                     {
-                                        textBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
+                                        TextBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
                                         {
                                             RelativeSizeAxes = Axes.X,
                                             // the textbox is hidden when the control is unfocused,
@@ -211,8 +202,8 @@ namespace osu.Game.Screens.Edit.Timing
             focusManager = GetContainingFocusManager()!;
             inputManager = GetContainingInputManager()!;
 
-            textBox.Focused.BindValueChanged(_ => updateState());
-            textBox.OnCommit += textCommitted;
+            TextBox.Focused.BindValueChanged(_ => updateState());
+            TextBox.OnCommit += textCommitted;
 
             currentLanguage.BindValueChanged(_ => Schedule(updateValueDisplay));
             current.BindValueChanged(_ =>
@@ -256,23 +247,23 @@ namespace osu.Game.Screens.Edit.Timing
         protected override bool OnClick(ClickEvent e)
         {
             if (!Current.Disabled)
-                focusManager.ChangeFocus(textBox);
+                focusManager.ChangeFocus(TextBox);
             return true;
         }
 
         private void updateState()
         {
-            textBox.ReadOnly = Current.Disabled;
-            textBox.Alpha = textBox.Focused.Value ? 1 : 0;
-            valueLabel.Alpha = textBox.Focused.Value ? 0 : 1;
+            TextBox.ReadOnly = Current.Disabled;
+            TextBox.Alpha = TextBox.Focused.Value ? 1 : 0;
+            valueLabel.Alpha = TextBox.Focused.Value ? 0 : 1;
 
             captionText.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content2;
-            textBox.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
+            TextBox.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
             valueLabel.Colour = Current.Disabled ? colourProvider.Background1 : colourProvider.Content1;
 
             if (Current.Disabled)
                 background.VisualStyle = VisualStyle.Disabled;
-            else if (textBox.Focused.Value)
+            else if (TextBox.Focused.Value)
                 background.VisualStyle = VisualStyle.Focused;
             else if (IsHovered || adjustmentControl.Contains(inputManager.CurrentState.Mouse.Position))
                 background.VisualStyle = VisualStyle.Hovered;
@@ -282,7 +273,7 @@ namespace osu.Game.Screens.Edit.Timing
 
         private void updateValueDisplay()
         {
-            textBox.Text = NumberFormattingExtensions.Normalise(decimal.CreateTruncating(Current.Value), OsuSliderBar<T>.MAX_DECIMAL_DIGITS).ToString(CultureInfo.CurrentCulture);
+            TextBox.Text = NumberFormattingExtensions.Normalise(decimal.CreateTruncating(Current.Value), OsuSliderBar<T>.MAX_DECIMAL_DIGITS).ToString(CultureInfo.CurrentCulture);
             valueLabel.Text = LabelFormat(Current.Value);
         }
 

--- a/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
+using osuTK;
+
+namespace osu.Game.Screens.Edit.Timing
+{
+    public partial class SliderVelocityAdjustmentControl : CompositeDrawable, IHasCurrentValue<double>
+    {
+        public Bindable<double> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1)
+        {
+            Precision = 0.01,
+            MinValue = 0.1,
+            MaxValue = 10
+        };
+
+        /// <summary>
+        /// This is a hack to allow the text box to show an indication that multiple slider velocity values are active
+        /// when the selection contains multiple objects with different velocities.
+        /// </summary>
+        public bool IsMultipleValues
+        {
+            get => isMultipleValues;
+            set
+            {
+                if (isMultipleValues == value)
+                    return;
+
+                isMultipleValues = value;
+                updateIndeterminateState();
+            }
+        }
+
+        private bool isMultipleValues;
+
+        private FormDiscreteAdjustmentControl<double> control = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            InternalChild = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(5),
+                Children = new Drawable[]
+                {
+                    control = new FormDiscreteAdjustmentControl<double>(0.05)
+                    {
+                        Caption = "Slider velocity",
+                        Current = Current,
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            control.TextBox.Focused.BindValueChanged(focused =>
+            {
+                if (focused.NewValue && IsMultipleValues)
+                    control.TextBox.Text = string.Empty;
+            });
+            updateIndeterminateState();
+        }
+
+        private void updateIndeterminateState()
+        {
+            control.LabelFormat = IsMultipleValues
+                ? static _ => "(multiple)"
+                : v => LocalisableString.Interpolate($"{v:0.00}x");
+            control.TextBox.PlaceholderText = IsMultipleValues ? "(multiple)" : string.Empty;
+        }
+
+        public bool TakeFocus() => GetContainingFocusManager()!.ChangeFocus(control.TextBox);
+    }
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/822d62a0-e51e-4227-807e-280e8957364c

---

Continuation of https://github.com/ppy/osu/pull/38140.

Applied in the slider velocity adjustment popover first because it is easier to do so. The right toolbox will come at the end of this series of queued changes.

The reason why `SliderVelocityAdjustmentControl` is a separate entity is twofold:

- I aim to use it directly both in the timeline popover *and* the right toolbox.
- It will receive a preset control that allows mappers to add and remove their own preset slider velocity values.