### PR TITLE
Add localisation support to short relative timestamps on score leaderboards

### DIFF
--- a/osu.Game/Extensions/TimeDisplayExtensions.cs
+++ b/osu.Game/Extensions/TimeDisplayExtensions.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using Humanizer;
+using System.Globalization;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Localisation;
 using osu.Game.Resources.Localisation.Web;
@@ -57,7 +57,7 @@ namespace osu.Game.Extensions
         /// <param name="time">The time to be displayed.</param>
         /// <param name="lowerCutoff">A timespan denoting the time length beneath which "now" should be displayed.</param>
         /// <returns>A short relative string representing the input time.</returns>
-        public static string ToShortRelativeTime(this DateTimeOffset time, TimeSpan lowerCutoff)
+        public static LocalisableString ToShortRelativeTime(this DateTimeOffset time, TimeSpan lowerCutoff)
         {
             // covers all `DateTimeOffset` instances with the date portion of 0001-01-01.
             if (time.Date == default)
@@ -66,42 +66,68 @@ namespace osu.Game.Extensions
             var now = DateTime.Now;
             var difference = now - time;
 
-            // web uses momentjs's custom locales to format the date for the purposes of the scoreboard.
-            // this is intended to be a best-effort, more legible approximation of that.
-            // compare:
-            // * https://github.com/ppy/osu-web/blob/a8f5a68fb435cb19a4faa4c7c4bce08c4f096933/resources/assets/lib/scoreboard-time.tsx
-            // * https://momentjs.com/docs/#/customization/ (reference for the customisation format)
-
-            // TODO: support localisation (probably via `CommonStrings.CountHours()` etc.)
-            // requires pluralisable string support framework-side
+            // formatting mirrors the osu-web scoreboard, reusing its (already localised) `common.scoreboard_time.*` strings.
+            // these are in moment.js format: a `%d` count placeholder plus a separate singular/plural variant per unit.
+            // compare: https://github.com/ppy/osu-web/blob/a8f5a68fb435cb19a4faa4c7c4bce08c4f096933/resources/assets/lib/scoreboard-time.tsx
 
             if (difference < lowerCutoff)
-                return CommonStrings.TimeNow.ToString();
+                return CommonStrings.TimeNow;
 
             if (difference.TotalMinutes < 1)
-                return "sec".ToQuantity((int)difference.TotalSeconds);
+                return scoreboardTime((int)difference.TotalSeconds, CommonStrings.ScoreboardTimes, CommonStrings.ScoreboardTimes);
             if (difference.TotalHours < 1)
-                return "min".ToQuantity((int)difference.TotalMinutes);
+                return scoreboardTime((int)difference.TotalMinutes, CommonStrings.ScoreboardTimem, CommonStrings.ScoreboardTimemm);
             if (difference.TotalDays < 1)
-                return "hr".ToQuantity((int)difference.TotalHours);
+                return scoreboardTime((int)difference.TotalHours, CommonStrings.ScoreboardTimeh, CommonStrings.ScoreboardTimehh);
 
             // this is where this gets more complicated because of how the calendar works.
             // since there's no `TotalMonths` / `TotalYears`, we have to iteratively add months/years
             // and test against cutoff dates to determine how many months/years to show.
 
             if (time > now.AddMonths(-1))
-                return difference.TotalDays < 2 ? "1dy" : $"{(int)difference.TotalDays}dys";
+                return scoreboardTime((int)difference.TotalDays, CommonStrings.ScoreboardTimed, CommonStrings.ScoreboardTimedd);
 
             for (int months = 1; months <= 11; ++months)
             {
                 if (time > now.AddMonths(-(months + 1)))
-                    return months == 1 ? "1mo" : $"{months}mos";
+                    return scoreboardTime(months, CommonStrings.ScoreboardTimeMonth, CommonStrings.ScoreboardTimeMonths);
             }
 
             int years = 1;
             while (time <= now.AddYears(-(years + 1)))
                 years += 1;
-            return years == 1 ? "1yr" : $"{years}yrs";
+            return scoreboardTime(years, CommonStrings.ScoreboardTimey, CommonStrings.ScoreboardTimeyy);
+        }
+
+        // moment.js uses the singular variant when the (rounded) count is exactly 1, and the plural variant otherwise.
+        private static LocalisableString scoreboardTime(int count, LocalisableString singular, LocalisableString plural)
+            => new LocalisableString(new ScoreboardTimeString(count == 1 ? singular : plural, count));
+
+        /// <summary>
+        /// Resolves an osu-web scoreboard time unit string (moment.js format, e.g. <c>"%dd"</c> or <c>"now"</c>),
+        /// substituting the moment.js <c>%d</c> count placeholder for <see cref="Count"/> in the target culture.
+        /// </summary>
+        private class ScoreboardTimeString : ILocalisableStringData
+        {
+            public readonly LocalisableString Unit;
+            public readonly int Count;
+
+            public ScoreboardTimeString(LocalisableString unit, int count)
+            {
+                Unit = unit;
+                Count = count;
+            }
+
+            public string GetLocalised(LocalisationParameters parameters)
+            {
+                // `Unit`'s underlying data is not accessible from here, so it is resolved via a non-splitting `PluralisableString`.
+                string format = new PluralisableString(Unit, Count, '\0').GetLocalised(parameters);
+                return format.Replace(@"%d", Count.ToString(parameters.Store?.EffectiveCulture ?? CultureInfo.CurrentCulture));
+            }
+
+            public override string ToString() => GetLocalised(LocalisationParameters.DEFAULT);
+
+            public bool Equals(ILocalisableStringData? other) => other is ScoreboardTimeString s && Count == s.Count && Unit.Equals(s.Unit);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38065.

Relative timestamps on score leaderboards ("4d", "9mo", "1y") were hardcoded to English rather than going through localisation, so non-English clients showed untranslated text while the hover tooltip was already localised. Reuses osu-web's existing `common.scoreboard_time.*` strings (same ones the in-game web views use) instead.

| Before | After |
| --- | --- |
| <img width="960" height="1080" alt="image" src="https://github.com/user-attachments/assets/0df40410-b75b-4dbf-9cbe-1cdc8c2a2e25" /> | <img width="932" height="1079" alt="image" src="https://github.com/user-attachments/assets/621c2f3a-9b27-451a-b7e7-72825b7d7bbe" /> |
