### PR TITLE
Fixed long (multi-line) messages overlapping with the previous message sent in ranked play.

### DIFF
--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/Components/RankedPlayChatDisplay.cs
@@ -295,16 +295,18 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay.Components
 
                 messageContainer.Add(newMessage);
 
-                float offset = 0;
-
                 ScheduleAfterChildren(() =>
                 {
-                    // Layout bubbles, pushing all others upwards to make room for the new one.
-                    foreach (var child in messageContainer.Reverse())
+                    ScheduleAfterChildren(() => // just one frame defer so that textflowcontainer settles wrapped height
                     {
-                        child.MoveToY(-offset, 400, Easing.OutPow10);
-                        offset += child.DrawHeight + message_spacing;
-                    }
+                        // Layout bubbles, pushing all others upwards to make room for the new one.
+                        float offset = 0;
+                        foreach (var child in messageContainer.Reverse())
+                        {
+                            child.MoveToY(-offset, 400, Easing.OutPow10);
+                            offset += child.Height + message_spacing;
+                        }
+                    });
                 });
 
                 // Hide any overflowing message.


### PR DESCRIPTION
Fix for Issue: #38282 

seemed to me that when a message is posted in the ranked play chat the textflowcontainer schedules the layout to run but the spritetext parts inside dont report the final metric until **next** frame, meaning the first layout pass sees the text as fitting on a single line so messagebubble.Height is too small and overlaps over the last sent message, the overlap would be fixed the next message sent, with the correct alignment between the multi-line and one-line messages.

note that the visibility of this issue was client-sided and the fix is pretty small (basically a one liner) and doesnt seem to be all that smart either...

InspectCode.ps1 fails locally with unknown tools version: 18.0, CodeFileSanity passes.