### PR TITLE
Fix accuracy and combo proportions being back-to-front in mania standardised score conversion algorithm

### DIFF
--- a/osu.Game/Database/StandardisedScoreMigrationTools.cs
+++ b/osu.Game/Database/StandardisedScoreMigrationTools.cs
@@ -334,8 +334,8 @@ namespace osu.Game.Database
 
                 case 3:
                     convertedTotalScoreWithoutMods = (long)Math.Round(
-                        850000 * comboProportion
-                        + 150000 * Math.Pow(score.Accuracy, 2 + 2 * score.Accuracy)
+                        150000 * comboProportion
+                        + 850000 * Math.Pow(score.Accuracy, 2 + 2 * score.Accuracy)
                         + bonusProportion);
                     break;
 

--- a/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
+++ b/osu.Game/Scoring/Legacy/LegacyScoreEncoder.cs
@@ -63,9 +63,10 @@ namespace osu.Game.Scoring.Legacy
         /// <item><description>30000016: Fix taiko standardised score estimation algorithm not including swell tick score gain into bonus portion. Reconvert all scores.</description></item>
         /// <item><description>30000017: Mod score multiplier rebalance. Recalculates the <see cref="ScoreInfo.TotalScore"/> of all scores with <see cref="ScoreInfo.TotalScoreWithoutMods"/> present.</description></item>
         /// <item><description>30000018: Further improvements to taiko standardised score estimation algorithm. Reconvert all scores.</description></item>
+        /// <item><description>30000019: Fix back-to-front combo and accuracy proportions in mania standardised score estimation algorithm. Reconvert all scores.</description></item>
         /// </list>
         /// </remarks>
-        public const int LATEST_VERSION = 30000018;
+        public const int LATEST_VERSION = 30000019;
 
         /// <summary>
         /// The first stable-compatible YYYYMMDD format version given to lazer usage of replays.


### PR DESCRIPTION
- [x] Pending sheet generation & verification

> [!WARNING]
> The deployment of this fix, if accepted, will consist of reverification of **all** mania legacy scores.
>
> Of particular note, https://github.com/ppy/osu/pull/38203 is also a change that requires server-side reprocessing and that reprocessing has not happened yet as far as I am aware.

Coming from https://github.com/ppy/osu/discussions/38102 (but does not fix it).

Compare:

https://github.com/ppy/osu/blob/d54366dd1192c030b133d85887a19220a4024399/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs#L28-L33 https://github.com/ppy/osu/blob/d54366dd1192c030b133d85887a19220a4024399/osu.Game/Database/StandardisedScoreMigrationTools.cs#L336-L339

Note once more that this *does not fix* the reported user issue. In that particular instance, the outcome will just be flipped (the lazer score will be favoured over the stable score). Unfortunately there is no way to improve the estimate any further to reproduce the exact result. The reason why is that the combo portion is calculated as

https://github.com/ppy/osu/blob/d54366dd1192c030b133d85887a19220a4024399/osu.Game.Rulesets.Mania/Scoring/ManiaScoreProcessor.cs#L35-L38

The key factor in the above calculation is `result.ComboAfterJudgement`, which is not replicable without being able to access full judgement history for a score, which is not available for stable scores unless the play is somehow fully simulated headless.