### PR TITLE
Update style of extended details on profile page

### DIFF
--- a/osu.Game/Overlays/Profile/Header/Components/ExtendedDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExtendedDetails.cs
@@ -32,7 +32,6 @@ namespace osu.Game.Overlays.Profile.Header.Components
         [BackgroundDependencyLoader]
         private void load(OverlayColourProvider colourProvider)
         {
-            var font = OsuFont.Default.With(size: 12);
             const float vertical_spacing = 4;
             const float horizontal_spacing = 20;
 
@@ -64,14 +63,14 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             Spacing = new Vector2(0, vertical_spacing),
                             Children = new Drawable[]
                             {
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsRankedScore },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsHitAccuracy },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsPlayCount },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsTotalScore },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsTotalHits },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsHitsPerPlay },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsMaximumCombo },
-                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsReplaysWatchedByOthers },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsRankedScore },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsHitAccuracy },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsPlayCount },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsTotalScore },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsTotalHits },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsHitsPerPlay },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsMaximumCombo },
+                                new ExtendedDetailsEntryLabel(colourProvider) { Text = UsersStrings.ShowStatsReplaysWatchedByOthers },
                             }
                         },
                         new FillFlowContainer
@@ -82,14 +81,14 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             Spacing = new Vector2(0, vertical_spacing),
                             Children = new Drawable[]
                             {
-                                rankedScore = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                hitAccuracy = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                playCount = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                totalScore = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                totalHits = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                hitsPerPlay = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                maximumCombo = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
-                                replaysWatched = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                rankedScore = new ExtendedDetailsEntryValue(colourProvider),
+                                hitAccuracy = new ExtendedDetailsEntryValue(colourProvider),
+                                playCount = new ExtendedDetailsEntryValue(colourProvider),
+                                totalScore = new ExtendedDetailsEntryValue(colourProvider),
+                                totalHits = new ExtendedDetailsEntryValue(colourProvider),
+                                hitsPerPlay = new ExtendedDetailsEntryValue(colourProvider),
+                                maximumCombo = new ExtendedDetailsEntryValue(colourProvider),
+                                replaysWatched = new ExtendedDetailsEntryValue(colourProvider),
                             }
                         },
                     }
@@ -127,6 +126,24 @@ namespace osu.Game.Overlays.Profile.Header.Components
             hitsPerPlay.Text = getHitsPerPlay(statistics).ToLocalisableString(@"N0");
             maximumCombo.Text = statistics.MaxCombo.ToLocalisableString(@"N0");
             replaysWatched.Text = statistics.ReplaysWatched.ToLocalisableString(@"N0");
+        }
+
+        public partial class ExtendedDetailsEntryLabel : OsuSpriteText
+        {
+            public ExtendedDetailsEntryLabel(OverlayColourProvider colourProvider)
+            {
+                Font = OsuFont.Default.With(size: 12);
+                Colour = colourProvider.Content1;
+            }
+        }
+
+        public partial class ExtendedDetailsEntryValue : OsuSpriteText
+        {
+            public ExtendedDetailsEntryValue(OverlayColourProvider colourProvider)
+            {
+                Font = OsuFont.Default.With(size: 12, weight: FontWeight.Bold);
+                Colour = colourProvider.Content2;
+            }
         }
     }
 }

--- a/osu.Game/Overlays/Profile/Header/Components/ExtendedDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/ExtendedDetails.cs
@@ -6,6 +6,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
@@ -29,57 +30,69 @@ namespace osu.Game.Overlays.Profile.Header.Components
         private SpriteText replaysWatched = null!;
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OverlayColourProvider colourProvider)
         {
             var font = OsuFont.Default.With(size: 12);
             const float vertical_spacing = 4;
+            const float horizontal_spacing = 20;
 
             AutoSizeAxes = Axes.Both;
+            CornerRadius = 6;
+            Masking = true;
 
-            // this should really be a grid, but trying to avoid one to avoid the performance hit.
-            InternalChild = new FillFlowContainer
+            InternalChildren = new Drawable[]
             {
-                AutoSizeAxes = Axes.Both,
-                Direction = FillDirection.Horizontal,
-                Spacing = new Vector2(20, 0),
-                Children = new[]
+                new Box
                 {
-                    new FillFlowContainer
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = colourProvider.Background4,
+                },
+                // this should really be a grid, but trying to avoid one to avoid the performance hit.
+                new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Horizontal,
+                    Spacing = new Vector2(horizontal_spacing, 0),
+                    Padding = new MarginPadding { Vertical = 18, Horizontal = 12 },
+                    Children = new[]
                     {
-                        Name = @"Labels",
-                        AutoSizeAxes = Axes.Both,
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(0, vertical_spacing),
-                        Children = new Drawable[]
+                        new FillFlowContainer
                         {
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsRankedScore },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsHitAccuracy },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsPlayCount },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsTotalScore },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsTotalHits },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsHitsPerPlay },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsMaximumCombo },
-                            new OsuSpriteText { Font = font, Text = UsersStrings.ShowStatsReplaysWatchedByOthers },
-                        }
-                    },
-                    new FillFlowContainer
-                    {
-                        Name = @"Values",
-                        AutoSizeAxes = Axes.Both,
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(0, vertical_spacing),
-                        Children = new Drawable[]
+                            Name = @"Labels",
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0, vertical_spacing),
+                            Children = new Drawable[]
+                            {
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsRankedScore },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsHitAccuracy },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsPlayCount },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsTotalScore },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsTotalHits },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsHitsPerPlay },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsMaximumCombo },
+                                new OsuSpriteText { Font = font, Colour = colourProvider.Content1, Text = UsersStrings.ShowStatsReplaysWatchedByOthers },
+                            }
+                        },
+                        new FillFlowContainer
                         {
-                            rankedScore = new OsuSpriteText { Font = font },
-                            hitAccuracy = new OsuSpriteText { Font = font },
-                            playCount = new OsuSpriteText { Font = font },
-                            totalScore = new OsuSpriteText { Font = font },
-                            totalHits = new OsuSpriteText { Font = font },
-                            hitsPerPlay = new OsuSpriteText { Font = font },
-                            maximumCombo = new OsuSpriteText { Font = font },
-                            replaysWatched = new OsuSpriteText { Font = font },
-                        }
-                    },
+                            Name = @"Values",
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(0, vertical_spacing),
+                            Children = new Drawable[]
+                            {
+                                rankedScore = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                hitAccuracy = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                playCount = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                totalScore = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                totalHits = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                hitsPerPlay = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                maximumCombo = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                                replaysWatched = new OsuSpriteText { Font = font.With(weight: FontWeight.Bold), Colour = colourProvider.Content2 },
+                            }
+                        },
+                    }
                 }
             };
         }


### PR DESCRIPTION
- matches web (see https://github.com/ppy/osu-web/pull/13107)

changes can be reviewed commit by commit

| master | PR | `osu-web` |
|-|-|-|
| <img width="405" height="271" alt="Снимок экрана 2026-06-30 162239" src="https://github.com/user-attachments/assets/dd2ff885-213d-4cf2-8d3e-78983d435d32" /> | <img width="451" height="303" alt="Снимок экрана 2026-06-30 161851" src="https://github.com/user-attachments/assets/2a3d0d7f-641c-4a88-ac79-b04c770afe37" /> | <img width="431" height="308" alt="Снимок экрана 2026-06-30 161828" src="https://github.com/user-attachments/assets/ba658cf0-b681-430c-9a63-1036a3af4ab9" /> |