### PR TITLE
Fix offset adjustment control not respecting "adjust existing object on timing changes" setting

### DIFF
--- a/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
+++ b/osu.Game/Screens/Edit/Timing/TapTimingControl.cs
@@ -244,7 +244,7 @@ namespace osu.Game.Screens.Edit.Timing
 
             foreach (var cp in currentGroupItems)
             {
-                if (cp is TimingControlPoint tp)
+                if (cp is TimingControlPoint tp && configManager.Get<bool>(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges))
                 {
                     TimingSectionAdjustments.AdjustHitObjectOffset(beatmap, tp, offsetChange.NewValue - offsetChange.OldValue);
                     beatmap.UpdateAllHitObjects();


### PR DESCRIPTION
Noticed this was inconsistent with the BPM adjustment control when checking https://github.com/ppy/osu/pull/37475.

I am in blame for breaking this, albeit not with the recent slider velocity control series, but with a plain omission almost 2 years ago: 0cddb93dda4275c592436c71f07c2e514e1635da