### PR TITLE
Adjust kiai flash on osu! hit circles to closer match stable

### DIFF
--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private readonly bool hasNumber;
 
         protected LegacyKiaiFlashingDrawable CircleSprite = null!;
-        protected LegacyKiaiFlashingDrawable OverlaySprite = null!;
+        protected Sprite OverlaySprite = null!;
 
         protected Container OverlayLayer { get; private set; } = null!;
 
@@ -93,12 +93,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    Child = OverlaySprite = new LegacyKiaiFlashingDrawable(() => new Sprite { Texture = skin.GetTexture(@$"{circleName}overlay")?.WithMaximumSize(maxSize) })
+                    Child = OverlaySprite = new Sprite
                     {
+                        Texture = skin.GetTexture(@$"{circleName}overlay")?.WithMaximumSize(maxSize),
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                     },
-                }
+                },
+                CircleSprite.FlashingDrawable.CreateProxy(),
             };
 
             if (hasNumber)
@@ -142,7 +144,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     255);
 
                 CircleSprite.Colour = LegacyColourCompatibility.DisallowZeroAlpha(colour.NewValue);
-                OverlaySprite.KiaiGlowColour = CircleSprite.KiaiGlowColour = LegacyColourCompatibility.DisallowZeroAlpha(kiaiTintColour);
+                CircleSprite.KiaiGlowColour = LegacyColourCompatibility.DisallowZeroAlpha(kiaiTintColour);
             }, true);
 
             if (hasNumber)

--- a/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
+++ b/osu.Game/Skinning/LegacyKiaiFlashingDrawable.cs
@@ -14,11 +14,11 @@ namespace osu.Game.Skinning
     {
         public Color4 KiaiGlowColour
         {
-            get => flashingDrawable.Colour;
-            set => flashingDrawable.Colour = value;
+            get => FlashingDrawable.Colour;
+            set => FlashingDrawable.Colour = value;
         }
 
-        private readonly Drawable flashingDrawable;
+        public readonly Drawable FlashingDrawable;
 
         private const float flash_opacity = 0.3f;
 
@@ -33,7 +33,7 @@ namespace osu.Game.Skinning
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;
                 }),
-                flashingDrawable = (creationFunc.Invoke() ?? Empty()).With(d =>
+                FlashingDrawable = (creationFunc.Invoke() ?? Empty()).With(d =>
                 {
                     d.Anchor = Anchor.Centre;
                     d.Origin = Anchor.Centre;
@@ -48,7 +48,7 @@ namespace osu.Game.Skinning
             if (!effectPoint.KiaiMode)
                 return;
 
-            flashingDrawable
+            FlashingDrawable
                 .FadeTo(flash_opacity)
                 .Then()
                 .FadeOut(Math.Max(80, timingPoint.BeatLength - 80), Easing.OutSine);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/26990.

| | baseline (stable, unadulterated) | lazer | difference |
| :-: | :-: | :-: | :-: |
| **master** | <img width="528" height="528" alt="stable-untouched" src="https://github.com/user-attachments/assets/50575b95-6446-43f4-aa6a-529b9595e194" /> | <img width="528" height="528" alt="lazer-master" src="https://github.com/user-attachments/assets/81faae45-9e61-44a8-b7a3-cfb3fea88c47" /> | <img width="528" height="528" alt="stable-untouched-vs-lazer-master" src="https://github.com/user-attachments/assets/68fbfec8-cc6a-47b8-a27f-110b03d4d05f" /> |
| **this PR** | <img width="528" height="528" alt="stable-untouched" src="https://github.com/user-attachments/assets/50575b95-6446-43f4-aa6a-529b9595e194" /> | <img width="528" height="528" alt="lazer-pr" src="https://github.com/user-attachments/assets/df2c5573-964d-418d-951c-01359692a25b" /> | <img width="528" height="528" alt="stable-untouched-vs-lazer-pr" src="https://github.com/user-attachments/assets/bcb0ec7c-3eeb-4afd-b86d-23018a4e478f" /> |

---

To explain this change I will first need to explain stable.

How kiai flashing works
-----------------------

As per stable source[^1] linked in https://github.com/ppy/osu/issues/26990#issuecomment-2391128493, kiai flashing for a hitobject `h` works in the following way:

- Take `h.CreateKiaiSprites()`.
	- For hit circles this is just `DimCollection[0].Clone()`[^2].
- Add `0.1f` to `Depth`.
- Set additive blending.
- Set colour of kiai sprite to accent colour of hitobject plus `max(25, 300 - R - G - B)` to each component.
- Add a fade-out transform.

There are two points of interest here to determine what stable does: what is `DimCollection[0]`, and what practical effect the `Depth` change has. To determine that, it is required to understand how a `HitCircleOsu` is rendered.

stable hit circle rendering
---------------------------

`HitCircleOsu` consists of the following sprites (listed in order of appearance in source and addition to `SpriteCollection`):[^3]

| Member name            | Texture name       | Depth                                               | `DimCollection` |
| :--------------------- | ------------------ | --------------------------------------------------- | --------------- |
| `SpriteApproachCircle` | `approachcircle`   | `drawOrderFwdPrio(2000 + StartTime - LocalPreEmpt)` | not present     |
| `SpriteHitCircle1`     | `hitcircle`        | `drawOrderBwd(StartTime)`                           | index `0`       |
| `SpriteHitCircle2`     | `hitcircleoverlay` | `drawOrderBwd(2000 + StartTime - LocalPreEmpt)`     | index `1`       |
| `SpriteHitCircleText`  | skin number font   | `drawOrderBwd(2000 + StartTime - LocalPreEmpt)`     | not present     |

The above already exposes one discrepancy compared to lazer. On master, the kiai effect is applied individually both to `hitcircle` and `hitcircleoverlay` - but stable never actually does the latter.

However, it is still unclear at what level in the depth ordering of sprites the cloned `hitcircle` that represents the kiai flash resides. Further analysis to determine this follows below.

Depth ordering analysis
-----------------------

First, let's define the two functions referenced above in the depth column:[^4]

```csharp
        /// <summary>
        ///   Used by hit values.  Has a range of 0.8-1 and loops every 10000 seconds (over 1 hour).
        /// </summary>
        /// <param name = "number"></param>
        /// <returns></returns>
        internal static
            float drawOrderFwdPrio(float number)
        {
            return 0.8F + (number % 6000000) / 30000000;
        }

        /// <summary>
        ///   Used by hitcircles.  Has a range of 0.8-0.2 and loops every 6000 seconds (1 hour).
        /// </summary>
        /// <param name = "number"></param>
        /// <returns></returns>
        internal static
            float drawOrderBwd(float number)
        {
            return 0.8F - (number % 6000000) / 10000000;
        }
```

To simplify further deliberations, let's assume some variables. These assumptions are a bit shaky, but should not meaningfully disturb further deliberations.

- `StartTime = 2000`
- `LocalPreEmpt = 1200` (corresponds to AR=5),
- `OverlayAboveNumber = true` (default).

Given the above assumptions, we have:

- `SpriteApproachCircle` with depth 0.8+(2000+2000-1200)/30000000 = 0.8000933333
- `SpriteHitCircle1` with depth 0.8-(2000/10000000) = 0.7998
- `SpriteHitCircle2` with depth 0.8-((2000-2)/10000000) = 0.7998002
- `SpriteHitCircleText` with depth 0.8-((2000-1)/10000000) = 0.7998001
- The kiai flashing sprite has depth of `SpriteHitCircle1` + 0.1 = 0.8998

Which would make the final ordering:

1. `SpriteHitCircle1` on the bottom
2. `SpriteHitCircleText` above (1)
3. `SpriteHitCircle2` above (2)
4. `SpriteApproachCircle` above (3)
5. The kiai flashing sprite above (4) and topmost.

This exposes the second discrepancy: the kiai flashing sprite, despite being only a copy of `SpriteHitCircle1` / `hitcircle`, is positioned *above* `SpriteHitCircle2` / `hitcircleoverlay` and will in fact be faintly visible on some skins as a subtle halo on `hitcircleoverlay`.

To illustrate this, see the following series of screenshots (recommend viewing these against a dark background):

| stable, kiai sprite with initial alpha set to zero | stable, kiai sprite with initial alpha set to 1 | difference (with pink rings highlighting bounds of the `hitcircleoverlay` ring) |
| :-: | :-: | :-: |
| <img width="522" height="522" alt="stable-no-kiai-effect" src="https://github.com/user-attachments/assets/4fa1240d-daa9-4061-9b6c-6b9db4da13f6" /> | <img width="522" height="522" alt="stable-kiai-effect-exaggerated" src="https://github.com/user-attachments/assets/a7408207-04bc-4b68-93d3-f337caf55640" /> | <img width="522" height="522" alt="stable-kiai-difference" src="https://github.com/user-attachments/assets/27ad41bf-68d5-4813-a664-2e40f2dcdbef" /> |

You should see a faint amount of green creep outside of the inner pink ring, which proves that on stable the kiai effect sprite is in front of `hitcircleoverlay`.

The fix
-------

To correct the above, the following is done:

- The `hitcircleoverlay` sprite is no longer wrapped in a `LegacyKiaiFlashingDrawable` instance, because as discussed above, in stable it is not used for the kiai effect in any way.
- The flashing sprite from the `LegacyKiaiFlashingDrawable` instance that is wrapping `hitcircle` is proxied out to be in front of `hitcircle`, `hitcircleoverlay`, and the combo number. This should match stable's depth ordering behaviour at least in the simple case.

  To disclaim from the get-go, I have not looked into worse cases like slider repeats, as the ordering is significantly more complicated in that case (https://github.com/ppy/osu/pull/14561#issuecomment-907785826). I am sort of hoping it will be fine, but I will double check if I am made to - I kind of want to see the reaction to what is in this diff already before expending even more effort towards this task.

[^1]: Stable reference: [`Ruleset.UpdateKiai()`](https://github.com/peppy/osu-stable-reference/blob/0e0aa3b29b10c81ef917de0551421274d22cdc79/osu!/GameModes/Play/Rulesets/Ruleset.cs#L1400-L1459)
[^2]: Stable reference: [`HitObject.CreateKiaiSprites()`](https://github.com/peppy/osu-stable-reference/blob/0e0aa3b29b10c81ef917de0551421274d22cdc79/osu!/GameplayElements/HitObjects/HitObject.cs#L326-L334)
[^3]: Stable reference: [`HitCircleOsu` constructor](https://github.com/peppy/osu-stable-reference/blob/0e0aa3b29b10c81ef917de0551421274d22cdc79/osu!/GameplayElements/HitObjects/Osu/HitCircleOsu.cs#L81-L113)
[^4]: Stable reference: [`SpriteManager`](https://github.com/peppy/osu-stable-reference/blob/0e0aa3b29b10c81ef917de0551421274d22cdc79/osu!/Graphics/Sprites/SpriteManager.cs#L755-L775)