### PR TITLE
Improve editor object inspector display

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectInspector.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Catch.Edit
                 if (precedingObject != null && precedingObject is not BananaShower)
                 {
                     double previousSnap = snapProvider.ReadCurrentDistanceSnap(precedingObject, firstSelectedHitObject);
-                    AddHeader("To previous");
+                    AddHeader("From previous");
                     AddValue($"{previousSnap:#,0.##}x");
                 }
 

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 if (precedingObject != null && precedingObject is not Spinner)
                 {
-                    AddHeader("To previous");
+                    AddHeader("From previous");
                     AddValue($"{(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px");
                 }
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorInspector.cs
@@ -33,17 +33,23 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
         }
 
-        protected void AddHeader(string header) => InspectorText.AddParagraph($"{header}: ", s =>
+        protected void AddHeader(string header)
         {
-            s.Font = OsuFont.Style.Caption1;
-            s.Colour = colourProvider.Content2;
-        });
+            InspectorText.AddParagraph($"{header}", s =>
+            {
+                s.Font = OsuFont.Style.Caption2;
+                s.Colour = colourProvider.Content2;
+            });
+        }
 
-        protected void AddValue(string value) => InspectorText.AddParagraph(value, s =>
+        protected void AddValue(string value)
         {
-            s.Padding = new MarginPadding { Top = -5 };
-            s.Font = OsuFont.Style.Body;
-            s.Colour = colourProvider.Content1;
-        });
+            InspectorText.NewLine();
+            InspectorText.AddText(value, s =>
+            {
+                s.Font = OsuFont.Style.Caption2.With(weight: FontWeight.SemiBold);
+                s.Colour = colourProvider.Content1;
+            });
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -59,70 +59,68 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 case 1:
                     var selected = objects.Single();
 
-                    AddHeader("Type");
-                    AddValue($"{selected.GetType().ReadableName()}");
+                    if (selected is IHasDuration duration)
+                    {
+                        AddHeader("Time");
+                        AddValue($"{selected.StartTime:#,0.##} - {duration.EndTime:#,0.##} ms");
 
-                    AddHeader("Time");
-                    AddValue($"{selected.StartTime:#,0.##}ms");
+                        if (selected is IHasRepeats repeats && repeats.RepeatCount > 0)
+                        {
+                            AddHeader("Duration");
+                            AddValue($"{duration.Duration:#,0.##} ms");
+                            AddValue($"({repeats.RepeatCount:#,0.##} repeats)");
+                        }
+                        else
+                        {
+                            AddHeader("Duration");
+                            AddValue($"{duration.Duration:#,0.##} ms");
+                        }
+                    }
+                    else
+                    {
+                        AddHeader("Time");
+                        AddValue($"{selected.StartTime:#,0.##} ms");
+                    }
 
                     switch (selected)
                     {
                         case IHasPosition pos:
                             AddHeader("Position");
-                            AddValue($"x:{pos.X:#,0.##}");
-                            AddValue($"y:{pos.Y:#,0.##}");
+                            AddValue($"({pos.X:#,0.##}, {pos.Y:#,0.##})");
                             break;
 
                         case IHasXPosition x:
                             AddHeader("Position");
-
-                            AddValue($"x:{x.X:#,0.##} ");
+                            AddValue($"{x.X:#,0.##}");
                             break;
 
                         case IHasYPosition y:
                             AddHeader("Position");
-
-                            AddValue($"y:{y.Y:#,0.##}");
+                            AddValue($"{y.Y:#,0.##}");
                             break;
-                    }
-
-                    if (selected is IHasDistance distance)
-                    {
-                        AddHeader("Distance");
-                        AddValue($"{distance.Distance:#,0.##}px");
                     }
 
                     if (selected is IHasSliderVelocity sliderVelocity)
                     {
                         AddHeader("Slider Velocity");
-                        AddValue($"{sliderVelocity.SliderVelocityMultiplier:#,0.00}x ({sliderVelocity.SliderVelocityMultiplier * EditorBeatmap.Difficulty.SliderMultiplier:#,0.00}x)");
+                        AddValue($"{sliderVelocity.SliderVelocityMultiplier:#,0.00}x");
+                        AddValue($"(actual: {sliderVelocity.SliderVelocityMultiplier * EditorBeatmap.Difficulty.SliderMultiplier:#,0.00}x)");
                     }
 
-                    if (selected is IHasRepeats repeats)
+                    if (selected is IHasDistance distance)
                     {
-                        AddHeader("Repeats");
-                        AddValue($"{repeats.RepeatCount:#,0.##}");
-                    }
-
-                    if (selected is IHasDuration duration)
-                    {
-                        AddHeader("End Time");
-                        AddValue($"{duration.EndTime:#,0.##}ms");
-                        AddHeader("Duration");
-                        AddValue($"{duration.Duration:#,0.##}ms");
+                        AddHeader("Distance covered");
+                        AddValue($"{distance.Distance:#,0.##} px");
                     }
 
                     break;
 
                 default:
-                    AddHeader("Selected Objects");
+                    AddHeader("Object count");
                     AddValue($"{objects.Length:#,0.##}");
 
-                    AddHeader("Start Time");
-                    AddValue($"{objects.Min(o => o.StartTime):#,0.##}ms");
-
-                    AddHeader("End Time");
-                    AddValue($"{objects.Max(o => o.GetEndTime()):#,0.##}ms");
+                    AddHeader("Selection");
+                    AddValue($"{objects.Min(o => o.StartTime):#,0.##} ms - {objects.Max(o => o.GetEndTime()):#,0.##} ms");
                     break;
             }
         }

--- a/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/HitObjectInspector.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Threading;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;


### PR DESCRIPTION
It was taking up far too much screen real estate for what it was. It was also displaying things in a sub-optimal way (sometimes incomprehensible).

I've gone through every displayed property and adjusted to my own subjective liking.

| Before | After |
| :---: | :---: |
| <img width="951" height="639" alt="osu! 2026-07-16 at 07 19 28" src="https://github.com/user-attachments/assets/19cb8060-22f0-4dc5-849a-bf977f770ea0" /> | <img width="950" height="638" alt="osu! 2026-07-16 at 07 18 03" src="https://github.com/user-attachments/assets/42d9d9d3-a89f-4357-b2d8-c5f6ec43fcb5" /> |