### PR TITLE
Add tier colour to ranked play ranking on profile overlay

### DIFF
--- a/osu.Game/Online/API/Requests/Responses/APIUserMatchmakingStatistics.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIUserMatchmakingStatistics.cs
@@ -17,7 +17,10 @@ namespace osu.Game.Online.API.Requests.Responses
         public int Rating { get; set; }
 
         [JsonProperty("rank")]
-        public int? Rank { get; set; }
+        public int Rank { get; set; }
+
+        [JsonProperty("rank_percent")]
+        public float RankPercent { get; set; }
 
         [JsonProperty("plays")]
         public int Plays { get; set; }

--- a/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsDisplay.cs
@@ -12,6 +12,7 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Resources.Localisation.Web;
+using osu.Game.Scoring;
 
 namespace osu.Game.Overlays.Profile.Header.Components
 {
@@ -107,30 +108,57 @@ namespace osu.Game.Overlays.Profile.Header.Components
                 return;
             }
 
-            APIUserMatchmakingStatistics[] stats = User.Value.User.MatchmakingStatistics;
+            APIUserMatchmakingStatistics[] allStats = User.Value.User.MatchmakingStatistics;
 
-            if (stats.Length == 0)
+            if (allStats.Length == 0)
             {
                 Hide();
                 return;
             }
 
-            int? highestRank = null;
+            APIUserMatchmakingStatistics? highestRankStats = null;
 
-            foreach (var stat in stats)
+            foreach (var stats in allStats)
             {
-                if (stat.Pool.Active && stat.Rank != null)
-                {
-                    if (highestRank == null || stat.Rank < highestRank)
-                        highestRank = stat.Rank;
-                }
+                if (stats.Pool.Active && (highestRankStats == null || stats.Rank < highestRankStats.Rank))
+                    highestRankStats = stats;
             }
 
-            rankText.Text = highestRank == null ? "-" : $"#{highestRank:N0}";
+            rankText.Text = highestRankStats == null ? "-" : $"#{highestRankStats.Rank:N0}";
 
-            TooltipContent = new MatchmakingStatsTooltipData(colourProvider, stats.OrderByDescending(s => s.PoolId).ToArray());
+            if (highestRankStats != null)
+                rankText.Colour = OsuColour.ForRankingTier(GetRankingTier(highestRankStats));
+
+            TooltipContent = new MatchmakingStatsTooltipData(colourProvider, allStats.OrderByDescending(s => s.PoolId).ToArray());
 
             Show();
+        }
+
+        /// <seealso href="https://github.com/ppy/osu-web/blob/9f136df53a1c436229b0e4eb192011c15514dcf9/resources/js/profile-page/matchmaking.tsx#L15-L34"/>
+        public static RankingTier GetRankingTier(APIUserMatchmakingStatistics stats)
+        {
+            int rank = stats.Rank;
+            float percent = stats.RankPercent;
+
+            if (rank <= 100)
+                return RankingTier.Lustrous;
+
+            if (percent < 0.05)
+                return RankingTier.Radiant;
+
+            if (percent < 0.2)
+                return RankingTier.Rhodium;
+
+            if (percent < 0.5)
+                return RankingTier.Platinum;
+
+            if (percent < 0.75)
+                return RankingTier.Gold;
+
+            if (percent < 0.95)
+                return RankingTier.Silver;
+
+            return RankingTier.Bronze;
         }
 
         public ITooltip<MatchmakingStatsTooltipData> GetCustomTooltip() => new MatchmakingStatsTooltip();

--- a/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsTooltip.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsTooltip.cs
@@ -78,19 +78,23 @@ namespace osu.Game.Overlays.Profile.Header.Components
             };
         }
 
-        private Drawable[] createRow(OverlayColourProvider colourProvider, APIUserMatchmakingStatistics stat)
+        private Drawable[] createRow(OverlayColourProvider colourProvider, APIUserMatchmakingStatistics stats)
         {
             return
             [
                 new StatisticText(colourProvider)
                 {
-                    Text = stat.Pool.Name,
+                    Text = stats.Pool.Name,
                     Colour = Color4.White
                 },
-                new StatisticText(colourProvider) { Text = $"#{stat.Rank:N0}" },
-                new StatisticText(colourProvider) { Text = stat.FirstPlacements.ToString("N0") },
-                new StatisticText(colourProvider) { Text = stat.Plays.ToString("N0") },
-                new StatisticText(colourProvider) { Text = stat.Rating.ToString("N0") + (stat.IsRatingProvisional ? "*" : string.Empty) }
+                new StatisticText(colourProvider)
+                {
+                    Text = $"#{stats.Rank:N0}",
+                    Colour = OsuColour.ForRankingTier(MatchmakingStatsDisplay.GetRankingTier(stats))
+                },
+                new StatisticText(colourProvider) { Text = stats.FirstPlacements.ToString("N0") },
+                new StatisticText(colourProvider) { Text = stats.Plays.ToString("N0") },
+                new StatisticText(colourProvider) { Text = stats.Rating.ToString("N0") + (stats.IsRatingProvisional ? "*" : string.Empty) }
             ];
         }
 


### PR DESCRIPTION
- port of https://github.com/ppy/osu-web/pull/13110

| actual profile | test scene |
|-|-|
| <img width="301" height="147" alt="image" src="https://github.com/user-attachments/assets/c3a6c30c-ad4d-4bd7-9d1e-1edd11fe74b5" /> | <img width="370" height="190" alt="image" src="https://github.com/user-attachments/assets/1bd5accb-cfad-45c6-bc19-56be4779099f" /> |
