### PR TITLE
Display queue time as hh:mm:ss for durations above 1 hour

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -893,12 +893,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 base.Update();
 
-                var elapsed = queue.QueueTimer.Elapsed;
-
-                if (elapsed.TotalHours >= 1)
-                    Text = $"{(int)elapsed.TotalHours:00}:{elapsed.Minutes:00}:{elapsed.Seconds:00}";
-                else
-                    Text = elapsed.ToString(@"mm\:ss");
+                Text = queue.QueueTimer.Elapsed.ToFormattedDuration();
             }
         }
     }

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -24,6 +24,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -893,7 +893,12 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
             {
                 base.Update();
 
-                Text = queue.QueueTimer.Elapsed.ToString(@"mm\:ss");
+                var elapsed = queue.QueueTimer.Elapsed;
+
+                if (elapsed.TotalHours >= 1)
+                    Text = $"{(int)elapsed.TotalHours:00}:{elapsed.Minutes:00}:{elapsed.Seconds:00}";
+                else
+                    Text = elapsed.ToString(@"mm\:ss");
             }
         }
     }


### PR DESCRIPTION
A fix for those in the ranked queue for over 1 hours. Displays 8h as 08:00:00, ~~2d as 48:00:00 and 10d as 240:00:00~~. For ranked queue timespan below 1 hours, retain xx:xx.

**EDIT 1:** Upon suggestion, opted for `osu.Game.Extensions.TimeDisplayExtensions.ToFormattedDuration`.