### PR TITLE
Fix skip overlay issue on multiplayer freestyle

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
@@ -127,8 +127,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestVoteDifferentDifficulties()
         {
-            const int beatmapId1 = 0;
-            const int beatmapId2 = 1;
+            const int beatmapid1 = 0;
+            const int beatmapid2 = 1;
 
             for (int i = 0; i < 2; i++)
             {
@@ -143,7 +143,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     });
 
                     MultiplayerClient.ChangeUserState(userId, MultiplayerUserState.Playing);
-                    MultiplayerClient.ChangeUserStyle(userId, beatmapId1, 0);
+                    MultiplayerClient.ChangeUserStyle(userId, beatmapid1, 0);
                 });
             }
 
@@ -156,11 +156,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 });
 
                 MultiplayerClient.ChangeUserState(2, MultiplayerUserState.Playing);
-                MultiplayerClient.ChangeUserStyle(2, beatmapId2, 0);
+                MultiplayerClient.ChangeUserStyle(2, beatmapid2, 0);
             });
             AddStep("change local user beatmap id same as user 0 and 1", () =>
             {
-                MultiplayerClient.ChangeUserStyle(beatmapId1, 0);
+                MultiplayerClient.ChangeUserStyle(beatmapid1, 0);
             });
             AddStep("local user votes", () => this.ChildrenOfType<MultiplayerSkipOverlay.Button>().Single().TriggerClick());
         }

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
@@ -127,8 +127,8 @@ namespace osu.Game.Tests.Visual.Multiplayer
         [Test]
         public void TestVoteDifferentDifficulties()
         {
-            int beatmapId1 = 0;
-            int beatmapId2 = 1;
+            const int beatmapId1 = 0;
+            const int beatmapId2 = 1;
             for (int i = 0; i < 2; i++)
             {
                 int userId = i;

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
@@ -129,6 +129,7 @@ namespace osu.Game.Tests.Visual.Multiplayer
         {
             const int beatmapId1 = 0;
             const int beatmapId2 = 1;
+
             for (int i = 0; i < 2; i++)
             {
                 int userId = i;
@@ -145,12 +146,13 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     MultiplayerClient.ChangeUserStyle(userId, beatmapId1, 0);
                 });
             }
-            AddStep($"join user {2}", () =>
+
+            AddStep("join user 2", () =>
             {
                 MultiplayerClient.AddUser(new APIUser
                 {
                     Id = 2,
-                    Username = $"User {2}"
+                    Username = "User 2"
                 });
 
                 MultiplayerClient.ChangeUserState(2, MultiplayerUserState.Playing);

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerSkipOverlay.cs
@@ -124,6 +124,45 @@ namespace osu.Game.Tests.Visual.Multiplayer
             AddStep("user 0 leaves", () => MultiplayerClient.RemoveUser(new APIUser { Id = 0 }));
         }
 
+        [Test]
+        public void TestVoteDifferentDifficulties()
+        {
+            int beatmapId1 = 0;
+            int beatmapId2 = 1;
+            for (int i = 0; i < 2; i++)
+            {
+                int userId = i;
+
+                AddStep($"join user {userId}", () =>
+                {
+                    MultiplayerClient.AddUser(new APIUser
+                    {
+                        Id = userId,
+                        Username = $"User {userId}"
+                    });
+
+                    MultiplayerClient.ChangeUserState(userId, MultiplayerUserState.Playing);
+                    MultiplayerClient.ChangeUserStyle(userId, beatmapId1, 0);
+                });
+            }
+            AddStep($"join user {2}", () =>
+            {
+                MultiplayerClient.AddUser(new APIUser
+                {
+                    Id = 2,
+                    Username = $"User {2}"
+                });
+
+                MultiplayerClient.ChangeUserState(2, MultiplayerUserState.Playing);
+                MultiplayerClient.ChangeUserStyle(2, beatmapId2, 0);
+            });
+            AddStep("change local user beatmap id same as user 0 and 1", () =>
+            {
+                MultiplayerClient.ChangeUserStyle(beatmapId1, 0);
+            });
+            AddStep("local user votes", () => this.ChildrenOfType<MultiplayerSkipOverlay.Button>().Single().TriggerClick());
+        }
+
         public partial class TestMultiplayerSkipOverlay : MultiplayerSkipOverlay
         {
             public TestMultiplayerSkipOverlay()

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
@@ -79,7 +79,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             if (client.Room == null || client.Room.Settings.AutoSkip)
                 return;
+
             int localBeatmapId = client.LocalUser?.BeatmapId ?? client.Room.CurrentPlaylistItem.BeatmapID;
+
             bool isSameDifficulty(MultiplayerRoomUser u)
             {
                 return (u.BeatmapId ?? client.Room.CurrentPlaylistItem.BeatmapID) == localBeatmapId;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerSkipOverlay.cs
@@ -79,9 +79,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             if (client.Room == null || client.Room.Settings.AutoSkip)
                 return;
+            int localBeatmapId = client.LocalUser?.BeatmapId ?? client.Room.CurrentPlaylistItem.BeatmapID;
+            bool isSameDifficulty(MultiplayerRoomUser u)
+            {
+                return (u.BeatmapId ?? client.Room.CurrentPlaylistItem.BeatmapID) == localBeatmapId;
+            }
 
-            int countTotal = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing);
-            int countSkipped = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing && u.VotedToSkipIntro);
+            int countTotal = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing && isSameDifficulty(u));
+            int countSkipped = client.Room.Users.Count(u => u.State == MultiplayerUserState.Playing && u.VotedToSkipIntro && isSameDifficulty(u));
             int countRequired = countTotal / 2 + 1;
 
             skipButton.SkippedCount.Value = Math.Min(countRequired, countSkipped);


### PR DESCRIPTION
In a multiplayer room, sometimes different players in the same room will choose different difficulties. During the play, a vote will be offered for everyone to decide whether the game should skip the intro.

As described in #38291, the bug is that the number of people required to vote for skipping is based on the total number of people in the room instead of the number of players of the same difficulty. This bug happens in both skip overlays and osu-server-spectator.

This PR fixes this bug with in-game overlays and adds a test for this scenario. Now the in-game multiplayer skip overlay will show the correct number of people required to skip the intro. However, the bug in osu-server-spectator still remains.

osu-sever-spectator issue:https://github.com/ppy/osu-server-spectator/issues/526