### PR TITLE
Fix: Clear collection filter when selected beatmap isn't inside it

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -348,6 +348,14 @@ namespace osu.Game.Screens.Select
             searchTextBox.Current.Value = query;
         }
 
+        /// <summary>
+        /// Clears the active collection filter, returning to "All Beatmaps".
+        /// </summary>
+        public void ClearCollectionFilter()
+        {
+            collectionDropdown.Current.Value = new AllBeatmapsCollectionFilterMenuItem();
+        }
+
         protected override void PopIn()
         {
             this.MoveToX(0, SongSelect.ENTER_DURATION, Easing.OutQuint)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1182,6 +1182,17 @@ namespace osu.Game.Screens.Select
 
             var beatmapInfo = workingBeatmap.BeatmapInfo;
 
+            // If a collection filter is active and the presented beatmap is not in it,
+            // clear the filter so the beatmap is visible in the carousel.
+            var criteria = FilterControl.CreateCriteria();
+
+            if (criteria.Collection != null)
+            {
+                var hashes = criteria.CollectionBeatmapMD5Hashes;
+                if (hashes == null || !hashes.Contains(beatmapInfo.MD5Hash))
+                    FilterControl.ClearCollectionFilter();
+            }
+
             // Don't change the local ruleset if the user is on another ruleset and is showing converted beatmaps.
             // Eventually we probably want to check whether conversion is actually possible for the current ruleset.
             bool requiresRulesetSwitch = !beatmapInfo.Ruleset.Equals(Ruleset.Value)


### PR DESCRIPTION
Fixes #38079

## Issue

When selecting a beatmap outside the active collection filter, the
song select carousel appears empty or out of sync with the selection.

## Fix

Clear the collection filter when the selected beatmap isn't in the
filtered collection, so the beatmap always shows in the carousel.

```cs
var criteria = FilterControl.CreateCriteria();
if (criteria.Collection != null)
{
    var hashes = criteria.CollectionBeatmapMD5Hashes;
    if (hashes == null || !hashes.Contains(beatmapInfo.MD5Hash))
        FilterControl.ClearCollectionFilter();
}
```

## Changes

- Add `ClearCollectionFilter()` to `FilterControl` that resets to "All Beatmaps"
- Call it in `SongSelect` when the selected beatmap isn't in the active collection

This is my first contribution to osu!, I'm so happyyyy :face_holding_back_tears:
I love this game :>