### PR TITLE
Update editor volume popover controls

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -5,8 +5,6 @@ using System.Linq;
 using System.Collections.Generic;
 using Humanizer;
 using NUnit.Framework;
-using osu.Framework.Graphics;
-using osu.Framework.Input;
 using osu.Framework.Testing;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
@@ -1232,9 +1230,6 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void seekSamplePiece(int direction) => AddStep($"seek sample piece {direction}", () =>
         {
-            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault(o => o.IsPresent);
-            popover?.FindClosestParent<IFocusManager>()?.ChangeFocus(null);
-
             InputManager.PressKey(Key.ControlLeft);
             InputManager.PressKey(Key.ShiftLeft);
             InputManager.Key(direction < 1 ? Key.Left : Key.Right);

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -83,10 +83,10 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
-        public void TestPopoverHasNoFocus()
+        public void TestPopoverHasFocus()
         {
             clickSamplePiece(0);
-            samplePopoverHasNoFocus();
+            samplePopoverHasFocus();
         }
 
         [Test]
@@ -1248,13 +1248,13 @@ namespace osu.Game.Tests.Visual.Editing
             return popover != null;
         });
 
-        private void samplePopoverHasNoFocus() => AddUntilStep("sample popover textbox not focused", () =>
+        private void samplePopoverHasFocus() => AddUntilStep("sample popover textbox not focused", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
             var slider = popover?.ChildrenOfType<SamplePointPiece.VolumeControl>().Single();
             var textbox = slider?.ChildrenOfType<OsuTextBox>().Single();
 
-            return textbox?.HasFocus == false;
+            return textbox?.HasFocus == true;
         });
 
         private void samplePopoverHasSingleVolume(int volume) => AddUntilStep($"sample popover has volume {volume}", () =>

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -5,8 +5,9 @@ using System.Linq;
 using System.Collections.Generic;
 using Humanizer;
 using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
 using osu.Framework.Testing;
-using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Graphics.UserInterface;
@@ -21,7 +22,6 @@ using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
-using osu.Game.Screens.Edit.Timing;
 using osu.Game.Tests.Beatmaps;
 using osuTK;
 using osuTK.Input;
@@ -1232,6 +1232,9 @@ namespace osu.Game.Tests.Visual.Editing
 
         private void seekSamplePiece(int direction) => AddStep($"seek sample piece {direction}", () =>
         {
+            var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault(o => o.IsPresent);
+            popover?.FindClosestParent<IFocusManager>()?.ChangeFocus(null);
+
             InputManager.PressKey(Key.ControlLeft);
             InputManager.PressKey(Key.ShiftLeft);
             InputManager.Key(direction < 1 ? Key.Left : Key.Right);
@@ -1248,7 +1251,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void samplePopoverHasNoFocus() => AddUntilStep("sample popover textbox not focused", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
+            var slider = popover?.ChildrenOfType<SamplePointPiece.VolumeControl>().Single();
             var textbox = slider?.ChildrenOfType<OsuTextBox>().Single();
 
             return textbox?.HasFocus == false;
@@ -1257,23 +1260,23 @@ namespace osu.Game.Tests.Visual.Editing
         private void samplePopoverHasSingleVolume(int volume) => AddUntilStep($"sample popover has volume {volume}", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
+            var slider = popover?.ChildrenOfType<SamplePointPiece.VolumeControl>().Single();
 
-            return slider?.Current.Value == volume;
+            return slider?.Current.Value == volume && !slider.IsMultipleValues;
         });
 
         private void samplePopoverHasIndeterminateVolume() => AddUntilStep("sample popover has indeterminate volume", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var slider = popover?.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
+            var slider = popover?.ChildrenOfType<SamplePointPiece.VolumeControl>().Single();
 
-            return slider != null && slider.Current.Value == null;
+            return slider != null && slider.IsMultipleValues;
         });
 
         private void samplePopoverHasSingleBank(string bank) => AddUntilStep($"sample popover has bank {bank}", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var dropdown = popover?.ChildrenOfType<LabelledDropdown<string>>().First();
+            var dropdown = popover?.ChildrenOfType<FormDropdown<string>>().First();
 
             return dropdown?.Current.Value == bank;
         });
@@ -1281,7 +1284,7 @@ namespace osu.Game.Tests.Visual.Editing
         private void samplePopoverHasIndeterminateBank() => AddUntilStep("sample popover has indeterminate bank", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var dropdown = popover?.ChildrenOfType<LabelledDropdown<string>>().First();
+            var dropdown = popover?.ChildrenOfType<FormDropdown<string>>().First();
 
             return dropdown?.Current.Value == "(multiple)";
         });
@@ -1289,21 +1292,21 @@ namespace osu.Game.Tests.Visual.Editing
         private void samplePopoverHasSingleAdditionBank(string bank) => AddUntilStep($"sample popover has bank {bank}", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().SingleOrDefault();
-            var dropdown = popover?.ChildrenOfType<LabelledDropdown<string>>().ElementAt(1);
+            var dropdown = popover?.ChildrenOfType<FormDropdown<string>>().ElementAt(1);
 
             return dropdown?.Current.Value == bank;
         });
 
         private void dismissPopover()
         {
-            AddStep("dismiss popover", () => InputManager.Key(Key.Escape));
+            AddRepeatStep("dismiss popover", () => InputManager.Key(Key.Escape), 2);
             AddUntilStep("wait for dismiss", () => !this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Any(popover => popover.IsPresent));
         }
 
         private void setVolumeViaPopover(int volume) => AddStep($"set volume {volume} via popover", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
-            var slider = popover.ChildrenOfType<IndeterminateSliderWithTextBoxInput<int>>().Single();
+            var slider = popover.ChildrenOfType<SamplePointPiece.VolumeControl>().Single();
             slider.Current.Value = volume;
         });
 
@@ -1323,14 +1326,14 @@ namespace osu.Game.Tests.Visual.Editing
         private void setBankViaPopover(string bank) => AddStep($"set bank {bank} via popover", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
-            var textBox = popover.ChildrenOfType<LabelledDropdown<string>>().First();
+            var textBox = popover.ChildrenOfType<FormDropdown<string>>().First();
             textBox.Current.Value = bank;
         });
 
         private void setAdditionBankViaPopover(string bank) => AddStep($"set addition bank {bank} via popover", () =>
         {
             var popover = this.ChildrenOfType<SamplePointPiece.SampleEditPopover>().Single();
-            var textBox = popover.ChildrenOfType<LabelledDropdown<string>>().ToArray()[1];
+            var textBox = popover.ChildrenOfType<FormDropdown<string>>().ToArray()[1];
             textBox.Current.Value = bank;
         });
 
@@ -1407,6 +1410,6 @@ namespace osu.Game.Tests.Visual.Editing
                 return h is not null && h.NodeSamples[nodeIndex].Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(o => o.Bank == bank);
             });
 
-        private void editorTimeIs(double time) => AddAssert($"editor time is {time}", () => Precision.AlmostEquals(EditorClock.CurrentTimeAccurate, time, 1));
+        private void editorTimeIs(double time) => AddUntilStep($"editor time is {time}", () => EditorClock.CurrentTimeAccurate, () => Is.EqualTo(time).Within(1));
     }
 }

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -247,18 +247,18 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                     AutoSizeAxes = Axes.Y,
                                     Children = new Drawable[]
                                     {
-                                        textBox = new FormNumberBox.InnerNumberBox(allowDecimals: true)
+                                        textBox = CreateTextBox().With(box =>
                                         {
-                                            RelativeSizeAxes = Axes.X,
+                                            box.RelativeSizeAxes = Axes.X;
                                             // the textbox is hidden when the control is unfocused,
                                             // but clicking on the label should reach the textbox,
                                             // therefore make it always present.
-                                            AlwaysPresent = true,
-                                            CommitOnFocusLost = true,
-                                            SelectAllOnFocus = true,
-                                            OnInputError = background.FlashOnInputError,
-                                            TabbableContentContainer = tabbableContentContainer,
-                                        },
+                                            box.AlwaysPresent = true;
+                                            box.CommitOnFocusLost = true;
+                                            box.SelectAllOnFocus = true;
+                                            box.OnInputError = background.FlashOnInputError;
+                                            box.TabbableContentContainer = tabbableContentContainer;
+                                        }),
                                         valueLabel = new TruncatingSpriteText
                                         {
                                             RelativeSizeAxes = Axes.X,
@@ -282,6 +282,8 @@ namespace osu.Game.Graphics.UserInterfaceV2
             if (game != null)
                 currentLanguage.BindTo(game.CurrentLanguage);
         }
+
+        internal virtual FormNumberBox.InnerNumberBox CreateTextBox() => new FormNumberBox.InnerNumberBox(true);
 
         protected override void LoadComplete()
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
@@ -744,6 +745,24 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 // Just disable it to hide the skeleton. It's of little use anyhow.
                 TooltipFormat = _ => default;
                 TransferValueOnCommit = true;
+            }
+
+            internal override FormNumberBox.InnerNumberBox CreateTextBox() => new TextBox();
+
+            private partial class TextBox : FormNumberBox.InnerNumberBox
+            {
+                public TextBox()
+                    : base(true)
+                {
+                }
+
+                public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+                {
+                    if (e.Action == PlatformAction.SelectBackwardWord || e.Action == PlatformAction.SelectForwardWord)
+                        return false;
+
+                    return base.OnPressed(e);
+                }
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -743,6 +743,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 // because the tooltip machinery framework-side is too smart for it (the tooltip text is only regenerated on direct changes to `Current`).
                 // Just disable it to hide the skeleton. It's of little use anyhow.
                 TooltipFormat = _ => default;
+                TransferValueOnCommit = true;
             }
         }
     }

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
+using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osu.Game.Audio;
 using osu.Game.Graphics;
@@ -24,7 +25,6 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
-using osu.Game.Screens.Edit.Timing;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -189,11 +189,11 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
         {
             private readonly HitObject hitObject;
 
-            private LabelledDropdown<string> bank = null!;
-            private LabelledDropdown<string> additionBank = null!;
+            private FormDropdown<string> bank = null!;
+            private FormDropdown<string> additionBank = null!;
             private FillFlowContainer<SampleSetTernaryButton>? sampleSetsFlow;
-            private LabelledDropdown<EditorBeatmapSkin.SampleSet>? sampleSetDropdown;
-            private IndeterminateSliderWithTextBoxInput<int> volume = null!;
+            private FormDropdown<EditorBeatmapSkin.SampleSet>? sampleSetDropdown;
+            private VolumeControl volume = null!;
             private SkinnableSound demoSample = null!;
 
             private FillFlowContainer togglesCollection = null!;
@@ -258,22 +258,26 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                                 Direction = FillDirection.Horizontal,
                                 Spacing = new Vector2(5, 5),
                             },
-                            bank = new LabelledDropdown<string>(padded: false)
+                            bank = new FormDropdown<string>
                             {
-                                Label = EditorStrings.NormalBank,
+                                Caption = EditorStrings.NormalBank,
                                 Items = HitSampleInfo.ALL_BANKS,
                             },
-                            additionBank = new LabelledDropdown<string>(padded: false)
+                            additionBank = new FormDropdown<string>
                             {
-                                Label = EditorStrings.AdditionBank,
+                                Caption = EditorStrings.AdditionBank,
                                 Items = HitSampleInfo.ALL_BANKS,
                             },
                             createSampleSetContent(),
-                            volume = new IndeterminateSliderWithTextBoxInput<int>(EditorStrings.SampleVolume, new BindableInt(100)
+                            volume = new VolumeControl
                             {
-                                MinValue = DrawableHitObject.MINIMUM_SAMPLE_VOLUME,
-                                MaxValue = 100,
-                            })
+                                Caption = EditorStrings.SampleVolume,
+                                Current = new BindableInt(100)
+                                {
+                                    MinValue = DrawableHitObject.MINIMUM_SAMPLE_VOLUME,
+                                    MaxValue = 100,
+                                }
+                            }
                         }
                     },
                     new EditorSkinProvidingContainer(beatmap)
@@ -291,8 +295,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 // even if there are multiple objects selected, we can still display sample volume or bank if they all have the same value.
                 int? commonVolume = getCommonVolume();
-                if (commonVolume != null)
-                    volume.Current.Value = commonVolume.Value;
+                volume.Current.Value = commonVolume ?? 100;
+                volume.IsMultipleValues = commonVolume == null;
 
                 updatePrimaryBankState();
                 bank.Current.BindValueChanged(val =>
@@ -320,8 +324,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                 volume.Current.BindValueChanged(val =>
                 {
-                    if (val.NewValue != null)
-                        setVolume(val.NewValue.Value);
+                    setVolume(val.NewValue);
                 });
 
                 createStateBindables();
@@ -329,15 +332,22 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 togglesCollection.AddRange(createTernaryButtons());
             }
 
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                ScheduleAfterChildren(() => volume.TakeFocus());
+            }
+
             private Drawable createSampleSetContent()
             {
                 if (beatmap.BeatmapSkin == null)
-                    return Empty();
+                    return Empty().With(d => d.Alpha = 0);
 
                 var sampleSets = beatmap.BeatmapSkin.GetAvailableSampleSets().ToList();
 
                 if (sampleSets.Count == 0)
-                    return Empty();
+                    return Empty().With(d => d.Alpha = 0);
 
                 sampleSets.Insert(0, new EditorBeatmapSkin.SampleSet(0, "User skin"));
 
@@ -366,9 +376,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     return sampleSetsFlow;
                 }
 
-                sampleSetDropdown = new LabelledDropdown<EditorBeatmapSkin.SampleSet>(padded: false)
+                sampleSetDropdown = new FormDropdown<EditorBeatmapSkin.SampleSet>
                 {
-                    Label = EditorStrings.SampleSet,
+                    Caption = EditorStrings.SampleSet,
                     Items = sampleSets,
                 };
                 sampleSetDropdown.Current.BindValueChanged(val =>
@@ -528,6 +538,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         relevantSamples[i] = relevantSamples[i].With(newVolume: newVolume);
                     }
                 });
+                volume.IsMultipleValues = false;
             }
 
             #region hitsound toggles
@@ -694,6 +705,45 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
 
             #endregion
+        }
+
+        internal partial class VolumeControl : FormSliderBar<int>
+        {
+            private bool isMultipleValues;
+
+            /// <summary>
+            /// This is a hack to allow the text box to show an indication that multiple slider velocity values are active
+            /// when the selection contains multiple objects with different velocities.
+            /// </summary>
+            public bool IsMultipleValues
+            {
+                get => isMultipleValues;
+                set
+                {
+                    if (isMultipleValues == value)
+                        return;
+
+                    isMultipleValues = value;
+                    updateLabelFormat();
+                }
+            }
+
+            private void updateLabelFormat()
+            {
+                LabelFormat = isMultipleValues
+                    ? static _ => "(multiple)"
+                    : v => LocalisableString.Interpolate($"{v / 100.0:P0}");
+            }
+
+            public VolumeControl()
+            {
+                updateLabelFormat();
+
+                // The `IsMultipleValues` / `updateLabelFormat()` hack above to jam an indicator of multiple active values does not work for tooltip
+                // because the tooltip machinery framework-side is too smart for it (the tooltip text is only regenerated on direct changes to `Current`).
+                // Just disable it to hide the skeleton. It's of little use anyhow.
+                TooltipFormat = _ => default;
+            }
         }
     }
 }


### PR DESCRIPTION
- Changes all control to new "form" variants.
  <img width="1712" height="1040" alt="Screenshot 2026-07-14 at 14 14 11" src="https://github.com/user-attachments/assets/2f0501fe-c245-4a0a-b7b1-ed91c1d7bad3" />
  <img width="1712" height="1040" alt="Screenshot 2026-07-14 at 14 14 23" src="https://github.com/user-attachments/assets/ff9fd12a-3429-40f0-9a50-9af57b3302bf" />
- Additionally, of note on @pishifat request from https://github.com/ppy/osu/discussions/31263, when the popover is opened, the volume textbox will automatically be focused so that input is permitted right away.

  There is one hiccup here, in that this conflicts with an existing feature: Ctrl-Shift-← and Ctrl-Shift-→ are both "move to previous/next word" in text box contexts (on all platforms other than macOS), and "move to previous/next sample marker" (editor-specific, added in https://github.com/ppy/osu/pull/28737). To be exact, the latter shortcut still *works*, but the text box must be unfocused first.

  I think this is fine to break on the grounds that (a) not many people probably know or use this, and (b) the editor shortcut is rebindable anyway (maybe the default binding should be changed?)