### PR TITLE
Fix converted beatmaps getting filtered out when Dual Stages and Ten Keys mods are active

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
+++ b/osu.Game.Rulesets.Mania.Tests/ManiaFilterCriteriaTest.cs
@@ -186,6 +186,19 @@ namespace osu.Game.Rulesets.Mania.Tests
         }
 
         [TestCase]
+        public void TestTwentyKeys()
+        {
+            var criteria = new ManiaFilterCriteria();
+
+            Assert.That(criteria.Matches(
+                new BeatmapInfo(new RulesetInfo { OnlineID = 0 }, new BeatmapDifficulty { CircleSize = 4 }),
+                new FilterCriteria
+                {
+                    Mods = [new ManiaModKey10(), new ManiaModDualStages()]
+                }), Is.True);
+        }
+
+        [TestCase]
         public void TestLnsEqual()
         {
             var criteria = new ManiaFilterCriteria();

--- a/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
+++ b/osu.Game.Rulesets.Mania/ManiaFilterCriteria.cs
@@ -19,7 +19,9 @@ namespace osu.Game.Rulesets.Mania
 {
     public class ManiaFilterCriteria : IRulesetFilterCriteria
     {
-        private readonly HashSet<int> includedKeyCounts = Enumerable.Range(1, LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT).ToHashSet();
+        // using `2 * MAX_STAGE_KEYS` here instead of `LegacyBeatmapDecoder.MAX_MANIA_KEY_COUNT`,
+        // as the former is higher and achievable by engaging key mods (Dual Stages + 10K)
+        private readonly HashSet<int> includedKeyCounts = Enumerable.Range(1, 2 * ManiaRuleset.MAX_STAGE_KEYS).ToHashSet();
         private FilterCriteria.OptionalRange<float> longNotePercentage;
 
         public bool Matches(BeatmapInfo beatmapInfo, FilterCriteria criteria)


### PR DESCRIPTION
Reported [on the forums](https://osu.ppy.sh/community/forums/topics/2221821?n=1).