### PR TITLE
Change `RulesetStore` to not recurse subdirectories

### DIFF
--- a/osu.Game/Rulesets/RulesetStore.cs
+++ b/osu.Game/Rulesets/RulesetStore.cs
@@ -118,10 +118,7 @@ namespace osu.Game.Rulesets
         {
             try
             {
-                // On net6-android (Debug), StartupDirectory can be different from where assemblies are placed.
-                // Search sub-directories too.
-
-                string[] files = Directory.GetFiles(RuntimeInfo.StartupDirectory, @$"{ruleset_library_prefix}.*.dll", SearchOption.AllDirectories);
+                string[] files = Directory.GetFiles(RuntimeInfo.StartupDirectory, @$"{ruleset_library_prefix}.*.dll");
 
                 foreach (string file in files.Where(f => !Path.GetFileName(f).Contains("Tests")))
                     loadRulesetFromFile(file);


### PR DESCRIPTION
Led down a rabbit hole after difficulty calculator was taking *minutes* in this method. Turns out it was iterating over hundreds of thousands of `.osu` files.

I'm unable to test android so pushing this to see what CI says and hopefully have someone with android setup run a quick test (@bdach maybe you can jump in here?)

Worst case, we will probably want to conditional this for android only I guess. It shouldn't happen for standard desktop / server app usages.