### PR TITLE
Move legacy health display to the front of every other skin component to match stable

### DIFF
--- a/osu.Game/Skinning/LegacySkin.cs
+++ b/osu.Game/Skinning/LegacySkin.cs
@@ -461,8 +461,11 @@ namespace osu.Game.Skinning
                                     new LegacyScoreCounter(),
                                     new LegacyAccuracyCounter(),
                                     new LegacySongProgress(),
-                                    new LegacyHealthDisplay(),
                                     new BarHitErrorMeter(),
+
+                                    // to match stable, health bars are in front of everything else
+                                    // for the sake of hacky full screen area health bars
+                                    new LegacyHealthDisplay(),
                                 }
                             };
                     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/38075

Since the issue didn't provide a skin, I found a similar one that "dims" the components in https://skins.osuck.net/skins/5312.

Can't revert to default right now because of https://github.com/ppy/osu/issues/38135, so you have to reimport skin to see default layout changing when applying/removing the commit.

| Before | After |
| --- | --- |
| <img width="343" height="72" alt="Screenshot 2026-07-02 at 7 38 17 PM" src="https://github.com/user-attachments/assets/f3d1f6d7-6f0a-4ce8-8b8a-50dd485f6bb8" /> | <img width="336" height="64" alt="Screenshot 2026-07-02 at 7 37 24 PM" src="https://github.com/user-attachments/assets/ee320e84-8119-4a91-a267-9db8f372856b" /> |