### PR TITLE
Add a "Download Replay" button to score context menu

### DIFF
--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -118,6 +118,7 @@ namespace osu.Game.Localisation
         /// "Download replay"
         /// </summary>
         public static LocalisableString DownloadReplay => new TranslatableString(getKey(@"download_replay"), @"Download replay");
+
         /// <summary>
         /// "Replay downloading"
         /// </summary>

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -118,6 +118,10 @@ namespace osu.Game.Localisation
         /// "Download replay"
         /// </summary>
         public static LocalisableString DownloadReplay => new TranslatableString(getKey(@"download_replay"), @"Download replay");
+        /// <summary>
+        /// "Replay downloading"
+        /// </summary>
+        public static LocalisableString ReplayDownloading => new TranslatableString(getKey(@"replay_downloading"), @"Replay downloading");
 
         /// <summary>
         /// "For all difficulties"

--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -115,6 +115,11 @@ namespace osu.Game.Localisation
         public static LocalisableString WatchReplay => new TranslatableString(getKey(@"watch_replay"), @"Watch replay");
 
         /// <summary>
+        /// "Download replay"
+        /// </summary>
+        public static LocalisableString DownloadReplay => new TranslatableString(getKey(@"download_replay"), @"Download replay");
+
+        /// <summary>
         /// "For all difficulties"
         /// </summary>
         public static LocalisableString ForAllDifficulties => new TranslatableString(getKey(@"for_all_difficulties"), @"For all difficulties");

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -630,7 +630,7 @@ namespace osu.Game.Screens.Select
                     items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => game?.CopyToClipboard($@"{api.Endpoints.WebsiteUrl}/scores/{Score.OnlineID}")));
 
                 if (Score.HasOnlineReplay && Score.Files.Count == 0)
-                    items.Add(new OsuMenuItem(@"Download replay", MenuItemType.Standard, () => scoreDownloader.Download(Score)));
+                    items.Add(new OsuMenuItem(SongSelectStrings.DownloadReplay, MenuItemType.Standard, () => scoreDownloader.Download(Score)));
 
                 if (Score.Files.Count <= 0) return items.ToArray();
 

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -623,16 +623,25 @@ namespace osu.Game.Screens.Select
                 // system mods should never be copied across regardless of anything.
                 var copyableMods = Score.Mods.Where(m => IsValidMod.Invoke(m) && m.Type != ModType.System).ToArray();
 
+                bool replayAvailableLocally = scoreManager.IsAvailableLocally(Score);
+                bool replayDownloading = scoreDownloader.GetExistingDownload(Score) != null;
+
                 if (copyableMods.Length > 0)
                     items.Add(new OsuMenuItem(SongSelectStrings.UseTheseMods, MenuItemType.Highlighted, () => SelectedMods.Value = copyableMods));
 
                 if (Score.OnlineID > 0)
                     items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => game?.CopyToClipboard($@"{api.Endpoints.WebsiteUrl}/scores/{Score.OnlineID}")));
 
-                if (Score.HasOnlineReplay && Score.Files.Count == 0)
-                    items.Add(new OsuMenuItem(SongSelectStrings.DownloadReplay, MenuItemType.Standard, () => scoreDownloader.Download(Score)));
+                if (!replayAvailableLocally)
+                {
+                    if (replayDownloading)
+                        items.Add(new OsuMenuItem(SongSelectStrings.ReplayDownloading));
+                    else if (Score.HasOnlineReplay)
+                        items.Add(new OsuMenuItem(SongSelectStrings.DownloadReplay, MenuItemType.Standard, () => scoreDownloader.Download(Score)));
+                }
 
-                if (Score.Files.Count <= 0) return items.ToArray();
+                if (Score.Files.Count <= 0)
+                    return items.ToArray();
 
                 if (items.Count > 0)
                     items.Add(new OsuMenuItemSpacer());

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -82,7 +82,7 @@ namespace osu.Game.Screens.Select
         private IAPIProvider api { get; set; } = null!;
 
         [Resolved]
-        private ScoreModelDownloader scoreDownloader { get; set; }
+        private ScoreModelDownloader scoreDownloader { get; set; } = null!;
 
         private const float expanded_right_content_width = 200;
         private const float grade_width = 35;

--- a/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
+++ b/osu.Game/Screens/Select/BeatmapLeaderboardScore.cs
@@ -81,6 +81,9 @@ namespace osu.Game.Screens.Select
         [Resolved]
         private IAPIProvider api { get; set; } = null!;
 
+        [Resolved]
+        private ScoreModelDownloader scoreDownloader { get; set; }
+
         private const float expanded_right_content_width = 200;
         private const float grade_width = 35;
         private const float username_min_width = 120;
@@ -625,6 +628,9 @@ namespace osu.Game.Screens.Select
 
                 if (Score.OnlineID > 0)
                     items.Add(new OsuMenuItem(CommonStrings.CopyLink, MenuItemType.Standard, () => game?.CopyToClipboard($@"{api.Endpoints.WebsiteUrl}/scores/{Score.OnlineID}")));
+
+                if (Score.HasOnlineReplay && Score.Files.Count == 0)
+                    items.Add(new OsuMenuItem(@"Download replay", MenuItemType.Standard, () => scoreDownloader.Download(Score)));
 
                 if (Score.Files.Count <= 0) return items.ToArray();
 


### PR DESCRIPTION
I thought the score context menu looked really bland.
The button only shows up in online leaderboards (global, country and friends).
A "Watch replay" button that downloads the replay and watches it could be added in the future, but this was a pretty simple PR so I thought I would just do this first.

Inspired by #37053.