### PR TITLE
Fix daily challenge profile badge size not matching ranked play badge size

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneUserProfileOverlay.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
@@ -24,6 +26,9 @@ namespace osu.Game.Tests.Visual.Online
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
         private UserProfileOverlay profile = null!;
+
+        [Resolved]
+        private FrameworkConfigManager configManager { get; set; } = null!;
 
         [SetUpSteps]
         public void SetUp()
@@ -232,6 +237,37 @@ namespace osu.Game.Tests.Visual.Online
             }));
         }
 
+        [Test]
+        public void TestOtherLanguages()
+        {
+            AddStep("set up request handling", () =>
+            {
+                dummyAPI.HandleRequest = req =>
+                {
+                    if (req is GetUserRequest getUserRequest)
+                    {
+                        getUserRequest.TriggerSuccess(TEST_USER);
+                        return true;
+                    }
+
+                    if (req is GetUserBeatmapsRequest getUserBeatmapsRequest)
+                    {
+                        getUserBeatmapsRequest.TriggerSuccess(new List<APIBeatmapSet>
+                        {
+                            CreateAPIBeatmapSet(),
+                            CreateAPIBeatmapSet()
+                        });
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+            AddStep("show user", () => profile.ShowUser(new APIUser { Id = 1 }));
+            AddStep("set language", () => configManager.SetValue(FrameworkSetting.Locale, "ko"));
+            AddStep("restore language", () => configManager.SetValue(FrameworkSetting.Locale, string.Empty));
+        }
+
         public static readonly APIUser TEST_USER = new APIUser
         {
             Username = @"Somebody",
@@ -331,7 +367,24 @@ namespace osu.Game.Tests.Visual.Online
                 WeeklyStreakBest = 51,
                 Top10PercentPlacements = 345,
                 Top50PercentPlacements = 427,
+                PlayCount = 213,
             },
+            MatchmakingStatistics =
+            [
+                new APIUserMatchmakingStatistics
+                {
+                    Pool = new APIMatchmakingPool
+                    {
+                        Active = true,
+                        Name = "osu!",
+                    },
+                    Rating = 1234,
+                    Rank = 333,
+                    FirstPlacements = 1234,
+                    Plays = 4444,
+                    TotalPoints = 5555,
+                }
+            ],
             Title = "osu!volunteer",
             Colour = "ff0000",
             Achievements = Array.Empty<APIUserAchievement>(),

--- a/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/DailyChallengeStatsDisplay.cs
@@ -54,7 +54,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
             {
                 content = new Container
                 {
-                    AutoSizeAxes = Axes.Both,
+                    AutoSizeAxes = Axes.X,
+                    Height = MainDetails.BADGE_HEIGHT,
                     CornerRadius = 6,
                     BorderThickness = 2,
                     BorderColour = colourProvider.Background4,
@@ -71,17 +72,22 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Padding = new MarginPadding(3f),
-                            AutoSizeAxes = Axes.Both,
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
                             Direction = FillDirection.Horizontal,
                             Children = new Drawable[]
                             {
                                 label = new OsuTextFlowContainer(s => s.Font = OsuFont.GetFont(size: 12))
                                 {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
                                     AutoSizeAxes = Axes.Both,
-                                    Margin = new MarginPadding { Horizontal = 5f, Bottom = 2f },
+                                    Margin = new MarginPadding { Horizontal = 5f, },
                                 },
                                 new Container
                                 {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
                                     AutoSizeAxes = Axes.X,
                                     RelativeSizeAxes = Axes.Y,
                                     CornerRadius = 3,

--- a/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MainDetails.cs
@@ -21,6 +21,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
 {
     public partial class MainDetails : CompositeDrawable
     {
+        public const float BADGE_HEIGHT = 36;
+
         private readonly Dictionary<ScoreRank, ScoreRankInfo> scoreRankInfos = new Dictionary<ScoreRank, ScoreRankInfo>();
         private ProfileValueDisplay medalInfo = null!;
         private ProfileValueDisplay ppInfo = null!;

--- a/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsDisplay.cs
+++ b/osu.Game/Overlays/Profile/Header/Components/MatchmakingStatsDisplay.cs
@@ -36,7 +36,8 @@ namespace osu.Game.Overlays.Profile.Header.Components
             {
                 new Container
                 {
-                    AutoSizeAxes = Axes.Both,
+                    AutoSizeAxes = Axes.X,
+                    Height = MainDetails.BADGE_HEIGHT,
                     CornerRadius = 6,
                     BorderThickness = 2,
                     BorderColour = colourProvider.Background4,
@@ -53,18 +54,23 @@ namespace osu.Game.Overlays.Profile.Header.Components
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Padding = new MarginPadding(3f),
-                            AutoSizeAxes = Axes.Both,
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
                             Direction = FillDirection.Horizontal,
                             Children = new Drawable[]
                             {
                                 new OsuSpriteText
                                 {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
                                     Text = UsersStrings.ShowMatchmakingTitle,
-                                    Margin = new MarginPadding { Horizontal = 5f, Vertical = 7f },
+                                    Margin = new MarginPadding { Horizontal = 5f, },
                                     Font = OsuFont.GetFont(size: 12)
                                 },
                                 new Container
                                 {
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
                                     AutoSizeAxes = Axes.X,
                                     RelativeSizeAxes = Axes.Y,
                                     CornerRadius = 3,


### PR DESCRIPTION
| before | after |
| :-: | :-: |
| <img width="291" height="71" alt="Screenshot 2026-07-09 at 14 44 15" src="https://github.com/user-attachments/assets/7625aaa7-9192-44aa-9220-1c0571b80370" /> | <img width="290" height="54" alt="Screenshot 2026-07-09 at 15 00 04" src="https://github.com/user-attachments/assets/29a2d014-65c8-4e64-be6a-3783cc41f319" /> |

---

Closes https://github.com/ppy/osu/issues/38255.

Hardcoding a height is a pretty sucky fix but I'm not sure I see better alternatives and this works for all languages that we have in the game.

This also includes a visual tests so it doesn't require running the game in release to visually review this. I'm not entirely sure that doing that is a good idea, I half-expect there to be hell in tests from touching locale. So maybe wait until this goes through CI green before clicking any buttons.