### PR TITLE
Make Mania mods "Invert" and "No Release" mutually incompatible

### DIFF
--- a/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModInvert.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override ModType Type => ModType.Conversion;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ManiaModHoldOff) };
+        public override Type[] IncompatibleMods => new[] { typeof(ManiaModHoldOff), typeof(ManiaModNoRelease) };
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {

--- a/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
+++ b/osu.Game.Rulesets.Mania/Mods/ManiaModNoRelease.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Rulesets.Mania.Mods
 
         public override ModType Type => ModType.DifficultyReduction;
 
-        public override Type[] IncompatibleMods => new[] { typeof(ManiaModHoldOff) };
+        public override Type[] IncompatibleMods => new[] { typeof(ManiaModHoldOff), typeof(ManiaModInvert) };
 
         public void ApplyToBeatmap(IBeatmap beatmap)
         {


### PR DESCRIPTION
"No Release" mod changes the beatmap's notes before "Invert" mod runs. "Invert" rebuilds the whole beatmap, replacing all the No Release hold notes with regular hold notes.

This is a workaround, not a real fix — the two mods could compose correctly if IApplicableAfterBeatmapConversion mods were applied in a different order (currently determined by ModType).

Reference issue: #37871