### PR TITLE
Fix Mania "No Release" and "Invert" mod combination

### DIFF
--- a/osu.Game/Beatmaps/WorkingBeatmap.cs
+++ b/osu.Game/Beatmaps/WorkingBeatmap.cs
@@ -297,8 +297,29 @@ namespace osu.Game.Beatmaps
             // Convert
             IBeatmap converted = converter.Convert(token);
 
+            List<IApplicableAfterBeatmapConversion> applicableAfterBeatmapConversions = mods.OfType<IApplicableAfterBeatmapConversion>().ToList();
+            List<IApplicableAfterBeatmapConversion> applicableAfterBeatmapConversionsSorted = new List<IApplicableAfterBeatmapConversion>();
+            IApplicableAfterBeatmapConversion noRelease = null;
+
+            foreach (var mod in applicableAfterBeatmapConversions)
+            {
+                if (mod.GetType().Name == "ManiaModNoRelease")
+                {
+                    noRelease = mod;
+                }
+                else
+                {
+                    applicableAfterBeatmapConversionsSorted.Add(mod);
+                }
+            }
+
+            if (noRelease != null)
+            {
+                applicableAfterBeatmapConversionsSorted.Add(noRelease);
+            }
+
             // Apply conversion mods to the result
-            foreach (var mod in mods.OfType<IApplicableAfterBeatmapConversion>())
+            foreach (var mod in applicableAfterBeatmapConversionsSorted)
             {
                 token.ThrowIfCancellationRequested();
                 mod.ApplyToBeatmap(converted);


### PR DESCRIPTION
- Fixes: https://github.com/ppy/osu/issues/37871

This PR makes No Release and Invert mods to work correctly, by making No Release load last.
I think this is better than making the 2 mods incompatible like in this [PR](https://github.com/ppy/osu/pull/38267).