### PR TITLE
Add marker line to show where default value is on slider bars

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneFormSliderBar.cs
@@ -8,7 +8,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterfaceV2;
@@ -102,7 +101,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             });
             AddStep("set slider to 1", () => slider.Current.Value = 1);
 
-            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<FormSliderBar<float>.InnerSliderNub>().Single()));
 
             AddStep("double click nub", () =>
             {
@@ -147,7 +146,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             AddStep("set slider to 1", () => slider.Current.Value = 1);
             AddStep("disable slider", () => slider.Current.Disabled = true);
 
-            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<FormSliderBar<float>.InnerSliderNub>().Single()));
 
             AddStep("double click nub", () =>
             {
@@ -172,7 +171,7 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("re-enable slider", () => slider.Current.Disabled = false);
 
-            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<Circle>().Single()));
+            AddStep("move mouse to nub", () => InputManager.MoveMouseTo(slider.ChildrenOfType<FormSliderBar<float>.InnerSliderNub>().Single()));
 
             AddStep("double click nub", () =>
             {

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -452,7 +452,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
             private Box leftBox = null!;
             private Box rightBox = null!;
+            private Container defaultLine = null!;
+
             private InnerSliderNub nub = null!;
+
             public const float NUB_WIDTH = 10;
 
             [Resolved]
@@ -492,10 +495,34 @@ namespace osu.Game.Graphics.UserInterfaceV2
                     {
                         RelativeSizeAxes = Axes.Both,
                         Padding = new MarginPadding { Horizontal = RangePadding, },
-                        Child = nub = new InnerSliderNub
+                        Children = new Drawable[]
                         {
-                            ResetToDefault = ResetToDefault,
-                        }
+                            nub = new InnerSliderNub
+                            {
+                                ResetToDefault = ResetToDefault,
+                            },
+                            defaultLine = new Container
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                Origin = Anchor.Centre,
+                                Anchor = Anchor.CentreLeft,
+                                Padding = new MarginPadding(5),
+                                Colour = colourProvider.Content2,
+                                RelativePositionAxes = Axes.X,
+                                Blending = BlendingParameters.Additive,
+                                Alpha = 0.3f,
+                                Children = new Drawable[]
+                                {
+                                    new Circle
+                                    {
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Width = 3,
+                                        RelativeSizeAxes = Axes.Y,
+                                    }
+                                }
+                            },
+                        },
                     },
                 };
             }
@@ -505,7 +532,22 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 base.LoadComplete();
 
                 Current.BindDisabledChanged(_ => updateState(), true);
+
+                Current.DefaultChanged += _ => updateDefaultValue();
+                updateDefaultValue();
+
                 FinishTransforms(true);
+            }
+
+            private void updateDefaultValue()
+            {
+                // hack to get normalised default value.
+                var copy = (BindableNumber<T>)Current.GetUnboundCopy();
+
+                copy.Disabled = false;
+                copy.SetDefault();
+
+                defaultLine.X = copy.NormalizedValue;
             }
 
             protected override void UpdateAfterChildren()
@@ -561,12 +603,19 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 rightBox.Colour = colourProvider.Background5;
 
                 Color4 leftColour = colourProvider.Light4;
+                Color4 defaultLineColour;
                 Color4 nubColour;
 
                 if (IsHovered || HasFocus || IsDragged)
+                {
+                    defaultLineColour = colourProvider.Content1.Lighten(0.4f);
                     nubColour = colourProvider.Highlight1;
+                }
                 else
+                {
                     nubColour = colourProvider.Highlight1.Darken(0.1f);
+                    defaultLineColour = colourProvider.Content2;
+                }
 
                 if (Current.Disabled)
                 {
@@ -576,6 +625,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
 
                 leftBox.FadeColour(leftColour, 250, Easing.OutQuint);
                 nub.FadeColour(nubColour, 250, Easing.OutQuint);
+                defaultLine.FadeColour(defaultLineColour, 250, Easing.OutQuint);
             }
 
             protected override void UpdateValue(float value)

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -186,6 +186,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             current.MinValueChanged += v => currentNumberInstantaneous.MinValue = v;
             current.MaxValueChanged += v => currentNumberInstantaneous.MaxValue = v;
             current.PrecisionChanged += v => currentNumberInstantaneous.Precision = v;
+            current.DefaultChanged += v => currentNumberInstantaneous.Default = v.NewValue;
             current.DisabledChanged += disabled =>
             {
                 if (disabled)

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -501,27 +501,17 @@ namespace osu.Game.Graphics.UserInterfaceV2
                             {
                                 ResetToDefault = ResetToDefault,
                             },
-                            defaultLine = new Container
+                            defaultLine = new Circle
                             {
-                                RelativeSizeAxes = Axes.Y,
-                                Origin = Anchor.Centre,
                                 Anchor = Anchor.CentreLeft,
-                                Padding = new MarginPadding(5),
+                                Origin = Anchor.Centre,
                                 Colour = colourProvider.Content2,
-                                RelativePositionAxes = Axes.X,
                                 Blending = BlendingParameters.Additive,
                                 Alpha = 0.3f,
-                                Children = new Drawable[]
-                                {
-                                    new Circle
-                                    {
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Width = 3,
-                                        RelativeSizeAxes = Axes.Y,
-                                    }
-                                }
-                            },
+                                Width = 4,
+                                Height = 6,
+                                RelativePositionAxes = Axes.X,
+                            }
                         },
                     },
                 };

--- a/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormSliderBar.cs
@@ -509,8 +509,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                                 Colour = colourProvider.Content2,
                                 Blending = BlendingParameters.Additive,
                                 Alpha = 0.3f,
-                                Width = 4,
-                                Height = 6,
+                                Size = new Vector2(4),
                                 RelativePositionAxes = Axes.X,
                             }
                         },
@@ -622,6 +621,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
             protected override void UpdateValue(float value)
             {
                 nub.MoveToX(value, 250, Easing.OutElasticQuarter);
+                defaultLine.ResizeHeightTo(Current.IsDefault ? 28 : 6, 250, Easing.OutElasticQuarter);
             }
 
             protected override bool Commit()


### PR DESCRIPTION
Came from https://github.com/ppy/osu/discussions/37973.

Seems like a low effort UX improvement.

<img width="2656" height="1445" alt="osu! 2026-07-16 at 06 27 30" src="https://github.com/user-attachments/assets/ad53a374-4193-438d-bcad-ca2d331fa2f6" />
