### PR TITLE
Add accessibility mods to ranked play

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboard.cs
@@ -48,7 +48,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
             public Dictionary<int, IReadOnlyList<Mod>> UserMods => UserScores.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ScoreProcessor.Mods);
 
             public TestLeaderboard(MultiplayerRoomUser[] users)
-                : base(users)
+                : base(users, false)
             {
             }
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerGameplayLeaderboardTeams.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         }
 
         protected override MultiplayerLeaderboardProvider CreateLeaderboardProvider() =>
-            new MultiplayerLeaderboardProvider(MultiplayerUsers.ToArray())
+            new MultiplayerLeaderboardProvider(MultiplayerUsers.ToArray(), false)
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,

--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneRankedPlayUserDisplay.cs
@@ -5,8 +5,10 @@ using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Utils;
+using osu.Game.Online.API;
 using osu.Game.Online.Rooms;
 using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
 using osu.Game.Tests.Visual.Multiplayer;
@@ -88,6 +90,20 @@ namespace osu.Game.Tests.Visual.RankedPlay
             {
                 health.Value = 1_000_000;
                 health.Value = 1;
+            });
+        }
+
+        [Test]
+        public void TestMods()
+        {
+            AddStep("set user mods", () => MultiplayerClient.ChangeUserMods(1001, [new APIMod(new OsuModHidden())]));
+
+            AddStep("reverse orientation", () => Child = new RankedPlayUserDisplay(new APIUser { Id = 1001, Username = "User 1001" }, Anchor.BottomRight, RankedPlayColourScheme.BLUE)
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(256, 72),
+                Health = { BindTarget = health }
             });
         }
     }

--- a/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
+++ b/osu.Game/Online/Matchmaking/IMatchmakingServer.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Online.Matchmaking
         /// <summary>
         /// Joins the matchmaking queue, allowing the local user to get matched up with others.
         /// </summary>
-        Task MatchmakingJoinQueue(int poolId);
+        Task<MatchmakingJoinQueueResponse> MatchmakingJoinQueueWithParams(MatchmakingJoinQueueRequest request);
 
         /// <summary>
         /// Leaves the matchmaking queue.

--- a/osu.Game/Online/Matchmaking/Requests/MatchmakingJoinQueueRequest.cs
+++ b/osu.Game/Online/Matchmaking/Requests/MatchmakingJoinQueueRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using MessagePack;
+using osu.Game.Online.API;
 
 namespace osu.Game.Online.Matchmaking.Requests
 {
@@ -12,5 +13,8 @@ namespace osu.Game.Online.Matchmaking.Requests
     {
         [Key(0)]
         public int PoolId { get; set; }
+
+        [Key(1)]
+        public APIMod[] Mods { get; set; } = [];
     }
 }

--- a/osu.Game/Online/Matchmaking/Requests/MatchmakingJoinQueueRequest.cs
+++ b/osu.Game/Online/Matchmaking/Requests/MatchmakingJoinQueueRequest.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Requests
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingJoinQueueRequest
+    {
+        [Key(0)]
+        public int PoolId { get; set; }
+    }
+}

--- a/osu.Game/Online/Matchmaking/Responses/MatchmakingJoinQueueResponse.cs
+++ b/osu.Game/Online/Matchmaking/Responses/MatchmakingJoinQueueResponse.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using MessagePack;
+
+namespace osu.Game.Online.Matchmaking.Responses
+{
+    [MessagePackObject]
+    [Serializable]
+    public class MatchmakingJoinQueueResponse
+    {
+    }
+}

--- a/osu.Game/Online/Multiplayer/MultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/MultiplayerClient.cs
@@ -1210,7 +1210,7 @@ namespace osu.Game.Online.Multiplayer
 
         public abstract Task MatchmakingLeaveLobby();
 
-        public abstract Task MatchmakingJoinQueue(int poolId);
+        public abstract Task<MatchmakingJoinQueueResponse> MatchmakingJoinQueueWithParams(MatchmakingJoinQueueRequest request);
 
         public abstract Task MatchmakingLeaveQueue();
 

--- a/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
+++ b/osu.Game/Online/Multiplayer/OnlineMultiplayerClient.cs
@@ -383,13 +383,13 @@ namespace osu.Game.Online.Multiplayer
             return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingLeaveLobby));
         }
 
-        public override Task MatchmakingJoinQueue(int poolId)
+        public override Task<MatchmakingJoinQueueResponse> MatchmakingJoinQueueWithParams(MatchmakingJoinQueueRequest request)
         {
             if (!IsConnected.Value)
-                return Task.CompletedTask;
+                return Task.FromResult(new MatchmakingJoinQueueResponse());
 
             Debug.Assert(connection != null);
-            return connection.InvokeAsync(nameof(IMatchmakingServer.MatchmakingJoinQueue), poolId);
+            return connection.InvokeAsync<MatchmakingJoinQueueResponse>(nameof(IMatchmakingServer.MatchmakingJoinQueueWithParams), request);
         }
 
         public override Task MatchmakingLeaveQueue()

--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -34,6 +34,9 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("total_score")]
         public long TotalScore { get; set; }
 
+        [JsonProperty("total_score_without_mods")]
+        public long TotalScoreWithoutMods { get; set; }
+
         [JsonProperty("accuracy")]
         public double Accuracy { get; set; }
 

--- a/osu.Game/Online/Rooms/MultiplayerScore.cs
+++ b/osu.Game/Online/Rooms/MultiplayerScore.cs
@@ -34,9 +34,6 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("total_score")]
         public long TotalScore { get; set; }
 
-        [JsonProperty("total_score_without_mods")]
-        public long TotalScoreWithoutMods { get; set; }
-
         [JsonProperty("accuracy")]
         public double Accuracy { get; set; }
 

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Online.Spectator
     public partial class SpectatorScoreProcessor : Component
     {
         /// <summary>
-        /// Whether to use the the total score without mods for display purposes.
+        /// Whether to use the total score without mods for display purposes.
         /// </summary>
         public bool UseTotalScoreWithoutMods { get; set; }
 

--- a/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
+++ b/osu.Game/Online/Spectator/SpectatorScoreProcessor.cs
@@ -14,7 +14,6 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
-using osu.Game.Scoring.Legacy;
 
 namespace osu.Game.Online.Spectator
 {
@@ -25,9 +24,22 @@ namespace osu.Game.Online.Spectator
     public partial class SpectatorScoreProcessor : Component
     {
         /// <summary>
+        /// Whether to use the the total score without mods for display purposes.
+        /// </summary>
+        public bool UseTotalScoreWithoutMods { get; set; }
+
+        /// <summary>
         /// The current total score.
         /// </summary>
         public readonly BindableLong TotalScore = new BindableLong { MinValue = 0 };
+
+        /// <summary>
+        /// The total number of points awarded for the score without including mod multipliers.
+        /// </summary>
+        /// <remarks>
+        /// The purpose of this property is to enable future lossless rebalances of mod multipliers.
+        /// </remarks>
+        public readonly BindableLong TotalScoreWithoutMods = new BindableLong { MinValue = 0 };
 
         /// <summary>
         /// The current accuracy.
@@ -52,9 +64,12 @@ namespace osu.Game.Online.Spectator
         /// <summary>
         /// The applied <see cref="Mod"/>s.
         /// </summary>
-        public IReadOnlyList<Mod> Mods => scoreInfo?.Mods ?? Array.Empty<Mod>();
+        public IReadOnlyList<Mod> Mods => Score?.Mods ?? Array.Empty<Mod>();
 
-        public Func<ScoringMode, long> GetDisplayScore => mode => scoreInfo?.GetDisplayScore(mode) ?? 0;
+        /// <summary>
+        /// The score.
+        /// </summary>
+        public ScoreInfo? Score { get; private set; }
 
         private IClock? referenceClock;
 
@@ -78,7 +93,6 @@ namespace osu.Game.Online.Spectator
         private readonly int userId;
 
         private SpectatorState? spectatorState;
-        private ScoreInfo? scoreInfo;
 
         public SpectatorScoreProcessor(int userId)
         {
@@ -101,13 +115,13 @@ namespace osu.Game.Online.Spectator
         {
             if (!spectatorStates.TryGetValue(userId, out var userState) || userState.BeatmapID == null || userState.RulesetID == null)
             {
-                scoreInfo = null;
+                Score = null;
                 spectatorState = null;
                 replayFrames.Clear();
                 return;
             }
 
-            if (scoreInfo != null)
+            if (Score != null)
                 return;
 
             RulesetInfo? rulesetInfo = rulesetStore.GetRuleset(userState.RulesetID.Value);
@@ -117,7 +131,7 @@ namespace osu.Game.Online.Spectator
             Ruleset ruleset = rulesetInfo.CreateInstance();
 
             spectatorState = userState;
-            scoreInfo = new ScoreInfo
+            Score = new ScoreInfo
             {
                 Ruleset = rulesetInfo,
                 Mods = userState.Mods.Select(m => m.ToMod(ruleset)).ToArray()
@@ -131,7 +145,7 @@ namespace osu.Game.Online.Spectator
 
             Schedule(() =>
             {
-                if (scoreInfo == null)
+                if (Score == null)
                     return;
 
                 replayFrames.Add(new TimedFrame(bundle.Frames.First().Time, bundle.Header));
@@ -141,7 +155,7 @@ namespace osu.Game.Online.Spectator
 
         public void UpdateScore()
         {
-            if (scoreInfo == null || replayFrames.Count == 0)
+            if (Score == null || replayFrames.Count == 0)
                 return;
 
             Debug.Assert(spectatorState != null);
@@ -154,16 +168,18 @@ namespace osu.Game.Online.Spectator
             TimedFrame frame = replayFrames[frameIndex];
             Debug.Assert(frame.Header != null);
 
-            scoreInfo.Accuracy = frame.Header.Accuracy;
-            scoreInfo.MaxCombo = frame.Header.MaxCombo;
-            scoreInfo.Statistics = frame.Header.Statistics;
-            scoreInfo.MaximumStatistics = spectatorState.MaximumStatistics;
-            scoreInfo.TotalScore = frame.Header.TotalScore;
+            Score.Accuracy = frame.Header.Accuracy;
+            Score.MaxCombo = frame.Header.MaxCombo;
+            Score.Statistics = frame.Header.Statistics;
+            Score.MaximumStatistics = spectatorState.MaximumStatistics;
+            Score.TotalScore = frame.Header.TotalScore;
+            Score.TotalScoreWithoutMods = frame.Header.TotalScoreWithoutMods ?? 0;
 
             Accuracy.Value = frame.Header.Accuracy;
             Combo.Value = frame.Header.Combo;
             HighestCombo.Value = frame.Header.MaxCombo;
             TotalScore.Value = frame.Header.TotalScore;
+            TotalScoreWithoutMods.Value = frame.Header.TotalScoreWithoutMods ?? 0;
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -44,7 +44,12 @@ namespace osu.Game.Rulesets.Scoring
         /// <remarks>
         /// Should only be disabled for special cases.
         /// When disabled, <see cref="JudgementProcessor.RevertResult"/> cannot be used.</remarks>
-        internal bool TrackHitEvents = true;
+        internal bool TrackHitEvents { get; set; } = true;
+
+        /// <summary>
+        /// Whether to use the the total score without mods for display purposes.
+        /// </summary>
+        internal bool UseTotalScoreWithoutMods { get; set; }
 
         /// <summary>
         /// Invoked when this <see cref="ScoreProcessor"/> was reset from a replay frame.

--- a/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
+++ b/osu.Game/Rulesets/Scoring/ScoreProcessor.cs
@@ -47,7 +47,7 @@ namespace osu.Game.Rulesets.Scoring
         internal bool TrackHitEvents { get; set; } = true;
 
         /// <summary>
-        /// Whether to use the the total score without mods for display purposes.
+        /// Whether to use the total score without mods for display purposes.
         /// </summary>
         internal bool UseTotalScoreWithoutMods { get; set; }
 

--- a/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
+++ b/osu.Game/Scoring/Legacy/ScoreInfoExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Rooms;
+using osu.Game.Online.Spectator;
 using osu.Game.Rulesets.Scoring;
 
 namespace osu.Game.Scoring.Legacy
@@ -13,18 +14,34 @@ namespace osu.Game.Scoring.Legacy
     public static class ScoreInfoExtensions
     {
         public static long GetDisplayScore(this ScoreProcessor scoreProcessor, ScoringMode mode)
-            => getDisplayScore(scoreProcessor.Ruleset.RulesetInfo.OnlineID, scoreProcessor.TotalScore.Value, mode, scoreProcessor.MaximumStatistics);
+        {
+            if (scoreProcessor.UseTotalScoreWithoutMods)
+                return GetDisplayScore(scoreProcessor.Ruleset.RulesetInfo.OnlineID, scoreProcessor.TotalScoreWithoutMods.Value, mode, scoreProcessor.MaximumStatistics);
+
+            return GetDisplayScore(scoreProcessor.Ruleset.RulesetInfo.OnlineID, scoreProcessor.TotalScore.Value, mode, scoreProcessor.MaximumStatistics);
+        }
+
+        public static long GetDisplayScore(this SpectatorScoreProcessor scoreProcessor, ScoringMode mode)
+        {
+            if (scoreProcessor.Score is not ScoreInfo score)
+                return 0;
+
+            if (scoreProcessor.UseTotalScoreWithoutMods)
+                return GetDisplayScore(score.RulesetID, score.TotalScoreWithoutMods, mode, score.MaximumStatistics);
+
+            return GetDisplayScore(score.RulesetID, score.TotalScore, mode, score.MaximumStatistics);
+        }
 
         public static long GetDisplayScore(this ScoreInfo scoreInfo, ScoringMode mode)
-            => getDisplayScore(scoreInfo.Ruleset.OnlineID, scoreInfo.TotalScore, mode, scoreInfo.MaximumStatistics);
+            => GetDisplayScore(scoreInfo.Ruleset.OnlineID, scoreInfo.TotalScore, mode, scoreInfo.MaximumStatistics);
 
         public static long GetDisplayScore(this SoloScoreInfo soloScoreInfo, ScoringMode mode)
-            => getDisplayScore(soloScoreInfo.RulesetID, soloScoreInfo.TotalScore, mode, soloScoreInfo.MaximumStatistics);
+            => GetDisplayScore(soloScoreInfo.RulesetID, soloScoreInfo.TotalScore, mode, soloScoreInfo.MaximumStatistics);
 
         public static long GetDisplayScore(this MultiplayerScore multiplayerScore, ScoringMode mode)
-            => getDisplayScore(multiplayerScore.RulesetId, multiplayerScore.TotalScore, mode, multiplayerScore.MaximumStatistics);
+            => GetDisplayScore(multiplayerScore.RulesetId, multiplayerScore.TotalScore, mode, multiplayerScore.MaximumStatistics);
 
-        private static long getDisplayScore(int rulesetId, long score, ScoringMode mode, IReadOnlyDictionary<HitResult, int> maximumStatistics)
+        public static long GetDisplayScore(int rulesetId, long score, ScoringMode mode, IReadOnlyDictionary<HitResult, int> maximumStatistics)
         {
             if (mode == ScoringMode.Standardised)
                 return score;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -15,6 +17,7 @@ using osu.Framework.Screens;
 using osu.Game.Database;
 using osu.Game.Graphics;
 using osu.Game.Localisation;
+using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Matchmaking;
 using osu.Game.Online.Matchmaking.Requests;
@@ -22,6 +25,7 @@ using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Intro;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
@@ -36,6 +40,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
     {
         public readonly Bindable<ScreenQueue.MatchmakingScreenState> CurrentState = new Bindable<ScreenQueue.MatchmakingScreenState>();
         public readonly Bindable<MatchmakingPool?> SelectedPool = new Bindable<MatchmakingPool?>();
+        public readonly Bindable<IReadOnlyList<Mod>> SelectedMods = new Bindable<IReadOnlyList<Mod>>([]);
 
         /// <summary>
         /// Timer since the queue was joined.
@@ -74,7 +79,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         /// Joins the matchmaking queue.
         /// </summary>
         /// <param name="pool">The pool to join.</param>
-        public void JoinQueue(MatchmakingPool pool)
+        /// <param name="mods">The requested mods.</param>
+        public void JoinQueue(MatchmakingPool pool, Mod[] mods)
         {
             lastDuelUser = null;
             lastDuelPool = null;
@@ -82,7 +88,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 
             client.MatchmakingJoinQueueWithParams(new MatchmakingJoinQueueRequest
             {
-                PoolId = pool.Id
+                PoolId = pool.Id,
+                Mods = mods.Select(m => new APIMod(m)).ToArray()
             }).FireAndForget();
         }
 
@@ -132,7 +139,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (lastDuelUser != null && lastDuelPool != null)
                 IssueDuel(lastDuelPool, lastDuelUser.Value);
             else if (SelectedPool.Value != null)
-                JoinQueue(SelectedPool.Value);
+                JoinQueue(SelectedPool.Value, SelectedMods.Value.ToArray());
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/QueueController.cs
@@ -80,7 +80,10 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             lastDuelPool = null;
             QueueTimer.Restart();
 
-            client.MatchmakingJoinQueue(pool.Id).FireAndForget();
+            client.MatchmakingJoinQueueWithParams(new MatchmakingJoinQueueRequest
+            {
+                PoolId = pool.Id
+            }).FireAndForget();
         }
 
         /// <summary>

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayFooterButtonFreeMods.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayFooterButtonFreeMods.cs
@@ -1,0 +1,128 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Localisation;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Screens.Footer;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Select;
+using osuTK;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
+{
+    public partial class RankedPlayFooterButtonFreeMods : ScreenFooterButton
+    {
+        public new readonly IBindable<ScreenQueue.MatchmakingScreenState> State = new Bindable<ScreenQueue.MatchmakingScreenState>();
+
+        public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>([]);
+
+        public new Action Action
+        {
+            set => throw new NotSupportedException("The click action is handled by the button itself.");
+        }
+
+        [Resolved]
+        private OsuColour colours { get; set; } = null!;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; } = null!;
+
+        private Container modsWedge = null!;
+
+        public RankedPlayFooterButtonFreeMods(ModSelectOverlay overlay)
+            : base(overlay)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Text = OnlinePlayStrings.FooterButtonFreemods;
+            TooltipText = MultiplayerMatchStrings.FreeModsButtonTooltip;
+            Icon = FontAwesome.Solid.ExchangeAlt;
+            AccentColour = colours.Lime1;
+
+            Add(modsWedge = new InputBlockingContainer
+            {
+                Y = -5f,
+                Depth = float.MaxValue,
+                Origin = Anchor.BottomLeft,
+                Shear = OsuGame.SHEAR,
+                CornerRadius = CORNER_RADIUS,
+                Size = new Vector2(BUTTON_WIDTH, FooterButtonMods.BAR_HEIGHT),
+                Masking = true,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Shadow,
+                    Radius = 4,
+                    // Figma says 50% opacity, but it does not match up visually if taken at face value, and looks bad.
+                    Colour = Colour4.Black.Opacity(0.25f),
+                    Offset = new Vector2(0, 2),
+                },
+                Alpha = 0,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = colourProvider.Background4,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    new Container
+                    {
+                        CornerRadius = CORNER_RADIUS,
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        Children = new Drawable[]
+                        {
+                            new ModDisplay(showExtendedInformation: true)
+                            {
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Shear = -OsuGame.SHEAR,
+                                Scale = new Vector2(0.5f),
+                                Current = { BindTarget = Mods },
+                                ExpansionMode = ExpansionMode.AlwaysContracted,
+                            },
+                        }
+                    },
+                }
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            State.BindValueChanged(s =>
+            {
+                if (s.NewValue == ScreenQueue.MatchmakingScreenState.Idle)
+                    Enabled.Value = true;
+                else
+                {
+                    Enabled.Value = false;
+                    Overlay?.Hide();
+                }
+            }, true);
+
+            Mods.BindValueChanged(m =>
+            {
+                if (m.NewValue.Count == 0)
+                    modsWedge.FadeOut(300, Easing.OutExpo);
+                else
+                    modsWedge.FadeIn(300, Easing.OutExpo);
+            }, true);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayModSelectOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayModSelectOverlay.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
+{
+    public partial class RankedPlayModSelectOverlay : UserModSelectOverlay
+    {
+        public new Func<Mod, bool> IsValidMod
+        {
+            get => base.IsValidMod;
+            set => base.IsValidMod = m => m.UserPlayable && value.Invoke(m);
+        }
+
+        public RankedPlayModSelectOverlay()
+            : base(OverlayColourScheme.Plum)
+        {
+            IsValidMod = _ => true;
+        }
+
+        public override VisibilityContainer CreateFooterContent() => new RankedPlayModSelectFooterContent(this)
+        {
+            Beatmap = { BindTarget = Beatmap },
+            ActiveMods = { BindTarget = ActiveMods },
+            Ruleset = { BindTarget = Ruleset },
+        };
+
+        public partial class RankedPlayModSelectFooterContent : ModSelectFooterContent
+        {
+            protected override bool ShowModEffects => false;
+
+            public RankedPlayModSelectFooterContent(RankedPlayModSelectOverlay overlay)
+                : base(overlay)
+            {
+            }
+
+            protected override IEnumerable<ShearedButton> CreateButtons() => [];
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayModSelectOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/RankedPlayModSelectOverlay.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -13,16 +12,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
 {
     public partial class RankedPlayModSelectOverlay : UserModSelectOverlay
     {
-        public new Func<Mod, bool> IsValidMod
-        {
-            get => base.IsValidMod;
-            set => base.IsValidMod = m => m.UserPlayable && value.Invoke(m);
-        }
-
         public RankedPlayModSelectOverlay()
             : base(OverlayColourScheme.Plum)
         {
-            IsValidMod = _ => true;
+            // Synchronise with server.
+            IsValidMod = m =>
+            {
+                switch (m)
+                {
+                    case ModHidden:
+                    case ModTraceable:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            };
         }
 
         public override VisibilityContainer CreateFooterContent() => new RankedPlayModSelectFooterContent(this)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -17,7 +17,6 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
@@ -30,7 +29,6 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
-using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
@@ -39,15 +37,12 @@ using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Overlays;
-using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
-using osu.Game.Screens.Play.HUD;
-using osu.Game.Screens.Select;
 using osuTK;
 using osuTK.Graphics;
 
@@ -955,144 +950,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 base.Update();
 
                 Text = queue.QueueTimer.Elapsed.ToString(@"mm\:ss");
-            }
-        }
-
-        private partial class RankedPlayModSelectOverlay : UserModSelectOverlay
-        {
-            public new Func<Mod, bool> IsValidMod
-            {
-                get => base.IsValidMod;
-                set => base.IsValidMod = m => m.UserPlayable && value.Invoke(m);
-            }
-
-            public RankedPlayModSelectOverlay()
-                : base(OverlayColourScheme.Plum)
-            {
-                IsValidMod = _ => true;
-            }
-
-            public override VisibilityContainer CreateFooterContent() => new RankedPlayModSelectFooterContent(this)
-            {
-                Beatmap = { BindTarget = Beatmap },
-                ActiveMods = { BindTarget = ActiveMods },
-                Ruleset = { BindTarget = Ruleset },
-            };
-
-            public partial class RankedPlayModSelectFooterContent : ModSelectFooterContent
-            {
-                protected override bool ShowModEffects => false;
-
-                public RankedPlayModSelectFooterContent(RankedPlayModSelectOverlay overlay)
-                    : base(overlay)
-                {
-                }
-
-                protected override IEnumerable<ShearedButton> CreateButtons() => [];
-            }
-        }
-
-        private partial class RankedPlayFooterButtonFreeMods : ScreenFooterButton
-        {
-            public new readonly IBindable<MatchmakingScreenState> State = new Bindable<MatchmakingScreenState>();
-
-            public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>([]);
-
-            public new Action Action
-            {
-                set => throw new NotSupportedException("The click action is handled by the button itself.");
-            }
-
-            [Resolved]
-            private OsuColour colours { get; set; } = null!;
-
-            [Resolved]
-            private OverlayColourProvider colourProvider { get; set; } = null!;
-
-            private Container modsWedge = null!;
-
-            public RankedPlayFooterButtonFreeMods(ModSelectOverlay overlay)
-                : base(overlay)
-            {
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
-                Text = OnlinePlayStrings.FooterButtonFreemods;
-                TooltipText = MultiplayerMatchStrings.FreeModsButtonTooltip;
-                Icon = FontAwesome.Solid.ExchangeAlt;
-                AccentColour = colours.Lime1;
-
-                Add(modsWedge = new InputBlockingContainer
-                {
-                    Y = -5f,
-                    Depth = float.MaxValue,
-                    Origin = Anchor.BottomLeft,
-                    Shear = OsuGame.SHEAR,
-                    CornerRadius = CORNER_RADIUS,
-                    Size = new Vector2(BUTTON_WIDTH, FooterButtonMods.BAR_HEIGHT),
-                    Masking = true,
-                    EdgeEffect = new EdgeEffectParameters
-                    {
-                        Type = EdgeEffectType.Shadow,
-                        Radius = 4,
-                        // Figma says 50% opacity, but it does not match up visually if taken at face value, and looks bad.
-                        Colour = Colour4.Black.Opacity(0.25f),
-                        Offset = new Vector2(0, 2),
-                    },
-                    Alpha = 0,
-                    Children = new Drawable[]
-                    {
-                        new Box
-                        {
-                            Colour = colourProvider.Background4,
-                            RelativeSizeAxes = Axes.Both,
-                        },
-                        new Container
-                        {
-                            CornerRadius = CORNER_RADIUS,
-                            RelativeSizeAxes = Axes.Both,
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new ModDisplay(showExtendedInformation: true)
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Shear = -OsuGame.SHEAR,
-                                    Scale = new Vector2(0.5f),
-                                    Current = { BindTarget = Mods },
-                                    ExpansionMode = ExpansionMode.AlwaysContracted,
-                                },
-                            }
-                        },
-                    }
-                });
-            }
-
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                State.BindValueChanged(s =>
-                {
-                    if (s.NewValue == MatchmakingScreenState.Idle)
-                        Enabled.Value = true;
-                    else
-                    {
-                        Enabled.Value = false;
-                        Overlay?.Hide();
-                    }
-                }, true);
-
-                Mods.BindValueChanged(m =>
-                {
-                    if (m.NewValue.Count == 0)
-                        modsWedge.FadeOut(300, Easing.OutExpo);
-                    else
-                        modsWedge.FadeIn(300, Easing.OutExpo);
-                }, true);
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -17,6 +17,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
@@ -29,6 +30,7 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Chat;
@@ -37,11 +39,15 @@ using osu.Game.Online.Matchmaking.Requests;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Mods;
 using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Screens.Footer;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Match;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Select;
 using osuTK;
 using osuTK.Graphics;
 
@@ -55,6 +61,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         public override bool ShowFooter => true;
 
         public override bool? ApplyModTrackAdjustments => false;
+
+        public override bool DisallowExternalBeatmapRulesetChanges => true;
 
         private Container mainContent = null!;
         private CloudVisualisation cloud = null!;
@@ -74,19 +82,25 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private UserLookupCache userLookupCache { get; set; } = null!;
 
         [Resolved]
-        private IBindable<RulesetInfo> ruleset { get; set; } = null!;
+        private MusicController music { get; set; } = null!;
 
         [Resolved]
-        private MusicController music { get; set; } = null!;
+        private RulesetStore rulesets { get; set; } = null!;
 
         [Resolved]
         private DashboardOverlay? dashboardOverlay { get; set; }
 
-        private readonly IBindable<MatchmakingScreenState> currentState = new Bindable<MatchmakingScreenState>();
+        [Resolved]
+        private IOverlayManager? overlayManager { get; set; }
 
+        private readonly IBindable<MatchmakingScreenState> currentState = new Bindable<MatchmakingScreenState>();
         private readonly Bindable<MatchmakingPool[]?> availablePools = new Bindable<MatchmakingPool[]?>();
         private readonly Bindable<MatchmakingPool?> selectedPool = new Bindable<MatchmakingPool?>();
+        private readonly Bindable<IReadOnlyList<Mod>> selectedMods = new Bindable<IReadOnlyList<Mod>>();
+
         private readonly MatchmakingPoolType poolType;
+
+        private readonly RankedPlayModSelectOverlay modSelectOverlay;
 
         private CancellationTokenSource userLookupCancellation = new CancellationTokenSource();
 
@@ -98,15 +112,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
         private DrawableSample waitingLoop = null!;
         private ScheduledDelegate? pushScreenDelegate;
 
-        private int? userRating;
-
         private GridContainer mainGrid = null!;
-
         private IBindable<bool> isConnected = null!;
+
+        private int? userRating;
+        private IDisposable? modSelectOverlayRegistration;
 
         public ScreenQueue(MatchmakingPoolType poolType)
         {
             this.poolType = poolType;
+
+            modSelectOverlay = new RankedPlayModSelectOverlay
+            {
+                SelectedMods = { BindTarget = selectedMods },
+                IsValidMod = m => m is ModHidden,
+            };
         }
 
         [BackgroundDependencyLoader]
@@ -131,7 +151,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                         {
                             Horizontal = 20,
                             Top = 20,
-                            Bottom = ScreenFooter.HEIGHT + 20
+                            Bottom = ScreenFooter.HEIGHT + 50
                         },
                         RowDimensions =
                         [
@@ -361,6 +381,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             experimentalText.AddText(" and provide any ");
             experimentalText.AddLink("feedback", @"https://osu.ppy.sh/community/forums/topics/2198397", sp => sp.Font = sp.Font.With(weight: FontWeight.SemiBold));
             experimentalText.AddText(" on the osu! forums!");
+
+            LoadComponent(modSelectOverlay);
         }
 
         protected override void LoadComplete()
@@ -387,7 +409,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             currentState.BindValueChanged(s => SetState(s.NewValue));
 
             selectedPool.BindTo(queue.SelectedPool);
-            selectedPool.BindValueChanged(e => refreshLobbyData());
+            selectedPool.BindValueChanged(onSelectedPoolChanged, true);
+
+            selectedMods.BindTo(queue.SelectedMods);
 
             isConnected = client.IsConnected.GetBoundCopy();
             isConnected.BindValueChanged(connected => Schedule(() =>
@@ -403,6 +427,19 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     clearLobbyData();
                 }
             }), true);
+
+            modSelectOverlayRegistration = overlayManager?.RegisterBlockingOverlay(modSelectOverlay);
+        }
+
+        private void onSelectedPoolChanged(ValueChangedEvent<MatchmakingPool?> e)
+        {
+            refreshLobbyData();
+
+            if (e.NewValue != null)
+                Ruleset.Value = rulesets.GetRuleset(e.NewValue.RulesetId);
+
+            if (e.NewValue?.Equals(e.OldValue) != true)
+                selectedMods.Value = [];
         }
 
         private async Task populateAvailablePools()
@@ -414,7 +451,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 availablePools.Value = pools;
 
                 // Default to the currently queueing pool, or fallback to the user's ruleset for the initial pool selection.
-                selectedPool.Value ??= pools.FirstOrDefault(p => p.RulesetId == ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
+                selectedPool.Value ??= pools.FirstOrDefault(p => p.RulesetId == Ruleset.Value.OnlineID) ?? pools.FirstOrDefault();
             });
         }
 
@@ -528,6 +565,8 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             if (base.OnExiting(e))
                 return true;
 
+            modSelectOverlay.Hide();
+
             stopWaitingLoopPlayback();
 
             switch (currentState.Value)
@@ -546,6 +585,17 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     // Block exit until it's initiated from inside the matchmaking screen.
                     return true;
             }
+        }
+
+        public override bool OnBackButton()
+        {
+            if (modSelectOverlay.State.Value == Visibility.Visible)
+            {
+                modSelectOverlay.Hide();
+                return true;
+            }
+
+            return base.OnBackButton();
         }
 
         public void SetState(MatchmakingScreenState newState)
@@ -593,7 +643,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                                 Action = () =>
                                 {
                                     Debug.Assert(selectedPool.Value != null);
-                                    queue.JoinQueue(selectedPool.Value);
+                                    queue.JoinQueue(selectedPool.Value, selectedMods.Value.ToArray());
                                 },
                                 Text = "Begin queueing",
                             },
@@ -747,9 +797,20 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             }
         }
 
+        public override IReadOnlyList<ScreenFooterButton> CreateFooterButtons() =>
+        [
+            new RankedPlayFooterButtonFreeMods(modSelectOverlay)
+            {
+                State = { BindTarget = currentState },
+                Mods = { BindTarget = selectedMods }
+            }
+        ];
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
+            modSelectOverlayRegistration?.Dispose();
 
             stopWaitingLoopPlayback();
 
@@ -894,6 +955,144 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                 base.Update();
 
                 Text = queue.QueueTimer.Elapsed.ToString(@"mm\:ss");
+            }
+        }
+
+        private partial class RankedPlayModSelectOverlay : UserModSelectOverlay
+        {
+            public new Func<Mod, bool> IsValidMod
+            {
+                get => base.IsValidMod;
+                set => base.IsValidMod = m => m.UserPlayable && value.Invoke(m);
+            }
+
+            public RankedPlayModSelectOverlay()
+                : base(OverlayColourScheme.Plum)
+            {
+                IsValidMod = _ => true;
+            }
+
+            public override VisibilityContainer CreateFooterContent() => new RankedPlayModSelectFooterContent(this)
+            {
+                Beatmap = { BindTarget = Beatmap },
+                ActiveMods = { BindTarget = ActiveMods },
+                Ruleset = { BindTarget = Ruleset },
+            };
+
+            public partial class RankedPlayModSelectFooterContent : ModSelectFooterContent
+            {
+                protected override bool ShowModEffects => false;
+
+                public RankedPlayModSelectFooterContent(RankedPlayModSelectOverlay overlay)
+                    : base(overlay)
+                {
+                }
+
+                protected override IEnumerable<ShearedButton> CreateButtons() => [];
+            }
+        }
+
+        private partial class RankedPlayFooterButtonFreeMods : ScreenFooterButton
+        {
+            public new readonly IBindable<MatchmakingScreenState> State = new Bindable<MatchmakingScreenState>();
+
+            public readonly Bindable<IReadOnlyList<Mod>> Mods = new Bindable<IReadOnlyList<Mod>>([]);
+
+            public new Action Action
+            {
+                set => throw new NotSupportedException("The click action is handled by the button itself.");
+            }
+
+            [Resolved]
+            private OsuColour colours { get; set; } = null!;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            private Container modsWedge = null!;
+
+            public RankedPlayFooterButtonFreeMods(ModSelectOverlay overlay)
+                : base(overlay)
+            {
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Text = OnlinePlayStrings.FooterButtonFreemods;
+                TooltipText = MultiplayerMatchStrings.FreeModsButtonTooltip;
+                Icon = FontAwesome.Solid.ExchangeAlt;
+                AccentColour = colours.Lime1;
+
+                Add(modsWedge = new InputBlockingContainer
+                {
+                    Y = -5f,
+                    Depth = float.MaxValue,
+                    Origin = Anchor.BottomLeft,
+                    Shear = OsuGame.SHEAR,
+                    CornerRadius = CORNER_RADIUS,
+                    Size = new Vector2(BUTTON_WIDTH, FooterButtonMods.BAR_HEIGHT),
+                    Masking = true,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Shadow,
+                        Radius = 4,
+                        // Figma says 50% opacity, but it does not match up visually if taken at face value, and looks bad.
+                        Colour = Colour4.Black.Opacity(0.25f),
+                        Offset = new Vector2(0, 2),
+                    },
+                    Alpha = 0,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Colour = colourProvider.Background4,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        new Container
+                        {
+                            CornerRadius = CORNER_RADIUS,
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new ModDisplay(showExtendedInformation: true)
+                                {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Shear = -OsuGame.SHEAR,
+                                    Scale = new Vector2(0.5f),
+                                    Current = { BindTarget = Mods },
+                                    ExpansionMode = ExpansionMode.AlwaysContracted,
+                                },
+                            }
+                        },
+                    }
+                });
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                State.BindValueChanged(s =>
+                {
+                    if (s.NewValue == MatchmakingScreenState.Idle)
+                        Enabled.Value = true;
+                    else
+                    {
+                        Enabled.Value = false;
+                        Overlay?.Hide();
+                    }
+                }, true);
+
+                Mods.BindValueChanged(m =>
+                {
+                    if (m.NewValue.Count == 0)
+                        modsWedge.FadeOut(300, Easing.OutExpo);
+                    else
+                        modsWedge.FadeIn(300, Easing.OutExpo);
+                }, true);
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -120,7 +120,6 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             modSelectOverlay = new RankedPlayModSelectOverlay
             {
                 SelectedMods = { BindTarget = selectedMods },
-                IsValidMod = m => m is ModHidden,
             };
         }
 

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayUserDisplay.cs
@@ -23,6 +23,8 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
+using osu.Game.Rulesets;
+using osu.Game.Screens.Play.HUD;
 using osu.Game.Users.Drawables;
 using osuTK;
 using osuTK.Graphics;
@@ -48,11 +50,15 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
         private OsuSpriteText beatmapState = null!;
         private OsuSpriteText damageMultiplierText = null!;
         private OsuSpriteText lastStandText = null!;
+        private ModDisplay modDisplay = null!;
 
         private BeatmapAvailability availability = BeatmapAvailability.Unknown();
 
         [Resolved]
         private MultiplayerClient client { get; set; } = null!;
+
+        [Resolved]
+        private RulesetStore rulesetStore { get; set; } = null!;
 
         [Resolved]
         private RankedPlayCornerPiece? cornerPiece { get; set; }
@@ -83,30 +89,47 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
                 ? Anchor.CentreLeft
                 : Anchor.CentreRight;
 
+            var modsAnchor = (contentAnchor & Anchor.x0) != 0
+                ? Anchor.TopCentre
+                : Anchor.BottomCentre;
+
             InternalChildren =
             [
-                new CircularContainer
+                new Container
                 {
-                    Name = "Avatar",
                     Size = new Vector2(72),
-                    Masking = true,
                     Anchor = contentAnchor,
                     Origin = contentAnchor,
                     Children =
                     [
-                        new Box
+                        new CircularContainer
                         {
+                            Name = "Avatar",
                             RelativeSizeAxes = Axes.Both,
-                            Colour = colourScheme.Surface,
-                            Alpha = 0.5f,
+                            Masking = true,
+                            Children =
+                            [
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = colourScheme.Surface,
+                                    Alpha = 0.5f,
+                                },
+                                grayScaleContainer = new BufferedContainer(cachedFrameBuffer: false, pixelSnapping: true)
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Child = new UpdateableAvatar(user)
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                    }
+                                }
+                            ]
                         },
-                        grayScaleContainer = new BufferedContainer(cachedFrameBuffer: false, pixelSnapping: true)
+                        modDisplay = new ModDisplay(false)
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Child = new UpdateableAvatar(user)
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                            }
+                            Anchor = modsAnchor,
+                            Origin = Anchor.Centre,
+                            Scale = new Vector2(0.5f)
                         }
                     ]
                 },
@@ -198,13 +221,27 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
             });
 
             client.RoomUpdated += onRoomUpdated;
+            client.UserModsChanged += onUserModsChanged;
+
             onRoomUpdated();
+
+            foreach (var roomUser in client.Room?.Users ?? [])
+                onUserModsChanged(roomUser);
         }
 
         private void onRoomUpdated()
         {
             updateBeatmapState();
             updateDamageMultiplier();
+        }
+
+        private void onUserModsChanged(MultiplayerRoomUser roomUser)
+        {
+            if (roomUser.UserID != user.Id)
+                return;
+
+            Ruleset ruleset = rulesetStore.GetRuleset(client.Room!.CurrentPlaylistItem.RulesetID)!.CreateInstance();
+            modDisplay.Current.Value = roomUser.Mods.Select(m => m.ToMod(ruleset)).ToArray();
         }
 
         private void updateBeatmapState()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/GameplayWarmupScreen.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 
             globalBeatmap.Value = beatmapManager.GetWorkingBeatmap(localBeatmap);
             globalRuleset.Value = ruleset;
-            globalMods.Value = item.RequiredMods.Select(m => m.ToMod(rulesetInstance)).ToArray();
+            globalMods.Value = Client.LocalUser!.Mods.Concat(item.RequiredMods).Select(m => m.ToMod(rulesetInstance)).ToArray();
 
             // Play the new track from its preview point.
             globalBeatmap.Value.PrepareTrackForPreview(false);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayPlayer.cs
@@ -11,7 +11,7 @@ using osu.Game.Screens.OnlinePlay.Multiplayer;
 
 namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
-    public class RankedPlayPlayer : MultiplayerPlayer
+    public partial class RankedPlayPlayer : MultiplayerPlayer
     {
         public RankedPlayPlayer(MultiplayerRoom room)
             : base(new Room(room), new PlaylistItem(room.CurrentPlaylistItem), room.Users.ToArray(), showFailingOverlay: false, useTotalScoreWithoutMods: true)

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayPlayer.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Threading.Tasks;
+using osu.Framework.Screens;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Scoring;
+using osu.Game.Screens.OnlinePlay.Multiplayer;
+
+namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
+{
+    public class RankedPlayPlayer : MultiplayerPlayer
+    {
+        public RankedPlayPlayer(MultiplayerRoom room)
+            : base(new Room(room), new PlaylistItem(room.CurrentPlaylistItem), room.Users.ToArray(), showFailingOverlay: false, useTotalScoreWithoutMods: true)
+        {
+        }
+
+        protected override async Task PrepareScoreForResultsAsync(Score score)
+        {
+            await base.PrepareScoreForResultsAsync(score).ConfigureAwait(false);
+
+            Scheduler.Add(() =>
+            {
+                if (this.IsCurrentScreen())
+                    this.Exit();
+            });
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -22,13 +22,11 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
-using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Components;
-using osu.Game.Screens.OnlinePlay.Matchmaking.Match.Gameplay;
 using osu.Game.Screens.OnlinePlay.Matchmaking.Queue;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Card;
 using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components;
@@ -300,7 +298,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private void onLoadRequested() => Scheduler.Add(() =>
         {
             sampleStart?.Play();
-            this.Push(new MultiplayerPlayerLoader(() => new ScreenGameplay(new Room(room), new PlaylistItem(client.Room!.CurrentPlaylistItem), room.Users.ToArray())));
+            this.Push(new MultiplayerPlayerLoader(() => new RankedPlayPlayer(room)));
         });
 
         private void onStageChanged(RankedPlayStage stage)

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -52,17 +52,19 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         /// <param name="playlistItem">The playlist item to be played.</param>
         /// <param name="users">The users which are participating in this game.</param>
         /// <param name="showFailingOverlay">Whether to show the red failing overlay.</param>
-        public MultiplayerPlayer(Room room, PlaylistItem playlistItem, MultiplayerRoomUser[] users, bool showFailingOverlay = true)
+        /// <param name="useTotalScoreWithoutMods">Whether to use the the total score without mods for display purposes.</param>
+        public MultiplayerPlayer(Room room, PlaylistItem playlistItem, MultiplayerRoomUser[] users, bool showFailingOverlay = true, bool useTotalScoreWithoutMods = false)
             : base(room, playlistItem, new PlayerConfiguration
             {
                 AllowPause = false,
                 AllowRestart = false,
                 AutomaticallySkipIntro = room.AutoSkip,
                 ShowLeaderboard = true,
-                ShowFailingOverlay = showFailingOverlay
+                ShowFailingOverlay = showFailingOverlay,
+                UseTotalScoreWithoutMods = useTotalScoreWithoutMods
             })
         {
-            leaderboardProvider = new MultiplayerLeaderboardProvider(users);
+            leaderboardProvider = new MultiplayerLeaderboardProvider(users, useTotalScoreWithoutMods);
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game/Screens/Play/Leaderboards/MultiSpectatorLeaderboardProvider.cs
+++ b/osu.Game/Screens/Play/Leaderboards/MultiSpectatorLeaderboardProvider.cs
@@ -10,7 +10,7 @@ namespace osu.Game.Screens.Play.Leaderboards
     public partial class MultiSpectatorLeaderboardProvider : MultiplayerLeaderboardProvider
     {
         public MultiSpectatorLeaderboardProvider(MultiplayerRoomUser[] users)
-            : base(users)
+            : base(users, false)
         {
         }
 

--- a/osu.Game/Screens/Play/Leaderboards/MultiplayerLeaderboardProvider.cs
+++ b/osu.Game/Screens/Play/Leaderboards/MultiplayerLeaderboardProvider.cs
@@ -38,6 +38,7 @@ namespace osu.Game.Screens.Play.Leaderboards
         public bool HasTeams => TeamScores.Count > 0;
 
         private readonly MultiplayerRoomUser[] users;
+        private readonly bool useTotalScoreWithoutMods;
 
         private readonly Bindable<ScoringMode> scoringMode = new Bindable<ScoringMode>();
         private readonly IBindableList<int> playingUserIds = new BindableList<int>();
@@ -56,9 +57,10 @@ namespace osu.Game.Screens.Play.Leaderboards
 
         private readonly Cached sorting = new Cached();
 
-        public MultiplayerLeaderboardProvider(MultiplayerRoomUser[] users)
+        public MultiplayerLeaderboardProvider(MultiplayerRoomUser[] users, bool useTotalScoreWithoutMods)
         {
             this.users = users;
+            this.useTotalScoreWithoutMods = useTotalScoreWithoutMods;
         }
 
         [BackgroundDependencyLoader]
@@ -69,6 +71,7 @@ namespace osu.Game.Screens.Play.Leaderboards
             foreach (var user in users)
             {
                 var scoreProcessor = new SpectatorScoreProcessor(user.UserID);
+                scoreProcessor.UseTotalScoreWithoutMods = useTotalScoreWithoutMods;
                 scoreProcessor.Mode.BindTo(scoringMode);
                 scoreProcessor.TotalScore.BindValueChanged(_ => Scheduler.AddOnce(updateTotals));
                 AddInternal(scoreProcessor);

--- a/osu.Game/Screens/Play/Leaderboards/MultiplayerLeaderboardProvider.cs
+++ b/osu.Game/Screens/Play/Leaderboards/MultiplayerLeaderboardProvider.cs
@@ -188,7 +188,8 @@ namespace osu.Game.Screens.Play.Leaderboards
                 return;
 
             var orderedByScore = scores
-                                 .OrderByDescending(i => i.TotalScore.Value)
+                                 // Some implementations override GetDisplayScore (see: SpectatorScoreProcessor.UseTotalScoreWithoutMods).
+                                 .OrderByDescending(i => i.GetDisplayScore(ScoringMode.Standardised))
                                  .ThenBy(i => i.TotalScoreTiebreaker)
                                  .ToList();
 

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -258,6 +258,7 @@ namespace osu.Game.Screens.Play
                 dependencies.CacheAs(scrollingRuleset.ScrollingInfo);
 
             ScoreProcessor = ruleset.CreateScoreProcessor();
+            ScoreProcessor.UseTotalScoreWithoutMods = Configuration.UseTotalScoreWithoutMods;
             ScoreProcessor.Mods.Value = gameplayMods;
             ScoreProcessor.ApplyBeatmap(playableBeatmap);
 

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -44,5 +44,10 @@ namespace osu.Game.Screens.Play
         /// Whether to show the red failing overlay.
         /// </summary>
         public bool ShowFailingOverlay { get; set; } = true;
+
+        /// <summary>
+        /// Whether to use the the total score without mods for display purposes.
+        /// </summary>
+        public bool UseTotalScoreWithoutMods { get; set; }
     }
 }

--- a/osu.Game/Screens/Play/PlayerConfiguration.cs
+++ b/osu.Game/Screens/Play/PlayerConfiguration.cs
@@ -46,7 +46,7 @@ namespace osu.Game.Screens.Play
         public bool ShowFailingOverlay { get; set; } = true;
 
         /// <summary>
-        /// Whether to use the the total score without mods for display purposes.
+        /// Whether to use the total score without mods for display purposes.
         /// </summary>
         public bool UseTotalScoreWithoutMods { get; set; }
     }

--- a/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
+++ b/osu.Game/Tests/Visual/Multiplayer/TestMultiplayerClient.cs
@@ -930,10 +930,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
             return Task.CompletedTask;
         }
 
-        public override async Task MatchmakingJoinQueue(int poolId)
+        public override async Task<MatchmakingJoinQueueResponse> MatchmakingJoinQueueWithParams(MatchmakingJoinQueueRequest request)
         {
             await ((IMatchmakingClient)this).MatchmakingQueueJoined().ConfigureAwait(false);
             await ((IMatchmakingClient)this).MatchmakingQueueStatusChanged(new MatchmakingQueueStatus.Searching()).ConfigureAwait(false);
+
+            return new MatchmakingJoinQueueResponse();
         }
 
         public override async Task MatchmakingLeaveQueue()


### PR DESCRIPTION
See also: https://github.com/ppy/osu-server-spectator/pull/522

Adds accessibility mods (HD, TC, CO, FI) to ranked play. Still called "free mods" to not introduce some new (possibly confusing) naming scheme.

The mods are selected _once_ by the player prior to queueing up, and last for the entire duration of the match. I feel like this is more appropriate to put players on an even playing field, rather than having players effectively cheese their way out of certain mechanics.

To facilitate this,`IMultiplayerClient.MatchmakingJoinQueue()` has been changed to a method that supports a complex params object that now includes the selected mods.

Queue selection screen:
<img width="380" height="347" alt="Screenshot 2026-07-02 at 16 55 17" src="https://github.com/user-attachments/assets/4001a0d5-1a43-4b56-be6b-6cbcc7f7d2f5" />

In the room:
| | |
| --- | --- |
| <img width="224" height="84" alt="Screenshot 2026-07-02 at 15 38 37" src="https://github.com/user-attachments/assets/933f4487-5764-472b-bee4-6b8aa216b3a2" /> | <img width="222" height="86" alt="Screenshot 2026-07-02 at 15 38 43" src="https://github.com/user-attachments/assets/f0484737-7f1f-42f5-853b-0e5eebff53bd" /> |
