### PR TITLE
Allow to hide hit objects instantly when hit in taiko

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHitAnimations.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHitAnimations.cs
@@ -1,0 +1,140 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Taiko.Configuration;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Replays;
+using osu.Game.Rulesets.Taiko.Tests.Mods;
+
+namespace osu.Game.Rulesets.Taiko.Tests
+{
+    public partial class TestSceneHitAnimations : TaikoModTestScene
+    {
+        [Test]
+        public void TestGameplayCompletesWithHitAnimationsDisabled()
+        {
+            setHitAnimations(false);
+
+            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+
+            CreateModTest(new ModTestData
+            {
+                Autoplay = true,
+                CreateBeatmap = createBeatmapWithStrongHit,
+                PassCondition = () => judgedHitsAlwaysHidden()
+                                      && Player.ScoreProcessor.HasCompleted.Value
+                                      && Player.Results.All(result => result.Type == result.Judgement.MaxResult),
+            });
+        }
+
+        [Test]
+        public void TestGameplayCompletesWhenStrongHitPressedWithSingleKey()
+        {
+            setHitAnimations(false);
+
+            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+
+            CreateModTest(new ModTestData
+            {
+                Autoplay = false,
+                CreateBeatmap = createBeatmapWithStrongHit,
+                // hit the strong note with a single key, such that its nested strong hit
+                // has to wait out the full second-hit window before it can be judged.
+                ReplayFrames = new List<ReplayFrame>
+                {
+                    new TaikoReplayFrame(100, TaikoAction.LeftCentre),
+                    new TaikoReplayFrame(120),
+                    new TaikoReplayFrame(300, TaikoAction.LeftRim),
+                    new TaikoReplayFrame(320),
+                },
+                PassCondition = () => judgedHitsAlwaysHidden() && Player.ScoreProcessor.HasCompleted.Value,
+            });
+        }
+
+        [Test]
+        public void TestGameplayCompletesWhenMissingWithHitAnimationsDisabled()
+        {
+            setHitAnimations(false);
+
+            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+
+            CreateModTest(new ModTestData
+            {
+                Autoplay = false,
+                CreateBeatmap = createBeatmapWithStrongHit,
+                PassCondition = () => judgedHitsAlwaysHidden() && Player.ScoreProcessor.HasCompleted.Value,
+            });
+        }
+
+        [Test]
+        public void TestHitsStillVisibleAfterJudgementWithHitAnimationsEnabled()
+        {
+            setHitAnimations(true);
+
+            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+
+            CreateModTest(new ModTestData
+            {
+                Autoplay = true,
+                CreateBeatmap = createBeatmapWithStrongHit,
+                PassCondition = () => !judgedHitsAlwaysHidden()
+                                      && Player.ScoreProcessor.HasCompleted.Value
+                                      && Player.Results.All(result => result.Type == result.Judgement.MaxResult),
+            });
+        }
+
+        private Func<bool> checkJudgedHitsAlwaysHidden()
+        {
+            bool judgedHitSeenVisible = false;
+
+            return () =>
+            {
+                judgedHitSeenVisible |= getJudgedHits().Any(hit => hit.Alpha > 0);
+                return !judgedHitSeenVisible;
+            };
+        }
+
+        private IEnumerable<DrawableHit> getJudgedHits()
+            => Player.ChildrenOfType<DrawableHit>().Where(hit => hit.Judged && hit.Time.Current > hit.HitStateUpdateTime);
+
+        private void setHitAnimations(bool enabled)
+            => AddStep($"set hit animations to {enabled}", () =>
+            {
+                var config = (TaikoRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull();
+                config.SetValue(TaikoRulesetSetting.HitAnimations, enabled);
+            });
+
+        private static IBeatmap createBeatmapWithStrongHit()
+        {
+            var beatmap = new Beatmap<TaikoHitObject>
+            {
+                HitObjects = new List<TaikoHitObject>
+                {
+                    new Hit { Type = HitType.Centre, StartTime = 100 },
+                    new Hit { Type = HitType.Rim, StartTime = 300, IsStrong = true },
+                    new DrumRoll { StartTime = 500, Duration = 600 },
+                    new Swell { StartTime = 1300, Duration = 500 },
+                },
+                BeatmapInfo =
+                {
+                    Ruleset = new TaikoRuleset().RulesetInfo,
+                },
+            };
+
+            // shorten the beat length such that the drum roll generates some ticks.
+            beatmap.ControlPointInfo.Add(0, new TimingControlPoint { BeatLength = 200 });
+
+            return beatmap;
+        }
+    }
+}

--- a/osu.Game.Rulesets.Taiko.Tests/TestSceneHitAnimations.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/TestSceneHitAnimations.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -25,15 +24,19 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             setHitAnimations(false);
 
-            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+            bool allSuccessfulHitsImmediatelyHidden = true;
 
             CreateModTest(new ModTestData
             {
                 Autoplay = true,
                 CreateBeatmap = createBeatmapWithStrongHit,
-                PassCondition = () => judgedHitsAlwaysHidden()
-                                      && Player.ScoreProcessor.HasCompleted.Value
-                                      && Player.Results.All(result => result.Type == result.Judgement.MaxResult),
+                PassCondition = () =>
+                {
+                    allSuccessfulHitsImmediatelyHidden &= getSuccessfulHits().All(h => h.Alpha == 0);
+                    return allSuccessfulHitsImmediatelyHidden
+                           && Player.ScoreProcessor.HasCompleted.Value
+                           && Player.Results.All(result => result.Type == result.Judgement.MaxResult);
+                },
             });
         }
 
@@ -42,7 +45,7 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             setHitAnimations(false);
 
-            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+            bool allSuccessfulHitsImmediatelyHidden = true;
 
             CreateModTest(new ModTestData
             {
@@ -57,7 +60,11 @@ namespace osu.Game.Rulesets.Taiko.Tests
                     new TaikoReplayFrame(300, TaikoAction.LeftRim),
                     new TaikoReplayFrame(320),
                 },
-                PassCondition = () => judgedHitsAlwaysHidden() && Player.ScoreProcessor.HasCompleted.Value,
+                PassCondition = () =>
+                {
+                    allSuccessfulHitsImmediatelyHidden &= getSuccessfulHits().All(h => h.Alpha == 0);
+                    return allSuccessfulHitsImmediatelyHidden && Player.ScoreProcessor.HasCompleted.Value;
+                },
             });
         }
 
@@ -66,13 +73,17 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             setHitAnimations(false);
 
-            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+            bool allSuccessfulHitsImmediatelyHidden = true;
 
             CreateModTest(new ModTestData
             {
                 Autoplay = false,
                 CreateBeatmap = createBeatmapWithStrongHit,
-                PassCondition = () => judgedHitsAlwaysHidden() && Player.ScoreProcessor.HasCompleted.Value,
+                PassCondition = () =>
+                {
+                    allSuccessfulHitsImmediatelyHidden &= getSuccessfulHits().All(h => h.Alpha == 0);
+                    return allSuccessfulHitsImmediatelyHidden && Player.ScoreProcessor.HasCompleted.Value;
+                },
             });
         }
 
@@ -81,31 +92,24 @@ namespace osu.Game.Rulesets.Taiko.Tests
         {
             setHitAnimations(true);
 
-            Func<bool> judgedHitsAlwaysHidden = checkJudgedHitsAlwaysHidden();
+            bool allSuccessfulHitsImmediatelyHidden = true;
 
             CreateModTest(new ModTestData
             {
                 Autoplay = true,
                 CreateBeatmap = createBeatmapWithStrongHit,
-                PassCondition = () => !judgedHitsAlwaysHidden()
-                                      && Player.ScoreProcessor.HasCompleted.Value
-                                      && Player.Results.All(result => result.Type == result.Judgement.MaxResult),
+                PassCondition = () =>
+                {
+                    allSuccessfulHitsImmediatelyHidden &= getSuccessfulHits().All(h => h.Alpha == 0);
+                    return !allSuccessfulHitsImmediatelyHidden
+                           && Player.ScoreProcessor.HasCompleted.Value
+                           && Player.Results.All(result => result.Type == result.Judgement.MaxResult);
+                },
             });
         }
 
-        private Func<bool> checkJudgedHitsAlwaysHidden()
-        {
-            bool judgedHitSeenVisible = false;
-
-            return () =>
-            {
-                judgedHitSeenVisible |= getJudgedHits().Any(hit => hit.Alpha > 0);
-                return !judgedHitSeenVisible;
-            };
-        }
-
-        private IEnumerable<DrawableHit> getJudgedHits()
-            => Player.ChildrenOfType<DrawableHit>().Where(hit => hit.Judged && hit.Time.Current > hit.HitStateUpdateTime);
+        private IEnumerable<DrawableHit> getSuccessfulHits()
+            => Player.ChildrenOfType<DrawableHit>().Where(hit => hit.Judged && hit.Result.IsHit && hit.Time.Current > hit.HitStateUpdateTime);
 
         private void setHitAnimations(bool enabled)
             => AddStep($"set hit animations to {enabled}", () =>

--- a/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Taiko/Configuration/TaikoRulesetConfigManager.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Taiko.Configuration
 
             SetDefault(TaikoRulesetSetting.TouchControlScheme, TaikoTouchControlScheme.KDDK);
             SetDefault(TaikoRulesetSetting.RateAdjustedHitAnimation, true);
+            SetDefault(TaikoRulesetSetting.HitAnimations, true);
         }
     }
 
@@ -26,5 +27,6 @@ namespace osu.Game.Rulesets.Taiko.Configuration
     {
         TouchControlScheme,
         RateAdjustedHitAnimation,
+        HitAnimations,
     }
 }

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -41,6 +41,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private TaikoRulesetConfigManager taikoConfig { get; set; }
 
         private readonly Bindable<bool> rateAdjustedHitAnimations = new Bindable<bool>(true);
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
         private readonly Bindable<HitType> type = new Bindable<HitType>();
 
         private bool validActionPressed;
@@ -61,6 +62,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
         private void load()
         {
             taikoConfig?.BindWith(TaikoRulesetSetting.RateAdjustedHitAnimation, rateAdjustedHitAnimations);
+            taikoConfig?.BindWith(TaikoRulesetSetting.HitAnimations, hitAnimations);
         }
 
         protected override void OnApply()
@@ -167,10 +169,20 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     break;
 
                 case ArmedState.Miss:
-                    this.FadeOut(100);
+                    this.FadeOut(hitAnimations.Value ? 100 : 0);
                     break;
 
                 case ArmedState.Hit:
+                    if (!hitAnimations.Value)
+                    {
+                        this.FadeOut(0);
+
+                        // despite being invisible, this object must stay alive long enough for its nested strong hit (if any) to be judged,
+                        // otherwise gameplay will never complete (see also: `TaikoModHidden.ApplyNormalVisibilityState()`).
+                        LifetimeEnd = HitStateUpdateTime + StrongNestedHit.SECOND_HIT_WINDOW;
+                        break;
+                    }
+
                     // If we're far enough away from the left stage, we should bring ourselves in front of it
                     ProxyContent();
 

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -175,7 +175,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                 case ArmedState.Hit:
                     if (!hitAnimations.Value)
                     {
-                        this.FadeOut(0);
+                        this.FadeOut();
 
                         // despite being invisible, this object must stay alive long enough for its nested strong hit (if any) to be judged,
                         // otherwise gameplay will never complete (see also: `TaikoModHidden.ApplyNormalVisibilityState()`).

--- a/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
+++ b/osu.Game.Rulesets.Taiko/Objects/Drawables/DrawableHit.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Rulesets.Taiko.Objects.Drawables
                     break;
 
                 case ArmedState.Miss:
-                    this.FadeOut(hitAnimations.Value ? 100 : 0);
+                    this.FadeOut(hitAnimations.Value ? 100 : 60);
                     break;
 
                 case ArmedState.Hit:

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -35,6 +35,12 @@ namespace osu.Game.Rulesets.Taiko
                 }),
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = RulesetSettingsStrings.HitAnimations,
+                    HintText = RulesetSettingsStrings.HitAnimationsTooltip,
+                    Current = config.GetBindable<bool>(TaikoRulesetSetting.HitAnimations)
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = RulesetSettingsStrings.RateAdjustedHitAnimation,
                     HintText = RulesetSettingsStrings.RateAdjustedHitAnimationTooltip,
                     Current = config.GetBindable<bool>(TaikoRulesetSetting.RateAdjustedHitAnimation)

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Rulesets.Taiko
         {
             var config = (TaikoRulesetConfigManager)Config;
 
+            FormCheckBox rateAdjustedAnimations;
+            FormCheckBox hitAnimations;
+
             Children = new Drawable[]
             {
                 new SettingsItemV2(new FormEnumDropdown<TaikoTouchControlScheme>
@@ -33,13 +36,13 @@ namespace osu.Game.Rulesets.Taiko
                     Caption = RulesetSettingsStrings.TouchControlScheme,
                     Current = config.GetBindable<TaikoTouchControlScheme>(TaikoRulesetSetting.TouchControlScheme)
                 }),
-                new SettingsItemV2(new FormCheckBox
+                new SettingsItemV2(hitAnimations = new FormCheckBox
                 {
                     Caption = RulesetSettingsStrings.HitAnimations,
                     HintText = RulesetSettingsStrings.HitAnimationsTaikoTooltip,
                     Current = config.GetBindable<bool>(TaikoRulesetSetting.HitAnimations)
                 }),
-                new SettingsItemV2(new FormCheckBox
+                new SettingsItemV2(rateAdjustedAnimations = new FormCheckBox
                 {
                     Caption = RulesetSettingsStrings.RateAdjustedHitAnimation,
                     HintText = RulesetSettingsStrings.RateAdjustedHitAnimationTooltip,
@@ -49,6 +52,11 @@ namespace osu.Game.Rulesets.Taiko
                     ApplyClassicDefault = c => ((IHasCurrentValue<bool>)c).Current.Value = false,
                 }
             };
+
+            hitAnimations.Current.BindValueChanged(val =>
+            {
+                rateAdjustedAnimations.Current.Disabled = !val.NewValue;
+            }, true);
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Rulesets.Taiko
                 new SettingsItemV2(new FormCheckBox
                 {
                     Caption = RulesetSettingsStrings.HitAnimations,
-                    HintText = RulesetSettingsStrings.HitAnimationsTooltip,
+                    HintText = RulesetSettingsStrings.HitAnimationsTaikoTooltip,
                     Current = config.GetBindable<bool>(TaikoRulesetSetting.HitAnimations)
                 }),
                 new SettingsItemV2(new FormCheckBox

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -5,19 +5,21 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
-using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.UI;
-using osu.Game.Rulesets.UI.Scrolling;
-using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.Configuration;
 using osu.Game.Rulesets.Taiko.Judgements;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.Objects.Drawables;
 using osu.Game.Rulesets.Taiko.Scoring;
+using osu.Game.Rulesets.UI;
+using osu.Game.Rulesets.UI.Scrolling;
 using osu.Game.Skinning;
 
 namespace osu.Game.Rulesets.Taiko.UI
@@ -39,6 +41,8 @@ namespace osu.Game.Rulesets.Taiko.UI
         private ScrollingHitObjectContainer drumRollHitContainer = null!;
         internal Drawable HitTarget = null!;
 
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
+
         private JudgementPooler<DrawableTaikoJudgement> judgementPooler = null!;
         private readonly IDictionary<HitResult, HitExplosionPool> explosionPools = new Dictionary<HitResult, HitExplosionPool>();
 
@@ -51,9 +55,11 @@ namespace osu.Game.Rulesets.Taiko.UI
         /// </remarks>
         private BarLinePlayfield barLinePlayfield = null!;
 
-        [BackgroundDependencyLoader]
-        private void load(OsuColour colours)
+        [BackgroundDependencyLoader(true)]
+        private void load(OsuColour colours, TaikoRulesetConfigManager? config)
         {
+            config?.BindWith(TaikoRulesetSetting.HitAnimations, hitAnimations);
+
             const float hit_target_width = BASE_HEIGHT;
             const float hit_target_offset = -24f;
 
@@ -329,8 +335,14 @@ namespace osu.Game.Rulesets.Taiko.UI
             }
         }
 
-        private void addDrumRollHit(DrawableDrumRollTick drawableTick) =>
+        private void addDrumRollHit(DrawableDrumRollTick drawableTick)
+        {
+            // with hit animations disabled, hits are hidden as soon as they're judged, so there's nothing to fly off the drum.
+            if (!hitAnimations.Value)
+                return;
+
             drumRollHitContainer.Add(new DrawableFlyingHit(drawableTick));
+        }
 
         private void addExplosion(DrawableHitObject drawableObject, HitResult result, HitType type)
         {

--- a/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
+++ b/osu.Game.Rulesets.Taiko/UI/TaikoPlayfield.cs
@@ -337,7 +337,6 @@ namespace osu.Game.Rulesets.Taiko.UI
 
         private void addDrumRollHit(DrawableDrumRollTick drawableTick)
         {
-            // with hit animations disabled, hits are hidden as soon as they're judged, so there's nothing to fly off the drum.
             if (!hitAnimations.Value)
                 return;
 

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -90,6 +90,16 @@ namespace osu.Game.Localisation
         public static LocalisableString RateAdjustedHitAnimationTooltip => new TranslatableString(getKey(@"rate_adjusted_hit_animation_tooltip"), @"Hits will fly faster or slower when beatmap rate is adjusted via mods.");
 
         /// <summary>
+        /// "Hit animations"
+        /// </summary>
+        public static LocalisableString HitAnimations => new TranslatableString(getKey(@"hit_animations"), @"Hit animations");
+
+        /// <summary>
+        /// "Hits will fly off the screen when hit. When disabled, hits will disappear immediately."
+        /// </summary>
+        public static LocalisableString HitAnimationsTooltip => new TranslatableString(getKey(@"hit_animations_tooltip"), @"Hits will fly off the screen when hit. When disabled, hits will disappear immediately.");
+
+        /// <summary>
         /// "{0}ms (speed {1:N1})"
         /// </summary>
         public static LocalisableString ScrollSpeedTooltip(int scrollTime, double scrollSpeed) => new TranslatableString(getKey(@"ruleset"), @"{0}ms (speed {1:N1})", scrollTime, scrollSpeed);

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -95,9 +95,9 @@ namespace osu.Game.Localisation
         public static LocalisableString HitAnimations => new TranslatableString(getKey(@"hit_animations"), @"Hit animations");
 
         /// <summary>
-        /// "Hits will fly off the screen when hit. When disabled, hits will disappear immediately."
+        /// "When enabled, hits will fly off the screen. When disabled, hits will disappear immediately."
         /// </summary>
-        public static LocalisableString HitAnimationsTooltip => new TranslatableString(getKey(@"hit_animations_tooltip"), @"Hits will fly off the screen when hit. When disabled, hits will disappear immediately.");
+        public static LocalisableString HitAnimationsTaikoTooltip => new TranslatableString(getKey(@"hit_animations_taiko_tooltip"), @"When enabled, hits will fly off the screen. When disabled, hits will disappear immediately.");
 
         /// <summary>
         /// "{0}ms (speed {1:N1})"


### PR DESCRIPTION

https://github.com/user-attachments/assets/f6d2b245-85f6-48ce-865e-1b4e92fe170a

There has been previous discussion about this feature [here](https://github.com/ppy/osu/discussions/23656).

Tests check that the circles are all hidden/visible depending on the option, judgments are still complete on all hit types and the map finishes (does not wait because of the optional second hit for finishers). Should catch future changes breaking the feature silently.

As an aside, I saw that a recent change for the rate the hit objects fly away there broke rewind in replays. Tried rewinding with these changes and it still works.