### PR TITLE
Disable "reset all keys" button when all bindings are already default

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -79,7 +79,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public readonly object Action;
 
-        private Bindable<bool> isDefault { get; } = new BindableBool(true);
+        public Bindable<bool> IsDefault { get; } = new BindableBool(true);
 
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
@@ -251,7 +251,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.LoadComplete();
 
-            isDefault.BindValueChanged(d =>
+            IsDefault.BindValueChanged(d =>
             {
                 if (d.NewValue)
                     revertButton.Hide();
@@ -272,7 +272,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 tryPersistKeyBinding(button.KeyBinding.Value, advanceToNextBinding: false, restoringDefaults: true);
             }
 
-            isDefault.Value = true;
+            IsDefault.Value = true;
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -591,7 +591,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private void updateIsDefaultValue()
         {
-            isDefault.Value = KeyBindings.Select(b => b.KeyCombination).SequenceEqual(Defaults);
+            IsDefault.Value = KeyBindings.Select(b => b.KeyCombination).SequenceEqual(Defaults);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingRow.cs
@@ -79,7 +79,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public readonly object Action;
 
-        public Bindable<bool> IsDefault { get; } = new BindableBool(true);
+        public IBindable<bool> IsDefault => isDefault;
+        private readonly Bindable<bool> isDefault = new BindableBool(true);
 
         [Resolved]
         private RealmAccess realm { get; set; } = null!;
@@ -251,7 +252,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             base.LoadComplete();
 
-            IsDefault.BindValueChanged(d =>
+            isDefault.BindValueChanged(d =>
             {
                 if (d.NewValue)
                     revertButton.Hide();
@@ -272,7 +273,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 tryPersistKeyBinding(button.KeyBinding.Value, advanceToNextBinding: false, restoringDefaults: true);
             }
 
-            IsDefault.Value = true;
+            isDefault.Value = true;
         }
 
         protected override bool OnHover(HoverEvent e)
@@ -591,7 +592,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         private void updateIsDefaultValue()
         {
-            IsDefault.Value = KeyBindings.Select(b => b.KeyCombination).SequenceEqual(Defaults);
+            isDefault.Value = KeyBindings.Select(b => b.KeyCombination).SequenceEqual(Defaults);
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingsSubsection.cs
@@ -18,6 +18,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public abstract partial class KeyBindingsSubsection : SettingsSubsection
     {
+        private ResetButton resetButton = null!;
+
         /// <summary>
         /// After a successful binding, automatically select the next binding row to make quickly
         /// binding a large set of keys easier on the user.
@@ -49,11 +51,15 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                         row.BindingUpdated = onBindingUpdated;
                         row.GetAllSectionBindings = getAllBindings;
                     });
+
                 row.KeyBindings.AddRange(bindings.Where(b => b.ActionInt.Equals(intKey)));
+
                 Add(row);
+
+                row.IsDefault.BindValueChanged(_ => updateDefaultButtonState());
             }
 
-            Add(new ResetButton
+            Add(resetButton = new ResetButton
             {
                 Action = () =>
                 {
@@ -69,6 +75,13 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     reloadAllBindings();
                 }
             });
+
+            updateDefaultButtonState();
+        }
+
+        private void updateDefaultButtonState()
+        {
+            resetButton.Enabled.Value = !Children.OfType<KeyBindingRow>().All(r => r.IsDefault.Value);
         }
 
         protected abstract IEnumerable<RealmKeyBinding> GetKeyBindings(Realm realm);


### PR DESCRIPTION
This is mostly just to reduce visual clutter. The buttons look much less present when in a disabled state.

https://github.com/user-attachments/assets/5d6275f2-77d8-4399-9602-7635d6b30008

