### PR TITLE
Adjust colour of dangerous menu items to be more legible against new colour scheme

### DIFF
--- a/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
+++ b/osu.Game/Graphics/UserInterface/DrawableOsuMenuItem.cs
@@ -80,6 +80,9 @@ namespace osu.Game.Graphics.UserInterface
             FinishTransforms();
         }
 
+        [Resolved]
+        private OsuColour colours { get; set; }
+
         private void updateText()
         {
             var osuMenuItem = Item as OsuMenuItem;
@@ -92,7 +95,7 @@ namespace osu.Game.Graphics.UserInterface
                     break;
 
                 case MenuItemType.Destructive:
-                    text.Colour = Color4.Red;
+                    text.Colour = colours.Red1;
                     break;
 
                 case MenuItemType.Highlighted:


### PR DESCRIPTION
Certain reds on certain backgrounds are basically eye cancer.

| Before | After |
| :---: | :---: |
| <img width="467" height="325" alt="osu! 2026-06-30 at 05 21 50" src="https://github.com/user-attachments/assets/d56f58fa-9f13-4888-99dd-46d7855c804f" /> | <img width="467" height="325" alt="osu! 2026-06-30 at 05 21 22" src="https://github.com/user-attachments/assets/98bdfc65-5cd1-4e7f-bc21-c1d1c45e00c5" /> |