### PR TITLE
Adjust spectator client code to use new server API

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneSpectator.cs
@@ -275,7 +275,7 @@ namespace osu.Game.Tests.Visual.Gameplay
 
                 var completedGameplayState = TestGameplayState.Create(new OsuRuleset());
                 completedGameplayState.HasPassed = true;
-                spectatorClient.EndPlaying(completedGameplayState);
+                spectatorClient.EndPlaying(null, completedGameplayState);
             });
 
             // We can't access API because we're an "online" test.

--- a/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
+++ b/osu.Game.Tests/Visual/Navigation/TestSceneScreenNavigation.cs
@@ -549,7 +549,7 @@ namespace osu.Game.Tests.Visual.Navigation
             // todo: see https://github.com/ppy/osu/issues/22220
             // tests are supposed to be immune to this edge case by the logic in TestPlayer,
             // but we're running a full game instance here, so we have to work around it manually.
-            AddStep("end spectator before retry", () => Game.SpectatorClient.EndPlaying(player.GameplayState));
+            AddStep("end spectator before retry", () => Game.SpectatorClient.EndPlaying(null, player.GameplayState));
 
             AddStep("attempt to retry", () => player.ChildrenOfType<HotkeyRetryOverlay>().First().Action());
             AddAssert("old player score marked failed", () => player.Score.ScoreInfo.Rank, () => Is.EqualTo(ScoreRank.F));

--- a/osu.Game/Online/Spectator/ISpectatorServer.cs
+++ b/osu.Game/Online/Spectator/ISpectatorServer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Threading.Tasks;
 
 namespace osu.Game.Online.Spectator
@@ -10,24 +11,56 @@ namespace osu.Game.Online.Spectator
     /// </summary>
     public interface ISpectatorServer
     {
+        #region V1 (obsoleted)
+
         /// <summary>
         /// Signal the start of a new play session.
         /// </summary>
         /// <param name="scoreToken">The score submission token.</param>
         /// <param name="state">The state of gameplay.</param>
+        [Obsolete("New clients should use BeginPlaySessionV2.")] // can remove method 20270102
         Task BeginPlaySession(long? scoreToken, SpectatorState state);
 
         /// <summary>
         /// Send a bundle of frame data for the current play session.
         /// </summary>
         /// <param name="data">The frame data.</param>
+        [Obsolete("New clients should use SendFrameDataV2.")] // can remove method 20270102
         Task SendFrameData(FrameDataBundle data);
 
         /// <summary>
         /// Signal the end of a play session.
         /// </summary>
         /// <param name="state">The state of gameplay.</param>
+        [Obsolete("New clients should use EndPlaySessionV2.")] // can remove method 20270102
         Task EndPlaySession(SpectatorState state);
+
+        #endregion
+
+        #region V2
+
+        /// <summary>
+        /// Signal the start of a new play session.
+        /// </summary>
+        /// <param name="scoreToken">The score submission token.</param>
+        /// <param name="state">The state of gameplay.</param>
+        Task BeginPlaySessionV2(long? scoreToken, SpectatorState state);
+
+        /// <summary>
+        /// Send a bundle of frame data for the current play session.
+        /// </summary>
+        /// <param name="scoreToken">The score submission token.</param>
+        /// <param name="data">The frame data.</param>
+        Task SendFrameDataV2(long? scoreToken, FrameDataBundle data);
+
+        /// <summary>
+        /// Signal the end of a play session.
+        /// </summary>
+        /// <param name="scoreToken">The score submission token.</param>
+        /// <param name="finalState">The final state of gameplay.</param>
+        Task EndPlaySessionV2(long? scoreToken, SpectatedUserState finalState);
+
+        #endregion
 
         /// <summary>
         /// Request spectating data for the specified user. May be called on multiple users and offline users.

--- a/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
+++ b/osu.Game/Online/Spectator/OnlineSpectatorClient.cs
@@ -62,7 +62,7 @@ namespace osu.Game.Online.Spectator
 
             try
             {
-                await connection.InvokeAsync(nameof(ISpectatorServer.BeginPlaySession), scoreToken, state).ConfigureAwait(false);
+                await connection.InvokeAsync(nameof(ISpectatorServer.BeginPlaySessionV2), scoreToken, state).ConfigureAwait(false);
                 return true;
             }
             catch (Exception exception)
@@ -83,24 +83,24 @@ namespace osu.Game.Online.Spectator
             }
         }
 
-        protected override Task SendFramesInternal(FrameDataBundle bundle)
+        protected override Task SendFramesInternal(long? scoreToken, FrameDataBundle bundle)
         {
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             Debug.Assert(connection != null);
 
-            return connection.SendAsync(nameof(ISpectatorServer.SendFrameData), bundle);
+            return connection.SendAsync(nameof(ISpectatorServer.SendFrameDataV2), scoreToken, bundle);
         }
 
-        protected override Task EndPlayingInternal(SpectatorState state)
+        protected override Task EndPlayingInternal(long? scoreToken, SpectatedUserState finalState)
         {
             if (!IsConnected.Value)
                 return Task.CompletedTask;
 
             Debug.Assert(connection != null);
 
-            return connection.InvokeAsync(nameof(ISpectatorServer.EndPlaySession), state);
+            return connection.InvokeAsync(nameof(ISpectatorServer.EndPlaySessionV2), scoreToken, finalState);
         }
 
         protected override Task WatchUserInternal(int userId)

--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -267,7 +267,7 @@ namespace osu.Game.Online.Spectator
                 purgePendingFrames();
         });
 
-        public void EndPlaying(GameplayState state)
+        public void EndPlaying(long? scoreToken, GameplayState state)
         {
             // This method is most commonly called via Dispose(), which is can be asynchronous (via the AsyncDisposalQueue).
             // We probably need to find a better way to handle this...
@@ -276,24 +276,21 @@ namespace osu.Game.Online.Spectator
                 if (!isPlaying)
                     return;
 
-                // Disposal can take some time, leading to EndPlaying potentially being called after a future play session.
-                // Account for this by ensuring the score of the current play matches the one in the provided state.
-                if (currentScore != state.Score)
-                    return;
-
                 if (pendingFrames.Count > 0)
                     purgePendingFrames();
 
                 clearScoreState();
 
-                if (state.HasPassed)
-                    currentState.State = SpectatedUserState.Passed;
-                else if (state.HasFailed)
-                    currentState.State = SpectatedUserState.Failed;
-                else
-                    currentState.State = SpectatedUserState.Quit;
+                SpectatedUserState finalState;
 
-                EndPlayingInternal(currentState).FireAndForget();
+                if (state.HasPassed)
+                    finalState = SpectatedUserState.Passed;
+                else if (state.HasFailed)
+                    finalState = SpectatedUserState.Failed;
+                else
+                    finalState = SpectatedUserState.Quit;
+
+                EndPlayingInternal(scoreToken, finalState).FireAndForget();
             });
         }
 
@@ -354,9 +351,9 @@ namespace osu.Game.Online.Spectator
         /// <returns>Whether the server-side invocation to start play succeeded.</returns>
         protected abstract Task<bool> BeginPlayingInternal(long? scoreToken, SpectatorState state);
 
-        protected abstract Task SendFramesInternal(FrameDataBundle bundle);
+        protected abstract Task SendFramesInternal(long? scoreToken, FrameDataBundle bundle);
 
-        protected abstract Task EndPlayingInternal(SpectatorState state);
+        protected abstract Task EndPlayingInternal(long? scoreToken, SpectatedUserState finalState);
 
         protected abstract Task WatchUserInternal(int userId);
 
@@ -413,7 +410,7 @@ namespace osu.Game.Online.Spectator
 
             lastSend = tcs.Task;
 
-            SendFramesInternal(bundle).ContinueWith(t =>
+            SendFramesInternal(currentScoreToken, bundle).ContinueWith(t =>
             {
                 // Handle exception outside of `Schedule` to ensure it doesn't go unobserved.
                 bool wasSuccessful = t.Exception == null;

--- a/osu.Game/Screens/Play/SubmittingPlayer.cs
+++ b/osu.Game/Screens/Play/SubmittingPlayer.cs
@@ -190,7 +190,7 @@ namespace osu.Game.Screens.Play
             score.ScoreInfo.Date = DateTimeOffset.Now;
 
             await submitScore(score).ConfigureAwait(false);
-            spectatorClient.EndPlaying(GameplayState);
+            spectatorClient.EndPlaying(token, GameplayState);
             userStatisticsWatcher?.RegisterForStatisticsUpdateAfter(score.ScoreInfo);
         }
 
@@ -249,7 +249,7 @@ namespace osu.Game.Screens.Play
                 Task.Run(async () =>
                 {
                     await submitScore(scoreCopy).ConfigureAwait(false);
-                    spectatorClient.EndPlaying(GameplayState);
+                    spectatorClient.EndPlaying(token, GameplayState);
                 }).FireAndForget();
             }
         }

--- a/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
+++ b/osu.Game/Tests/Visual/Spectator/TestSpectatorClient.cs
@@ -170,7 +170,7 @@ namespace osu.Game.Tests.Visual.Spectator
             return true;
         }
 
-        protected override Task SendFramesInternal(FrameDataBundle bundle)
+        protected override Task SendFramesInternal(long? scoreToken, FrameDataBundle bundle)
         {
             FrameSendAttempts++;
 
@@ -180,7 +180,12 @@ namespace osu.Game.Tests.Visual.Spectator
             return ((ISpectatorClient)this).UserSentFrames(api.LocalUser.Value.Id, bundle);
         }
 
-        protected override Task EndPlayingInternal(SpectatorState state) => ((ISpectatorClient)this).UserFinishedPlaying(api.LocalUser.Value.Id, state);
+        protected override Task EndPlayingInternal(long? scoreToken, SpectatedUserState finalState) => ((ISpectatorClient)this).UserFinishedPlaying(api.LocalUser.Value.Id, new SpectatorState
+        {
+            BeatmapID = userBeatmapDictionary.GetValueOrDefault(api.LocalUser.Value.Id),
+            Mods = userModsDictionary.GetValueOrDefault(api.LocalUser.Value.Id) ?? [],
+            State = finalState,
+        });
 
         protected override Task WatchUserInternal(int userId)
         {

--- a/osu.Game/Tests/Visual/TestPlayer.cs
+++ b/osu.Game/Tests/Visual/TestPlayer.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Tests.Visual
             // Until this is handled properly at game-side, ensure EndPlaying is called before exiting player.
             // see: https://github.com/ppy/osu/issues/22220
             if (LoadedBeatmapSuccessfully)
-                spectatorClient?.EndPlaying(GameplayState);
+                spectatorClient?.EndPlaying(null, GameplayState);
 
             return exiting;
         }
@@ -124,7 +124,7 @@ namespace osu.Game.Tests.Visual
             // Specific to tests, the player can be disposed without OnExiting() ever being called.
             // We should make sure that the gameplay session has finished even in this case.
             if (LoadedBeatmapSuccessfully)
-                spectatorClient?.EndPlaying(GameplayState);
+                spectatorClient?.EndPlaying(null, GameplayState);
         }
     }
 }


### PR DESCRIPTION
- Client-side counterpart to / depends on https://github.com/ppy/osu-server-spectator/pull/523
- [x] Requires on server deploy of above