### PR TITLE
Fix global overlay offset not behaving as expected

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1739,7 +1739,7 @@ namespace osu.Game
 
             horizontalOffsetAdjust = (float)Interpolation.DampContinuously(horizontalOffsetAdjust, adjust, 100, Time.Elapsed);
             // Avoid having everything on the screen moving by miniscule amounts (can create overhead on busy screens).
-            if (Math.Abs(horizontalOffsetAdjust) < 0.5f)
+            if (adjust == 0 && Math.Abs(horizontalOffsetAdjust) < 0.2f)
                 horizontalOffsetAdjust = 0;
 
             ScreenOffsetContainer.X = horizontalOffsetAdjust;


### PR DESCRIPTION
abs(0) wasn't too great because it can cross over zero when two overlays
are toggled. to avoid this issue, we check if the target is also zero
before rounding the actual value down.

Closes https://github.com/ppy/osu/issues/38233.
