### PR TITLE
Fix song select buttons not working after attempting to force-exit when mod select is open

### DIFF
--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -316,6 +316,26 @@ namespace osu.Game.Tests.Visual.Navigation
         }
 
         [Test]
+        public void TestFooterButtonsAfterModSelectForceExit()
+        {
+            Screens.Select.SongSelect songSelect = null;
+            MainMenu mainMenu = null;
+
+            AddUntilStep("get main menu", () => (mainMenu = Game.ScreenStack.CurrentScreen as MainMenu) != null);
+            PushAndConfirm(() => songSelect = new SoloSongSelect());
+            AddStep("show mods overlay", () => InputManager.Key(Key.F1));
+
+            // follows alt-f4 code path behavior, can't use home or `game.AttemptExit()` as those run `CloseAllOverlays()`
+            AddStep("force exit song select", () => mainMenu.MakeCurrent());
+
+            AddStep("import beatmap", () => BeatmapImportHelper.LoadQuickOszIntoOsu(Game).GetResultSafely());
+            PushAndConfirm(() => new SoloSongSelect());
+            AddUntilStep("wait for song select", () => songSelect.CarouselItemsPresented);
+            AddStep("show options", () => InputManager.Key(Key.F3));
+            AddAssert("options is shown", () => Game!.ChildrenOfType<FooterButtonOptions.Popover>().Single().State.Value, () => Is.EqualTo(Visibility.Visible));
+        }
+
+        [Test]
         public void TestAttemptPlayBeatmapWrongHashFails()
         {
             Screens.Select.SongSelect songSelect = null;

--- a/osu.Game/Screens/Footer/ScreenFooter.cs
+++ b/osu.Game/Screens/Footer/ScreenFooter.cs
@@ -187,7 +187,6 @@ namespace osu.Game.Screens.Footer
 
         public void SetButtons(IReadOnlyList<ScreenFooterButton> buttons)
         {
-            temporarilyHiddenButtons.Clear();
             overlays.Clear();
 
             this.HidePopover();

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsSongSelect.cs
@@ -201,6 +201,7 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                 return true;
 
             addToPlaylistFooterButton.Disappear().Expire();
+            freeModSelect.Hide();
             return false;
         }
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -759,6 +759,7 @@ namespace osu.Game.Screens.Select
             modSelectOverlay.SelectedMods.UnbindFrom(Mods);
             modSelectOverlay.Ruleset.UnbindFrom(Ruleset);
             modSelectOverlay.Beatmap.UnbindFrom(Beatmap);
+            modSelectOverlay.Hide();
 
             updateWedgeVisibility();
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/38146

When pressing Alt-F4, the mod select overlay never closes and does this in order:
```c#
SetButton();
clearActiveOverlayContainer(); // inside SetButton()
```

Pressing home or exiting via Esc runs `clearActiveOverlayContainer()` first, and it doesn't trigger the bug because the `hiddenButtonsContainer` container gets cleared before the `temporarilyHiddenButtons` list does. Unsure why `SetButtons()` needs to clear `temporarilyHiddenButtons`. There's no regression when I tested.

`Hide()`ing the overlay on the screen's `OnExiting()` is also a fix. `MultiplayerMatchSongSelect` already has `freeModSelect.Hide()`.

I've applied both above as one makes sure the bug doesn't happen anymore when forgetting to `Hide()` the overlay on the screen's `OnExiting()` and the other fixes the no pop out animation.