### PR TITLE
resolve the issue on the skip overlays on multiplayers free style

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
@@ -127,8 +127,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestVoteDifferentDifficulties()
         {
-            int beatmapId1 = 0;
-            int beatmapId2 = 1;
+            const int beatmapId1 = 0;
+            const int beatmapId2 = 1;
             for (int i = 0; i < 2; i++)
             {
                 int userId = i;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
@@ -124,6 +124,45 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("user 0 leaves", () => MultiplayerClient.RemoveUser(new APIUser { Id = 0 }));
         }
 
+        [Test]
+        public void TestVoteDifferentDifficulties()
+        {
+            int beatmapId1 = 0;
+            int beatmapId2 = 1;
+            for (int i = 0; i < 2; i++)
+            {
+                int userId = i;
+
+                AddStep($"join user {userId}", () =>
+                {
+                    MultiplayerClient.AddUser(new APIUser
+                    {
+                        Id = userId,
+                        Username = $"User {userId}"
+                    });
+
+                    MultiplayerClient.ChangeUserState(userId, MultiplayerUserState.Playing);
+                    MultiplayerClient.ChangeUserStyle(userId, beatmapId1, 0);
+                });
+            }
+            AddStep($"join user {2}", () =>
+            {
+                MultiplayerClient.AddUser(new APIUser
+                {
+                    Id = 2,
+                    Username = $"User {2}"
+                });
+
+                MultiplayerClient.ChangeUserState(2, MultiplayerUserState.Playing);
+                MultiplayerClient.ChangeUserStyle(2, beatmapId2, 0);
+            });
+            AddStep("change local user beatmap id same as user 0 and 1", () =>
+            {
+                MultiplayerClient.ChangeUserStyle(beatmapId1, 0);
+            });
+            AddStep("local user votes", () => this.ChildrenOfType<MultiplayerSkipOverlay.Button>().Single().TriggerClick());
+        }
+
         public partial class TestMultiplayerSkipOverlay : MultiplayerSkipOverlay
         {
             public TestMultiplayerSkipOverlay()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
@@ -79,9 +79,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             if (client.Room == null || client.Room.Settings.AutoSkip)
                 return;
+            int localBeatmapId = client.LocalUser?.BeatmapId ?? client.Room.CurrentPlaylistItem.BeatmapID;
+            bool isSameDifficulty(MultiplayerRoomUser u)
+            {
+                return (u.BeatmapId ?? client.Room.CurrentPlaylistItem.BeatmapID) == localBeatmapId;
+            }
 
-            int countTotal = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing);
-            int countSkipped = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing && u.VotedToSkipIntro);
+            int countTotal = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing && isSameDifficulty(u));
+            int countSkipped = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing && u.VotedToSkipIntro && isSameDifficulty(u));
             int countRequired = countTotal / 2 + 1;
 
             skipButton.SkippedCount.Value = Math.Min(countRequired, countSkipped);


### PR DESCRIPTION
[#38291](https://github.com/ppy/osu/issues/38291)

When there are different difficulties been selected by multiple users, the total required skip count will only be based on the number of players choosing the same diffculties

However, this only change the overlays in game but did not change how game server behave. Same issue also found in osu-server-spectator, which needed to adjusted later.