### PR TITLE
Fix timed pp calculation regression with optimisations

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -21,6 +21,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         [TestCase(1.3280410795791415d, 54, "zero-length-sliders")]
         [TestCase(0.40867325147697559d, 4, "very-fast-slider")]
         [TestCase(0.87058175794353554d, 6, "nan-slider")]
+        [TestCase(6.3059767387139756d, 2359, "801165")] // real world test
         public void Test(double expectedStarRating, int expectedMaxCombo, string name)
             => base.Test(expectedStarRating, expectedMaxCombo, name);
 

--- a/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
+++ b/osu.Game.Rulesets.Osu.Tests/OsuDifficultyCalculatorTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
@@ -34,6 +36,39 @@ namespace osu.Game.Rulesets.Osu.Tests
         public void TestClassicMod(double expectedStarRating, int expectedMaxCombo, string name)
             => Test(expectedStarRating, expectedMaxCombo, name, new OsuModClassic());
 
+        [Test]
+        public void TestTimedExtended()
+        {
+            var beatmap = GetBeatmap("diffcalc-test");
+
+            Dictionary<double, (double StarRating, int MaxCombo)> timedAttributes = CreateDifficultyCalculator(beatmap)
+                                                                                    .CalculateTimed()
+                                                                                    .ToDictionary(a => a.Time, a => (a.Attributes.StarRating, a.Attributes.MaxCombo));
+
+            Assert.That(timedAttributes[500].MaxCombo, Is.EqualTo(1));
+            Assert.That(timedAttributes[500].StarRating, Is.EqualTo(0).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[1000].MaxCombo, Is.EqualTo(2));
+            Assert.That(timedAttributes[1000].StarRating, Is.EqualTo(0.16948857823852109).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[1500].MaxCombo, Is.EqualTo(3));
+            Assert.That(timedAttributes[1500].StarRating, Is.EqualTo(0.26606949612932967).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[2000].MaxCombo, Is.EqualTo(4));
+            Assert.That(timedAttributes[2000].StarRating, Is.EqualTo(0.35775631754708426).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[2500].MaxCombo, Is.EqualTo(5));
+            Assert.That(timedAttributes[2500].StarRating, Is.EqualTo(0.56319343599556226).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[17000].MaxCombo, Is.EqualTo(62));
+            Assert.That(timedAttributes[17000].StarRating, Is.EqualTo(5.6685465406782036).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[18000].MaxCombo, Is.EqualTo(63));
+            Assert.That(timedAttributes[18000].StarRating, Is.EqualTo(5.7272669362777702).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[18125].MaxCombo, Is.EqualTo(64));
+            Assert.That(timedAttributes[18125].StarRating, Is.EqualTo(5.7347762555961532).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[61500].MaxCombo, Is.EqualTo(160));
+            Assert.That(timedAttributes[61500].StarRating, Is.EqualTo(6.5240565852553738).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[70000].MaxCombo, Is.EqualTo(176));
+            Assert.That(timedAttributes[70000].StarRating, Is.EqualTo(6.5240609777925842).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes[74600].MaxCombo, Is.EqualTo(195));
+            Assert.That(timedAttributes[74600].StarRating, Is.EqualTo(6.5240617806983261).Within(CHECK_PRECISION));
+        }
+
         [TestCase(239, "diffcalc-test")]
         [TestCase(54, "zero-length-sliders")]
         [TestCase(4, "very-fast-slider")]
@@ -52,8 +87,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
                 attributes = CreateDifficultyCalculator(beatmap).Calculate();
 
-                // Platform-dependent math functions (Pow, Cbrt, Exp, etc) may result in minute differences.
-                Assert.That(attributes.StarRating, Is.EqualTo(expectedStarRating).Within(0.00001));
+                Assert.That(attributes.StarRating, Is.EqualTo(expectedStarRating).Within(CHECK_PRECISION));
                 Assert.That(attributes.MaxCombo, Is.EqualTo(expectedMaxCombo));
             }
         }

--- a/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
@@ -166,7 +166,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <summary>
         /// Saves the current peak strain level to the list of strain peaks, which will be used to calculate an overall difficulty.
         /// </summary>
-        private StrainPeak saveCurrentPeak(double sectionLength)
+        private void saveCurrentPeak(double sectionLength)
         {
             if (finalPeak != null)
             {
@@ -186,8 +186,6 @@ namespace osu.Game.Rulesets.Difficulty.Skills
                 totalLength -= strainPeaks[^1].SectionLength;
                 strainPeaks.RemoveAt(strainPeaks.Count - 1);
             }
-
-            return peak;
         }
 
         /// <summary>

--- a/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
@@ -171,6 +171,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             if (finalPeak != null)
             {
                 strainPeaks.Remove(finalPeak.Value);
+                totalLength -= finalPeak.Value.SectionLength;
                 finalPeak = null;
             }
 

--- a/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
@@ -166,9 +166,17 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <summary>
         /// Saves the current peak strain level to the list of strain peaks, which will be used to calculate an overall difficulty.
         /// </summary>
-        private void saveCurrentPeak(double sectionLength)
+        private StrainPeak saveCurrentPeak(double sectionLength)
         {
-            strainPeaks.AddInPlace(new StrainPeak(currentSectionPeak, sectionLength));
+            if (finalPeak != null)
+            {
+                strainPeaks.Remove(finalPeak.Value);
+                finalPeak = null;
+            }
+
+            StrainPeak peak = new StrainPeak(currentSectionPeak, sectionLength);
+
+            strainPeaks.AddInPlace(peak);
             totalLength += sectionLength;
 
             // Remove from the back of our strain peaks if there's any which are too deep to contribute to difficulty.
@@ -178,6 +186,8 @@ namespace osu.Game.Rulesets.Difficulty.Skills
                 totalLength -= strainPeaks[^1].SectionLength;
                 strainPeaks.RemoveAt(strainPeaks.Count - 1);
             }
+
+            return peak;
         }
 
         /// <summary>
@@ -200,7 +210,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <returns>The peak strain.</returns>
         protected abstract double CalculateInitialStrain(double time, DifficultyHitObject current);
 
-        private bool peaksFinalised;
+        private StrainPeak? finalPeak;
 
         /// <summary>
         /// Returns a live enumerable of the peak strains for each <see cref="MaxSectionLength"/> section of the beatmap,
@@ -208,11 +218,8 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public IEnumerable<StrainPeak> GetCurrentStrainPeaks()
         {
-            if (!peaksFinalised)
-            {
-                saveCurrentPeak(currentSectionEnd - currentSectionBegin);
-                peaksFinalised = true;
-            }
+            if (finalPeak != null)
+                finalPeak = saveCurrentPeak(currentSectionEnd - currentSectionBegin);
 
             return strainPeaks;
         }
@@ -238,7 +245,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// <summary>
         /// Used to store the difficulty of a section of a map.
         /// </summary>
-        public readonly struct StrainPeak : IComparable<StrainPeak>
+        public readonly record struct StrainPeak : IComparable<StrainPeak>
         {
             public StrainPeak(double value, double sectionLength)
             {

--- a/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
@@ -171,7 +171,6 @@ namespace osu.Game.Rulesets.Difficulty.Skills
             if (finalPeak != null)
             {
                 strainPeaks.Remove(finalPeak.Value);
-                totalLength -= finalPeak.Value.SectionLength;
                 finalPeak = null;
             }
 
@@ -219,7 +218,11 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public IEnumerable<StrainPeak> GetCurrentStrainPeaks()
         {
-            finalPeak ??= saveCurrentPeak(currentSectionEnd - currentSectionBegin);
+            if (finalPeak == null)
+            {
+                finalPeak = new StrainPeak(currentSectionPeak, currentSectionEnd - currentSectionBegin);
+                strainPeaks.AddInPlace(finalPeak.Value);
+            }
 
             return strainPeaks;
         }

--- a/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
+++ b/osu.Game/Rulesets/Difficulty/Skills/VariableLengthStrainSkill.cs
@@ -218,8 +218,7 @@ namespace osu.Game.Rulesets.Difficulty.Skills
         /// </summary>
         public IEnumerable<StrainPeak> GetCurrentStrainPeaks()
         {
-            if (finalPeak != null)
-                finalPeak = saveCurrentPeak(currentSectionEnd - currentSectionBegin);
+            finalPeak ??= saveCurrentPeak(currentSectionEnd - currentSectionBegin);
 
             return strainPeaks;
         }

--- a/osu.Game/Tests/Beatmaps/DifficultyCalculatorTest.cs
+++ b/osu.Game/Tests/Beatmaps/DifficultyCalculatorTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -23,13 +24,24 @@ namespace osu.Game.Tests.Beatmaps
 
         protected abstract string ResourceAssembly { get; }
 
+        /// <summary>
+        /// Platform-dependent math functions (Pow, Cbrt, Exp, etc) may result in minute differences.
+        /// </summary>
+        protected const double CHECK_PRECISION = 0.00001;
+
         protected void Test(double? expectedStarRating, int expectedMaxCombo, string name, params Mod[] mods)
         {
-            var attributes = CreateDifficultyCalculator(GetBeatmap(name)).Calculate(mods);
+            var calc = CreateDifficultyCalculator(GetBeatmap(name));
+            var attributes = calc.Calculate(mods);
 
-            // Platform-dependent math functions (Pow, Cbrt, Exp, etc) may result in minute differences.
-            Assert.That(attributes.StarRating, Is.EqualTo(expectedStarRating).Within(0.00001));
+            var timedAttributes = calc.CalculateTimed(mods);
+
+            Assert.That(attributes.StarRating, Is.EqualTo(expectedStarRating).Within(CHECK_PRECISION));
             Assert.That(attributes.MaxCombo, Is.EqualTo(expectedMaxCombo));
+
+            // Test timed attributes ends on same value as non-timed.
+            Assert.That(attributes.StarRating, Is.EqualTo(timedAttributes.Last().Attributes.StarRating).Within(CHECK_PRECISION));
+            Assert.That(attributes.MaxCombo, Is.EqualTo(timedAttributes.Last().Attributes.MaxCombo));
         }
 
         protected IWorkingBeatmap GetBeatmap(string name)

--- a/osu.Game/Tests/Beatmaps/DifficultyCalculatorTest.cs
+++ b/osu.Game/Tests/Beatmaps/DifficultyCalculatorTest.cs
@@ -40,8 +40,8 @@ namespace osu.Game.Tests.Beatmaps
             Assert.That(attributes.MaxCombo, Is.EqualTo(expectedMaxCombo));
 
             // Test timed attributes ends on same value as non-timed.
-            Assert.That(attributes.StarRating, Is.EqualTo(timedAttributes.Last().Attributes.StarRating).Within(CHECK_PRECISION));
-            Assert.That(attributes.MaxCombo, Is.EqualTo(timedAttributes.Last().Attributes.MaxCombo));
+            Assert.That(timedAttributes.Last().Attributes.StarRating, Is.EqualTo(attributes.StarRating).Within(CHECK_PRECISION));
+            Assert.That(timedAttributes.Last().Attributes.MaxCombo, Is.EqualTo(attributes.MaxCombo));
         }
 
         protected IWorkingBeatmap GetBeatmap(string name)


### PR DESCRIPTION
See https://discord.com/channels/188630481301012481/380598781432823815/1522142729407037500

Needs testing and probably test coverage. Just PRing as draft for now for feedback.

Alternative is undoing the optimisation chain, but it'll be a pain and adds significant overhead to the static diffcalc path.