### PR TITLE
Fix automatic intro skip not triggering in multiplayer

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -54,6 +54,24 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddUntilStep("score changed", () => player.GameplayState.ScoreProcessor.TotalScore.Value > 0);
         }
 
+        [Test]
+        public void TestSkipBeforeGameplayStartsWhenAutoSkipEnabled()
+        {
+            AddStep("enable auto skip", () => MultiplayerClient.ChangeSettings(autoSkip: true));
+
+            setupBeforeGameplayStart();
+
+            AddStep("click skip overlay", () => this.ChildrenOfType<MultiplayerSkipOverlay.Button>().Single().TriggerClick());
+
+            startGameplay();
+
+            AddAssert("gameplay clock skipped to intro", () =>
+            {
+                GameplayClockContainer clock = player.ChildrenOfType<GameplayClockContainer>().Single();
+                return clock.CurrentTime >= clock.GameplayStartTime - MasterGameplayClockContainer.MINIMUM_SKIP_TIME;
+            });
+        }
+
         private void setup(Func<IReadOnlyList<Mod>>? mods = null)
         {
             setupBeforeGameplayStart(mods);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerPlayer.cs
@@ -56,6 +56,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
         private void setup(Func<IReadOnlyList<Mod>>? mods = null)
         {
+            setupBeforeGameplayStart(mods);
+            startGameplay();
+        }
+
+        private void setupBeforeGameplayStart(Func<IReadOnlyList<Mod>>? mods = null)
+        {
             AddStep("set beatmap", () =>
             {
                 Beatmap.Value = CreateWorkingBeatmap(new OsuRuleset().RulesetInfo);
@@ -69,7 +75,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("initialise gameplay", () =>
             {
-                Stack.Push(player = new MultiplayerPlayer(MultiplayerClient.ServerAPIRoom!, new PlaylistItem(Beatmap.Value.BeatmapInfo)
+                Stack.Push(player = new MultiplayerPlayer(MultiplayerClient.ClientAPIRoom!, new PlaylistItem(Beatmap.Value.BeatmapInfo)
                 {
                     RulesetID = Beatmap.Value.BeatmapInfo.Ruleset.OnlineID,
                 }, MultiplayerClient.ServerRoom!.Users.ToArray()));
@@ -79,7 +85,10 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddAssert("gameplay clock is paused", () => player.ChildrenOfType<GameplayClockContainer>().Single().IsPaused.Value);
             AddAssert("gameplay clock is not running", () => !player.ChildrenOfType<GameplayClockContainer>().Single().IsRunning);
+        }
 
+        private void startGameplay()
+        {
             AddStep("start gameplay", () => ((IMultiplayerClient)MultiplayerClient).GameplayStarted());
 
             AddUntilStep("gameplay clock is not paused", () => !player.ChildrenOfType<GameplayClockContainer>().Single().IsPaused.Value);

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -198,6 +198,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             loadingDisplay.Hide();
             base.StartGameplay();
 
+            // It is possible that the skip overlay has been clicked before `onGameplayStarted()'.
+            // If so, the intro-skipped clock will reset as gameplay starts, leaving the player unable to skip.
+            // This ensures the intro is properly skipped regardless of the overlay.
             if (Configuration.AutomaticallySkipIntro)
             {
                 RequestIntroSkip();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -197,6 +197,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             loadingDisplay.Hide();
             base.StartGameplay();
+
+            if (Configuration.AutomaticallySkipIntro)
+            {
+                base.RequestIntroSkip();
+            }
         });
 
         private void onResultsReady()
@@ -225,15 +230,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override void RequestIntroSkip()
         {
-            // If the room is set up such that the intro is automatically skipped, there's no need to vote on it.
-            if (Configuration.AutomaticallySkipIntro)
+            if (!Configuration.AutomaticallySkipIntro)
             {
-                base.RequestIntroSkip();
-                return;
+                // No base call because we aren't skipping yet.
+                client.VoteToSkipIntro().FireAndForget();
             }
-
-            // No base call because we aren't skipping yet.
-            client.VoteToSkipIntro().FireAndForget();
         }
 
         private void onVoteToSkipIntroPassed()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPlayer.cs
@@ -200,7 +200,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
             if (Configuration.AutomaticallySkipIntro)
             {
-                base.RequestIntroSkip();
+                RequestIntroSkip();
             }
         });
 
@@ -230,11 +230,15 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         protected override void RequestIntroSkip()
         {
-            if (!Configuration.AutomaticallySkipIntro)
+            // If the room is set up such that the intro is automatically skipped, there's no need to vote on it.
+            if (Configuration.AutomaticallySkipIntro)
             {
-                // No base call because we aren't skipping yet.
-                client.VoteToSkipIntro().FireAndForget();
+                base.RequestIntroSkip();
+                return;
             }
+
+            // No base call because we aren't skipping yet.
+            client.VoteToSkipIntro().FireAndForget();
         }
 
         private void onVoteToSkipIntroPassed()


### PR DESCRIPTION
Closes #36783 and #37906.

Ideally the clock is reset on `onGameplayStarted`, then the intro is automatically skipped on `RequestIntroSkip` (from `SkipOverlay.SkipWhenReady`).
However, if at least one other player stays in `PlayerLoader`, the players who enter the loaded state first are able to click the skip overlay before the gameplay starts.
This causes the clock to skip the intro first, then reset back to zero as the gameplay starts.