### PR TITLE
Add presets to slider velocity control

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectDifficultyPointAdjustments.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -142,6 +143,75 @@ namespace osu.Game.Tests.Visual.Editing
             setVelocityViaPopover(3);
             hitObjectHasVelocity(0, 3);
             hitObjectHasVelocity(1, 3);
+        }
+
+        [Test]
+        public void TestPresetInteractions()
+        {
+            clickDifficultyPiece(0);
+            AddAssert("three presets displayed",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Select(b => b.Velocity),
+                () => Is.EquivalentTo([0.75d, 1d, 1.5d]));
+            AddAssert("one preset selected",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Count(b => b.Current.Value == TernaryState.True),
+                () => Is.EqualTo(1));
+            AddAssert("selected preset is 1.0x",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Single(b => b.Current.Value == TernaryState.True).Velocity,
+                () => Is.EqualTo(1));
+
+            AddStep("press first preset", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            hitObjectHasVelocity(0, 0.75);
+
+            dismissPopover();
+
+            AddStep("select both objects", () => EditorBeatmap.SelectedHitObjects.AddRange(EditorBeatmap.HitObjects));
+            clickDifficultyPiece(0);
+            AddAssert("three presets displayed",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Select(b => b.Velocity),
+                () => Is.EquivalentTo([0.75d, 1d, 1.5d]));
+            AddAssert("no preset fully selected",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Count(b => b.Current.Value == TernaryState.True),
+                () => Is.EqualTo(0));
+            AddAssert("one preset indeterminate",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Count(b => b.Current.Value == TernaryState.Indeterminate),
+                () => Is.EqualTo(1));
+
+            AddStep("remove second preset", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().ElementAt(1));
+                InputManager.Click(MouseButton.Middle);
+            });
+            AddAssert("two presets displayed",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Select(b => b.Velocity),
+                () => Is.EquivalentTo([0.75d, 1.5d]));
+            hitObjectHasVelocity(0, 0.75);
+            hitObjectHasVelocity(1, 2);
+
+            AddStep("press last preset", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Last());
+                InputManager.Click(MouseButton.Left);
+            });
+            hitObjectHasVelocity(0, 1.5);
+            hitObjectHasVelocity(1, 1.5);
+
+            setVelocityViaPopover(2);
+            hitObjectHasVelocity(0, 2);
+            hitObjectHasVelocity(1, 2);
+
+            AddStep("add preset", () =>
+            {
+                var popover = this.ChildrenOfType<DifficultyPointPiece.DifficultyEditPopover>().SingleOrDefault();
+                InputManager.MoveMouseTo(popover.ChildrenOfType<RoundedButton>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("three presets displayed",
+                () => this.ChildrenOfType<SliderVelocityAdjustmentControl.SliderVelocityPresetTernaryButton>().Select(b => b.Velocity),
+                () => Is.EquivalentTo([0.75d, 1.5d, 2d]));
         }
 
         private void clickDifficultyPiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} difficulty piece", () =>

--- a/osu.Game/Beatmaps/Beatmap.cs
+++ b/osu.Game/Beatmaps/Beatmap.cs
@@ -146,6 +146,8 @@ namespace osu.Game.Beatmaps
 
         public int[] Bookmarks { get; set; } = Array.Empty<int>();
 
+        public double[] SliderVelocityPresets { get; set; } = [0.75, 1, 1.5];
+
         public int BeatmapVersion { get; set; } = LegacyBeatmapEncoder.FIRST_LAZER_VERSION;
 
         IBeatmap IBeatmap.Clone() => Clone();

--- a/osu.Game/Beatmaps/BeatmapConverter.cs
+++ b/osu.Game/Beatmaps/BeatmapConverter.cs
@@ -85,6 +85,7 @@ namespace osu.Game.Beatmaps
             beatmap.Countdown = original.Countdown;
             beatmap.CountdownOffset = original.CountdownOffset;
             beatmap.Bookmarks = original.Bookmarks;
+            beatmap.SliderVelocityPresets = original.SliderVelocityPresets;
             beatmap.BeatmapVersion = original.BeatmapVersion;
 
             return beatmap;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -321,6 +321,14 @@ namespace osu.Game.Beatmaps.Formats
                     }).Where(p => p.result).Select(p => p.val).ToArray();
                     break;
 
+                case @"VelocityPresets":
+                    beatmap.SliderVelocityPresets = pair.Value.Split(',').Select(v =>
+                    {
+                        bool result = double.TryParse(v, out double val);
+                        return new { result, val };
+                    }).Where(p => p.result).Select(p => p.val).ToArray();
+                    break;
+
                 case @"DistanceSpacing":
                     beatmap.DistanceSpacing = Math.Max(0, Parsing.ParseDouble(pair.Value));
                     break;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine(FormattableString.Invariant($"BeatDivisor: {beatmap.BeatmapInfo.BeatDivisor}"));
             writer.WriteLine(FormattableString.Invariant($"GridSize: {beatmap.GridSize}"));
             writer.WriteLine(FormattableString.Invariant($"TimelineZoom: {beatmap.TimelineZoom}"));
+            writer.WriteLine(FormattableString.Invariant($@"VelocityPresets: {string.Join(',', beatmap.SliderVelocityPresets)}"));
         }
 
         private void handleMetadata(TextWriter writer)

--- a/osu.Game/Beatmaps/IBeatmap.cs
+++ b/osu.Game/Beatmaps/IBeatmap.cs
@@ -103,6 +103,8 @@ namespace osu.Game.Beatmaps
 
         int[] Bookmarks { get; internal set; }
 
+        double[] SliderVelocityPresets { get; internal set; }
+
         int BeatmapVersion { get; }
 
         /// <summary>

--- a/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
+++ b/osu.Game/Rulesets/Difficulty/DifficultyCalculator.cs
@@ -421,6 +421,12 @@ namespace osu.Game.Rulesets.Difficulty
                 set => baseBeatmap.Bookmarks = value;
             }
 
+            public double[] SliderVelocityPresets
+            {
+                get => baseBeatmap.SliderVelocityPresets;
+                set => baseBeatmap.SliderVelocityPresets = value;
+            }
+
             #endregion
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -98,37 +98,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 // if the piece belongs to an unselected object, operate on that object alone, independently of the selection.
                 var relevantObjects = (beatmap.SelectedHitObjects.Contains(hitObject) ? beatmap.SelectedHitObjects : hitObject.Yield()).Where(o => o is IHasSliderVelocity).ToArray();
 
-                // even if there are multiple objects selected, we can still display a value if they all have the same value.
-                var selectedPointBindable = relevantObjects.Select(point => ((IHasSliderVelocity)point).SliderVelocityMultiplier).Distinct().Count() == 1
-                    ? ((IHasSliderVelocity)relevantObjects.First()).SliderVelocityMultiplierBindable
-                    : null;
-
-                if (selectedPointBindable != null)
-                {
-                    // there may be legacy control points, which contain infinite precision for compatibility reasons (see LegacyDifficultyControlPoint).
-                    // generally that level of precision could only be set by externally editing the .osu file, so at the point
-                    // a user is looking to update this within the editor it should be safe to obliterate this additional precision.
-                    adjustmentControl.Current.Value = selectedPointBindable.Value;
-                }
-                else
-                {
-                    adjustmentControl.IsMultipleValues = true;
-                }
-
-                adjustmentControl.Current.BindValueChanged(val =>
-                {
-                    beatmap.BeginChange();
-
-                    foreach (var h in relevantObjects)
-                    {
-                        ((IHasSliderVelocity)h).SliderVelocityMultiplier = val.NewValue;
-                        beatmap.Update(h);
-                    }
-
-                    beatmap.EndChange();
-
-                    adjustmentControl.IsMultipleValues = false;
-                });
+                adjustmentControl.ObjectsToAdjust.Clear();
+                adjustmentControl.ObjectsToAdjust.AddRange(relevantObjects);
             }
 
             protected override void LoadComplete()
@@ -141,9 +112,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
     internal partial class SliderVelocityInspector : EditorInspector
     {
-        private readonly Bindable<double> current;
+        private readonly IBindable<double> current;
 
-        public SliderVelocityInspector(Bindable<double> current)
+        public SliderVelocityInspector(IBindable<double> current)
         {
             this.current = current;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/DifficultyPointPiece.cs
@@ -15,6 +15,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Cursor;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -74,22 +75,27 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 Children = new Drawable[]
                 {
-                    new FillFlowContainer
+                    new OsuContextMenuContainer // required for `SliderVelocityAdjustmentControl`'s context menus to work when right-clicking velocity presets
                     {
                         Width = 250,
-                        Direction = FillDirection.Vertical,
                         AutoSizeAxes = Axes.Y,
-                        Spacing = new Vector2(0, 15),
-                        Children = new Drawable[]
+                        Child = new FillFlowContainer
                         {
-                            adjustmentControl = new SliderVelocityAdjustmentControl(),
-                            new OsuTextFlowContainer
+                            Direction = FillDirection.Vertical,
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Spacing = new Vector2(0, 15),
+                            Children = new Drawable[]
                             {
-                                AutoSizeAxes = Axes.Y,
-                                RelativeSizeAxes = Axes.X,
-                                Text = "Hold shift while dragging the end of an object to adjust velocity while snapping."
-                            },
-                            new SliderVelocityInspector(adjustmentControl.Current),
+                                adjustmentControl = new SliderVelocityAdjustmentControl(),
+                                new OsuTextFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Y,
+                                    RelativeSizeAxes = Axes.X,
+                                    Text = "Hold shift while dragging the end of an object to adjust velocity while snapping."
+                                },
+                                new SliderVelocityInspector(adjustmentControl.Current),
+                            }
                         }
                     }
                 };

--- a/osu.Game/Screens/Edit/EditorBeatmap.cs
+++ b/osu.Game/Screens/Edit/EditorBeatmap.cs
@@ -132,6 +132,14 @@ namespace osu.Game.Screens.Edit
                 EndChange();
             });
 
+            SliderVelocityPresets = new BindableList<double>(playableBeatmap.SliderVelocityPresets);
+            SliderVelocityPresets.BindCollectionChanged((_, _) =>
+            {
+                BeginChange();
+                playableBeatmap.SliderVelocityPresets = SliderVelocityPresets.OrderBy(x => x).Distinct().ToArray();
+                EndChange();
+            });
+
             PreviewTime = new BindableInt(BeatmapInfo.Metadata.PreviewTime);
             PreviewTime.BindValueChanged(s =>
             {
@@ -290,6 +298,14 @@ namespace osu.Game.Screens.Edit
         {
             get => PlayableBeatmap.Bookmarks;
             set => PlayableBeatmap.Bookmarks = value;
+        }
+
+        public readonly BindableList<double> SliderVelocityPresets;
+
+        double[] IBeatmap.SliderVelocityPresets
+        {
+            get => PlayableBeatmap.SliderVelocityPresets;
+            set => PlayableBeatmap.SliderVelocityPresets = value;
         }
 
         public int BeatmapVersion { get; set; }

--- a/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
@@ -9,6 +9,8 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
@@ -20,6 +22,7 @@ using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
 using osuTK.Input;
+using CommonStrings = osu.Game.Resources.Localisation.Web.CommonStrings;
 
 namespace osu.Game.Screens.Edit.Timing
 {
@@ -206,7 +209,7 @@ namespace osu.Game.Screens.Edit.Timing
             base.Dispose(isDisposing);
         }
 
-        internal partial class SliderVelocityPresetTernaryButton : DrawableTernaryButton
+        internal partial class SliderVelocityPresetTernaryButton : DrawableTernaryButton, IHasContextMenu
         {
             public double Velocity { get; }
             public Action<double>? OnDelete { get; init; }
@@ -247,6 +250,11 @@ namespace osu.Game.Screens.Edit.Timing
 
                 return base.OnMouseDown(e);
             }
+
+            public MenuItem[] ContextMenuItems =>
+            [
+                new OsuMenuItem(CommonStrings.ButtonsDelete, MenuItemType.Destructive, () => OnDelete?.Invoke(Velocity))
+            ];
         }
 
         private partial class AddPresetButton : RoundedButton

--- a/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
@@ -1,51 +1,51 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Timing
 {
-    public partial class SliderVelocityAdjustmentControl : CompositeDrawable, IHasCurrentValue<double>
+    public partial class SliderVelocityAdjustmentControl : CompositeDrawable
     {
-        public Bindable<double> Current
-        {
-            get => current.Current;
-            set => current.Current = value;
-        }
-
-        private readonly BindableNumberWithCurrent<double> current = new BindableNumberWithCurrent<double>(1)
+        public Bindable<double> Current { get; } = new BindableNumber<double>(1)
         {
             Precision = 0.01,
             MinValue = 0.1,
             MaxValue = 10
         };
 
-        /// <summary>
-        /// This is a hack to allow the text box to show an indication that multiple slider velocity values are active
-        /// when the selection contains multiple objects with different velocities.
-        /// </summary>
-        public bool IsMultipleValues
-        {
-            get => isMultipleValues;
-            set
-            {
-                if (isMultipleValues == value)
-                    return;
+        public BindableList<HitObject> ObjectsToAdjust { get; } = new BindableList<HitObject>();
 
-                isMultipleValues = value;
-                updateIndeterminateState();
-            }
-        }
+        public bool IsMultipleValues { get; private set; }
 
-        private bool isMultipleValues;
+        private bool applyingStateFromBeatmap;
 
         private FormDiscreteAdjustmentControl<double> control = null!;
+        private FillFlowContainer presetsFlow = null!;
+        private RoundedButton addPresetButton = null!;
+
+        private readonly BindableList<double> presets = new BindableList<double>();
+
+        [Resolved]
+        private EditorBeatmap beatmap { get; set; } = null!;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -65,9 +65,26 @@ namespace osu.Game.Screens.Edit.Timing
                     {
                         Caption = "Slider velocity",
                         Current = Current,
+                    },
+                    presetsFlow = new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Full,
+                        Spacing = new Vector2(5),
+                        Child = addPresetButton = new RoundedButton
+                        {
+                            Width = 50,
+                            Height = 25,
+                            Text = "+",
+                            Action = () => presets.Add(Current.Value),
+                        }
                     }
                 }
             };
+
+            presets.BindTo(beatmap.SliderVelocityPresets);
+            presetsFlow.SetLayoutPosition(addPresetButton, float.MinValue);
         }
 
         protected override void LoadComplete()
@@ -79,17 +96,157 @@ namespace osu.Game.Screens.Edit.Timing
                 if (focused.NewValue && IsMultipleValues)
                     control.TextBox.Text = string.Empty;
             });
-            updateIndeterminateState();
+
+            beatmap.TransactionEnded += updateState;
+            beatmap.BeatmapReprocessed += updateState;
+            ObjectsToAdjust.BindCollectionChanged((_, _) => updateState(), true);
+            presets.BindCollectionChanged((_, _) => updatePresets(), true);
+
+            Current.BindValueChanged(val => applyVelocity(val.NewValue));
         }
 
-        private void updateIndeterminateState()
+        private void updateState()
         {
+            HashSet<double> velocities = ObjectsToAdjust.OfType<IHasSliderVelocity>().Select(point => Math.Round(point.SliderVelocityMultiplier, 2)).Distinct().ToHashSet();
+            IsMultipleValues = velocities.Count > 1;
+
+            applyingStateFromBeatmap = true;
+
+            control.Current.Value = velocities.FirstOrDefault(defaultValue: 1);
+
             control.LabelFormat = IsMultipleValues
                 ? static _ => "(multiple)"
-                : v => LocalisableString.Interpolate($"{v:0.00}x");
+                : v => LocalisableString.Interpolate($@"{v:0.00}x");
             control.TextBox.PlaceholderText = IsMultipleValues ? "(multiple)" : string.Empty;
+
+            foreach (var preset in presetsFlow.OfType<SliderVelocityPresetTernaryButton>())
+            {
+                if (velocities.Contains(preset.Velocity))
+                    preset.Current.Value = IsMultipleValues ? TernaryState.Indeterminate : TernaryState.True;
+                else
+                    preset.Current.Value = TernaryState.False;
+            }
+
+            addPresetButton.Enabled.Value = velocities.Count == 1 && !presets.Contains(velocities.Single());
+
+            applyingStateFromBeatmap = false;
         }
 
-        public bool TakeFocus() => GetContainingFocusManager()!.ChangeFocus(control.TextBox);
+        private void updatePresets()
+        {
+            var remainingPresets = presets.ToHashSet();
+
+            foreach (var button in presetsFlow.OfType<SliderVelocityPresetTernaryButton>())
+            {
+                if (remainingPresets.Contains(button.Velocity))
+                    remainingPresets.Remove(button.Velocity);
+                else
+                    button.Expire();
+            }
+
+            foreach (double preset in remainingPresets)
+            {
+                var presetButton = new SliderVelocityPresetTernaryButton(preset)
+                {
+                    Description = default,
+                    OnDelete = v => presets.Remove(v),
+                };
+                presetButton.Current.BindValueChanged(val =>
+                {
+                    if (applyingStateFromBeatmap)
+                        return;
+
+                    if (val.NewValue == TernaryState.True)
+                        applyVelocity(preset);
+                    else
+                        updateState();
+                });
+
+                presetsFlow.Add(presetButton);
+                presetsFlow.SetLayoutPosition(presetButton, (float)preset);
+            }
+
+            updateState();
+        }
+
+        private void applyVelocity(double velocity)
+        {
+            if (applyingStateFromBeatmap)
+                return;
+
+            beatmap.BeginChange();
+
+            foreach (var h in ObjectsToAdjust)
+            {
+                if (h is IHasSliderVelocity sv)
+                {
+                    sv.SliderVelocityMultiplier = velocity;
+                    beatmap.Update(h);
+                }
+            }
+
+            beatmap.EndChange();
+        }
+
+        public bool TakeFocus()
+        {
+            if (IsMultipleValues)
+                control.TextBox.Text = string.Empty;
+            return GetContainingFocusManager()!.ChangeFocus(control.TextBox);
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (beatmap.IsNotNull())
+            {
+                beatmap.TransactionEnded -= updateState;
+                beatmap.BeatmapReprocessed -= updateState;
+            }
+
+            base.Dispose(isDisposing);
+        }
+
+        internal partial class SliderVelocityPresetTernaryButton : DrawableTernaryButton
+        {
+            public double Velocity { get; }
+            public Action<double>? OnDelete { get; init; }
+
+            public SliderVelocityPresetTernaryButton(double velocity)
+            {
+                Velocity = velocity;
+                CreateIcon = () => new Container
+                {
+                    Child = new OsuSpriteText
+                    {
+                        Text = LocalisableString.Format($@"{velocity:0.00}x"),
+                        Font = OsuFont.Style.Body.With(weight: FontWeight.Bold),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
+                };
+                RelativeSizeAxes = Axes.None;
+                Width = 50;
+                Height = 25;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Icon.Position = Vector2.Zero;
+                Icon.RelativeSizeAxes = Axes.Both;
+                Icon.Size = new Vector2(1);
+            }
+
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                if ((e.ShiftPressed && e.Button == MouseButton.Right) || e.Button == MouseButton.Middle)
+                {
+                    OnDelete?.Invoke(Velocity);
+                    return true;
+                }
+
+                return base.OnMouseDown(e);
+            }
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
+++ b/osu.Game/Screens/Edit/Timing/SliderVelocityAdjustmentControl.cs
@@ -72,7 +72,7 @@ namespace osu.Game.Screens.Edit.Timing
                         AutoSizeAxes = Axes.Y,
                         Direction = FillDirection.Full,
                         Spacing = new Vector2(5),
-                        Child = addPresetButton = new RoundedButton
+                        Child = addPresetButton = new AddPresetButton
                         {
                             Width = 50,
                             Height = 25,
@@ -84,7 +84,7 @@ namespace osu.Game.Screens.Edit.Timing
             };
 
             presets.BindTo(beatmap.SliderVelocityPresets);
-            presetsFlow.SetLayoutPosition(addPresetButton, float.MinValue);
+            presetsFlow.SetLayoutPosition(addPresetButton, float.MaxValue);
         }
 
         protected override void LoadComplete()
@@ -246,6 +246,16 @@ namespace osu.Game.Screens.Edit.Timing
                 }
 
                 return base.OnMouseDown(e);
+            }
+        }
+
+        private partial class AddPresetButton : RoundedButton
+        {
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Content.CornerRadius = 5;
             }
         }
     }


### PR DESCRIPTION
https://github.com/user-attachments/assets/a3f7cd65-271a-4604-adb3-94fdc4bac1dc

- Default presets match stable (0.75x, 1.00x, 1.50x).
- Set a non-standard velocity and press the green "+" button to create a new preset.
- Middle-click or shift-right-click an existing preset to delete it.
- Presets are stored to the `[Editor]` section of the `.osu`, therefore they are persistent when saved and will also be accessible to other people that open the map in the editor.