### PR TITLE
Re-enable frame-stable playback in the editor in selected circumstances

### DIFF
--- a/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
+++ b/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Caching;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -26,6 +28,9 @@ namespace osu.Game.Rulesets.Edit
         [Resolved]
         private EditorBeatmap beatmap { get; set; } = null!;
 
+        [Resolved]
+        private EditorClock editorClock { get; set; } = null!;
+
         public DrawableEditorRulesetWrapper(DrawableRuleset<TObject> drawableRuleset)
         {
             this.drawableRuleset = drawableRuleset;
@@ -44,6 +49,8 @@ namespace osu.Game.Rulesets.Edit
 
         [Resolved]
         private IEditorChangeHandler? changeHandler { get; set; }
+
+        private readonly Cached autoplayRegenerated = new Cached();
 
         protected override void LoadComplete()
         {
@@ -65,10 +72,33 @@ namespace osu.Game.Rulesets.Edit
             Scheduler.AddOnce(regenerateAutoplay);
         }
 
+        protected override void Update()
+        {
+            base.Update();
+
+            // Frame-stable playback is enabled in selected circumstances to ensure that the autoplay replay
+            // plays all the important frames that are required for the gameplay preview inside editor to look and sound correctly
+            // (hit animations present, hitsounds play in time).
+            // Of note:
+            // - Frame stability is only active when the editor clock is actually running.
+            //   If it were to be enabled while the editor clock was not running, instant seeks could become non-instant.
+            //   Moreover, the impact of it being off in that scenario is reduced as hitsounds do not play when the editor clock is paused anyway.
+            // - Autoplay regenerations turn off frame stability for a frame.
+            //   This is because substituting the autoplay replay under the drawable ruleset while the editor clock is running
+            //   would result in the drawable ruleset replaying the entirety of the new replay from time 0 until the editor clock's current time
+            //   which results in long frame times and many hitsounds playing at once.
+            // - Large seeks turn off frame stability as they would also provoke a clock catch-up,
+            //   which will result in long frame times and many hitsounds playing at once.
+            bool inLargeSeek = Math.Abs(drawableRuleset.FrameStableClock.CurrentTime - editorClock.CurrentTime) > 1000;
+            drawableRuleset.FrameStablePlayback = editorClock.IsRunning && autoplayRegenerated.IsValid && !inLargeSeek;
+            autoplayRegenerated.Validate();
+        }
+
         private void regenerateAutoplay()
         {
             var autoplayMod = drawableRuleset.Mods.OfType<ModAutoplay>().Single();
             drawableRuleset.SetReplayScore(autoplayMod.CreateScoreFromReplayData(drawableRuleset.Beatmap, drawableRuleset.Mods));
+            autoplayRegenerated.Invalidate();
         }
 
         private void hitObjectAdded(HitObject hitObject)


### PR DESCRIPTION
RFC.

The angle to this commit is to possibly close https://github.com/ppy/osu/issues/26559.

Enabling frame stability in the editor has been tried once before in https://github.com/ppy/osu/pull/26382, and then reverted in https://github.com/ppy/osu/pull/26521. The reason for it being reverted is that it caused a performance degradation, most visible in the mania editor.

Even in https://github.com/ppy/osu/pull/26382, an inline comment expressed the hope that "gameplay elements should not require frame stability". Before I go further, I feel like this comment warrants addressing.

The problem here is that it is not so much the case that "gameplay elements require frame stability" for hitsounds to correctly play. The bigger problem here is that *the editor is reliant on accurate replay playback to show how gameplay looks like*.

When frame-stable playback is off, the `FrameStabilityContainer` is allowed to *entirely skip frames* that hit some objects. Due to this, those objects *never become hit* and are *misses* instead, and *that* is why they do not play a hitsound.

You can experimentally verify this by commenting out

https://github.com/ppy/osu/blob/43897457fb7b0617125aa05a084e4078633ad4ac/osu.Game/Rulesets/Edit/DrawableEditorRulesetWrapper.cs#L42

and playing a beatmap such as https://osu.ppy.sh/beatmapsets/1252588#osu/3203995 in the editor. On my setup at least, there are several missed objects in the first 20 seconds of the map.

Given the dependence of editor gameplay preview correctness on replay playback correctness, there do not appear to be many choices here other than:

1. Improve replay playback correctness as much as possible by enabling frame stability as often as possible.
2. Stop depending on replays for editor gameplay preview.

I briefly explored option (2). The idea behind it was to completely dissociate from the replay subsystem and instead have editor-specific code that would simulate perfect gameplay *inside* `DrawableEditorRulesetWrapper` by forcing hits to happen in the correct time instants on the `DrawableHitObject`s.

After some finagling, I got it to work... only in the osu! ruleset. The problem with this idea is that *it is not sufficient* to only operate on the `DrawableHitObject`s. Other rulesets have parts of the playfield that need to somehow show user input too.

- taiko has the input drum (which notably is the one making sounds).
- catch has the catcher.
- mania has the keys (which notably are the ones making sounds, leaving aside foibles like maps keysounded via storyboard samples)

Therefore, for that idea to work, *each ruleset* would have to bundle its appropriate logic for real-time simulation of gameplay, basically duplicating what replays / autoplay already is in a clunkier way.

Thus I am offering this diff in earnest. The hope is the issues that were hit in https://github.com/ppy/osu/pull/26382 can be avoided with additional heuristics.

- Frame stability is only active when the editor clock is actually running. If it were to be enabled while the editor clock was *not* running, instant seeks could become non-instant. Moreover, the impact of it being off in that scenario is reduced as hitsounds do not play when the editor clock is paused anyway.
- Autoplay regenerations turn off frame stability for a frame. This is because substituting the autoplay replay under the drawable ruleset while the editor clock is running would result in the drawable ruleset replaying the entirety of the new replay from the start until the editor clock's current time, which results in long frame times and many hitsounds playing at once.
- Large seeks turn off frame stability as they would also provoke a clock catch-up, which will result in long frame times and many hitsounds playing at once. (This is unchanged from the original attempt.)

It is very possible that in the future these heuristics will need to be expanded further to cover off other scenarios. For instance, I predict that frame stability may be disabled in the future in the case of live mapping, though the heuristics above (particularly the autoplay regeneration case) may be enough to handle that use case.