### PR TITLE
Clamp pp score params where possible

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
             num100 = score.GetCount100() ?? 0; // HitResult.LargeTickHit
             num50 = score.GetCount50() ?? 0; // HitResult.SmallTickHit
             numKatu = score.GetCountKatu() ?? 0; // HitResult.SmallTickMiss
-            numMiss = score.GetCountMiss() ?? 0; // HitResult.Miss PLUS HitResult.LargeTickMiss
+            numMiss = Math.Max(0, score.GetCountMiss() ?? 0); // HitResult.Miss PLUS HitResult.LargeTickMiss
 
             double scoreMaxCombo = Math.Clamp(score.MaxCombo, 0, catchAttributes.MaxCombo);
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -32,7 +32,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         {
             var catchAttributes = (CatchDifficultyAttributes)attributes;
 
-            num300 = score.Statistics[HitResult.Great];
+            num300 = score.Statistics.GetValueOrDefault(HitResult.Great);
             num100 = score.GetCount100() ?? 0; // HitResult.LargeTickHit
             num50 = score.GetCount50() ?? 0; // HitResult.SmallTickHit
             numKatu = score.GetCountKatu() ?? 0; // HitResult.SmallTickMiss

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -8,6 +8,7 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Utils;
@@ -31,11 +32,13 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         {
             var catchAttributes = (CatchDifficultyAttributes)attributes;
 
-            num300 = score.GetCount300() ?? 0; // HitResult.Great
+            num300 = score.Statistics[HitResult.Great];
             num100 = score.GetCount100() ?? 0; // HitResult.LargeTickHit
             num50 = score.GetCount50() ?? 0; // HitResult.SmallTickHit
             numKatu = score.GetCountKatu() ?? 0; // HitResult.SmallTickMiss
             numMiss = score.GetCountMiss() ?? 0; // HitResult.Miss PLUS HitResult.LargeTickMiss
+
+            double scoreMaxCombo = Math.Clamp(score.MaxCombo, 0, catchAttributes.MaxCombo);
 
             // We are heavily relying on aim in catch the beat
             double value = DiffUtils.Pow(5.0 * Math.Max(1.0, catchAttributes.StarRating / 0.0049) - 4.0, 2.0) / 100000.0;
@@ -52,7 +55,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
 
             // Combo scaling
             if (catchAttributes.MaxCombo > 0)
-                value *= Math.Min(DiffUtils.Pow(score.MaxCombo, 0.35) / DiffUtils.Pow(catchAttributes.MaxCombo, 0.35), 1.0);
+                value *= Math.Min(DiffUtils.Pow(scoreMaxCombo, 0.35) / DiffUtils.Pow(catchAttributes.MaxCombo, 0.35), 1.0);
 
             var difficulty = score.BeatmapInfo!.Difficulty.Clone();
 

--- a/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs
@@ -2,14 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Utils;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
 using osu.Game.Utils;
@@ -33,7 +31,7 @@ namespace osu.Game.Rulesets.Catch.Difficulty
         {
             var catchAttributes = (CatchDifficultyAttributes)attributes;
 
-            num300 = score.Statistics.GetValueOrDefault(HitResult.Great);
+            num300 = score.GetCount300() ?? 0; // HitResult.Great
             num100 = score.GetCount100() ?? 0; // HitResult.LargeTickHit
             num50 = score.GetCount50() ?? 0; // HitResult.SmallTickHit
             numKatu = score.GetCountKatu() ?? 0; // HitResult.SmallTickMiss

--- a/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs
@@ -35,8 +35,8 @@ namespace osu.Game.Rulesets.Mania.Difficulty
             countGood = score.Statistics.GetValueOrDefault(HitResult.Good);
             countOk = score.Statistics.GetValueOrDefault(HitResult.Ok);
             countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
-            countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
-            scoreAccuracy = calculateCustomAccuracy();
+            countMiss = Math.Max(0, score.Statistics.GetValueOrDefault(HitResult.Miss));
+            scoreAccuracy = Math.Clamp(calculateCustomAccuracy(), 0, 1);
 
             double multiplier = 1.0;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -78,8 +78,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             usingClassicSliderAccuracy = score.Mods.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value);
             usingScoreV2 = score.Mods.Any(m => m is ModScoreV2);
 
-            accuracy = score.Accuracy;
-            scoreMaxCombo = score.MaxCombo;
+            accuracy = Math.Clamp(score.Accuracy, 0, 1);
+            scoreMaxCombo = Math.Clamp(score.MaxCombo, 0, osuAttributes.MaxCombo);
             countGreat = score.Statistics.GetValueOrDefault(HitResult.Great);
             countOk = score.Statistics.GetValueOrDefault(HitResult.Ok);
             countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -123,6 +123,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             effectiveMissCount = Math.Max(countMiss, effectiveMissCount);
             effectiveMissCount = Math.Min(totalHits, effectiveMissCount);
+            effectiveMissCount = Math.Max(0, effectiveMissCount);
 
             if (effectiveMissCount > 0)
             {

--- a/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Taiko/Difficulty/TaikoPerformanceCalculator.cs
@@ -41,7 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Difficulty
             countGreat = score.Statistics.GetValueOrDefault(HitResult.Great);
             countOk = score.Statistics.GetValueOrDefault(HitResult.Ok);
             countMeh = score.Statistics.GetValueOrDefault(HitResult.Meh);
-            countMiss = score.Statistics.GetValueOrDefault(HitResult.Miss);
+            countMiss = Math.Max(0, score.Statistics.GetValueOrDefault(HitResult.Miss));
 
             clockRate = ModUtils.CalculateRateWithMods(score.Mods);
 


### PR DESCRIPTION
Some people are having too much fun with it. Intentionally PR'ing against `master` so that it can be merged without waiting for the next pp deploy.
<img width="1285" height="435" alt="image" src="https://github.com/user-attachments/assets/fbdd7e2e-4146-43d3-9c47-30a6fbb3e1b4" />
