### PR TITLE
Improve taiko standardised score conversion algorithm

### DIFF
--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -66,7 +66,11 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                 drainLength = ((int)Math.Round(baseBeatmap.HitObjects[^1].StartTime) - (int)Math.Round(baseBeatmap.HitObjects[0].StartTime) - breakLength) / 1000;
             }
 
-            difficultyPeppyStars = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(baseBeatmap.Difficulty, objectCount, drainLength);
+            var alteredDifficulty = baseBeatmap.Difficulty.Clone();
+            // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManagerTaiko.cs#L78
+            alteredDifficulty.CircleSize = 2;
+
+            difficultyPeppyStars = LegacyRulesetExtensions.CalculateDifficultyPeppyStars(alteredDifficulty, objectCount, drainLength);
 
             LegacyScoreAttributes attributes = new LegacyScoreAttributes();
 

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -74,8 +74,13 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             LegacyScoreAttributes attributes = new LegacyScoreAttributes();
 
-            foreach (var obj in playableBeatmap.HitObjects)
-                simulateHit(obj, ref attributes);
+            for (int i = 0; i < playableBeatmap.HitObjects.Count; ++i)
+            {
+                simulateHit(
+                    playableBeatmap.HitObjects[i],
+                    i < playableBeatmap.HitObjects.Count - 1 ? playableBeatmap.HitObjects[i + 1] : null,
+                    ref attributes);
+            }
 
             attributes.BonusScoreRatio = legacyBonusScore == 0 ? 0 : (double)standardisedBonusScore / legacyBonusScore;
             attributes.BonusScore = legacyBonusScore;
@@ -84,7 +89,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             return attributes;
         }
 
-        private void simulateHit(HitObject hitObject, ref LegacyScoreAttributes attributes)
+        private void simulateHit(HitObject hitObject, HitObject? nextHitObject, ref LegacyScoreAttributes attributes)
         {
             bool increaseCombo = true;
             bool addScoreComboMultiplier = false;
@@ -130,7 +135,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                     halfSpinsRequiredForCompletion = Math.Max(1, (int)(halfSpinsRequiredForCompletion * 1.5f));
 
                     for (int i = 0; i <= halfSpinsRequiredForCompletion; i++)
-                        simulateHit(new SwellTick(), ref attributes);
+                        simulateHit(new SwellTick(), null, ref attributes);
 
                     scoreIncrease = 300;
                     addScoreComboMultiplier = true;
@@ -144,9 +149,19 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
                     addScoreComboMultiplier = true;
                     break;
 
-                case DrumRoll:
-                    foreach (var nested in hitObject.NestedHitObjects)
-                        simulateHit(nested, ref attributes);
+                case DrumRoll drumRoll:
+                    double minHitDelay = getSliderTaikoMinHitDelay(drumRoll);
+
+                    // source for `HittableEndTime`:
+                    // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjects/Taiko/SliderTaiko.cs#L157
+                    // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjects/Taiko/SliderTaiko.cs#L225-L228
+                    double? nextObjectHittableStartTime = nextHitObject is DrumRoll nextDrumRoll ? nextDrumRoll.StartTime - getSliderTaikoMinHitDelay(nextDrumRoll) : nextHitObject?.StartTime;
+                    bool endpointHittable = nextObjectHittableStartTime == null || nextObjectHittableStartTime - (drumRoll.EndTime + (int)minHitDelay) > (int)minHitDelay;
+                    double hittableEndTime = endpointHittable ? drumRoll.EndTime + (int)minHitDelay : drumRoll.EndTime;
+
+                    // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjects/Taiko/SliderTaiko.cs#L288
+                    for (double i = drumRoll.StartTime; i < hittableEndTime; i += minHitDelay)
+                        simulateHit(new DrumRollTick(drumRoll), null, ref attributes);
                     return;
 
                 case StrongNestedHitObject:
@@ -210,6 +225,31 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
             if (increaseCombo)
                 combo++;
+        }
+
+        // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjects/Taiko/SliderTaiko.cs#L74-L92
+        private double getSliderTaikoMinHitDelay(DrumRoll drumRoll)
+        {
+            double maxRate;
+            double beatLength = playableBeatmap.ControlPointInfo.TimingPointAt(drumRoll.StartTime).BeatLength;
+
+            if (playableBeatmap.BeatmapVersion >= 8)
+            {
+                double sliderTickRate = playableBeatmap.Difficulty.SliderTickRate;
+                if (sliderTickRate == 3 || sliderTickRate == 6 || sliderTickRate == 1.5d)
+                    maxRate = beatLength / 6;
+                else
+                    maxRate = beatLength / 8;
+            }
+            else
+                maxRate = beatLength / 8;
+
+            while (maxRate < 60)
+                maxRate *= 2;
+            while (maxRate > 120)
+                maxRate /= 2;
+
+            return maxRate;
         }
 
         public double GetLegacyScoreMultiplier(IReadOnlyList<Mod> mods, LegacyBeatmapConversionDifficultyInfo difficulty)

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoLegacyScoreSimulator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Logging;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects;
@@ -161,7 +162,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
 
                     // https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjects/Taiko/SliderTaiko.cs#L288
                     for (double i = drumRoll.StartTime; i < hittableEndTime; i += minHitDelay)
-                        simulateHit(new DrumRollTick(drumRoll), null, ref attributes);
+                        simulateHit(new DrumRollTick(drumRoll) { IsStrong = drumRoll.IsStrong }, null, ref attributes);
                     return;
 
                 case StrongNestedHitObject:


### PR DESCRIPTION
Previous attempt: https://github.com/ppy/osu/pull/37313

- [x] Pending sheet generation & verification

> [!WARNING]
> The deployment of these fixes, if accepted, will consist of:
>
> - recomputation of legacy scoring attributes for **all** taiko beatmaps (including converts),
> - reverification of **all** taiko legacy scores.

## [Fix incorrect score conversion in taiko due to not porting stable quirk](https://github.com/ppy/osu/commit/5c3aef88d84f2db23b0916cd25b362d834826d5e)

Reported in [discord](https://discord.com/channels/188630481301012481/1097318920991559880/1493976971766403203).

In taiko specifically, [stable decides to set circle size to 2 uniformly](https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManagerTaiko.cs#L78). This factors into `difficultyPeppyStars`, which makes `TaikoLegacyScoreSimulator` incorrectly estimate the maximum achievable score.

## [Fix incorrect taiko score conversion due to mismatching number of drum roll ticks](https://github.com/ppy/osu/commit/9eaef5fb82fd6cff88c01256f96dc5f65c5d631c)

lazer's drum roll tick generation does not match stable; stable uses a complicated sequence of calculations involving beat length and even the temporal placement of the next object in the beatmap.

I have confirmed that the new code matches stable's results on a few selected beatmaps that exhibited this issue, which were:

- https://osu.ppy.sh/beatmapsets/28793#osu/95989
- https://osu.ppy.sh/beatmapsets/1020146#osu/2134593
- https://osu.ppy.sh/beatmapsets/1787972#taiko/3707679
- https://osu.ppy.sh/beatmapsets/2213902#taiko/4690636