### PR TITLE
Fix hitobjects not shaking on invalid hit outside of classic mod

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneStartTimeOrderedHitPolicy.cs
@@ -5,21 +5,26 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Screens;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Replays;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.UI;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Tests.Visual;
@@ -31,6 +36,56 @@ namespace osu.Game.Rulesets.Osu.Tests
     {
         private const double early_miss_window = 1000; // time after -1000 to -500 is considered a miss
         private const double late_miss_window = 500; // time after +500 is considered a miss
+
+        [Test]
+        public void TestClickJustBeforeHitWindowStart()
+        {
+            const double time_circle = 1500;
+            Vector2 positionCircle = OsuPlayfield.BASE_SIZE / 2;
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle,
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_circle - early_miss_window - 10, Position = positionCircle, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_circle - early_miss_window, Position = positionCircle },
+            });
+            AddAssert("hit object shook", () => testPolicy.ClickActions, () => Is.EquivalentTo([ClickAction.Shake]));
+            addJudgementAssert(hitObjects[0], HitResult.Miss);
+            addJudgementOffsetAssert(hitObjects[0], late_miss_window);
+        }
+
+        [Test]
+        public void TestClickJustAfterHitWindowStart()
+        {
+            const double time_circle = 1500;
+            Vector2 positionCircle = OsuPlayfield.BASE_SIZE / 2;
+
+            var hitObjects = new List<OsuHitObject>
+            {
+                new TestHitCircle
+                {
+                    StartTime = time_circle,
+                    Position = positionCircle,
+                }
+            };
+
+            performTest(hitObjects, new List<ReplayFrame>
+            {
+                new OsuReplayFrame { Time = time_circle - early_miss_window + 10, Position = positionCircle, Actions = { OsuAction.LeftButton } },
+                new OsuReplayFrame { Time = time_circle - early_miss_window + 20, Position = positionCircle },
+            });
+            AddAssert("hit object hit", () => testPolicy.ClickActions, () => Is.EquivalentTo([ClickAction.Hit]));
+            addJudgementAssert(hitObjects[0], HitResult.Miss);
+            addJudgementOffsetAssert(hitObjects[0], -early_miss_window + 10);
+        }
 
         /// <summary>
         /// Tests clicking a future circle before the first circle's start time, while the first circle HAS NOT been judged.
@@ -409,6 +464,7 @@ namespace osu.Game.Rulesets.Osu.Tests
 
         private ScoreAccessibleReplayPlayer currentPlayer;
         private List<JudgementResult> judgementResults;
+        private HitPolicyResultInterceptor testPolicy;
 
         private void performTest(List<OsuHitObject> hitObjects, List<ReplayFrame> frames)
         {
@@ -440,6 +496,12 @@ namespace osu.Game.Rulesets.Osu.Tests
 
             AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
             AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+            AddStep("Substitute hit policy", () =>
+            {
+                var playfield = currentPlayer.ChildrenOfType<OsuPlayfield>().Single();
+                var currentPolicy = playfield.HitPolicy;
+                playfield.HitPolicy = testPolicy = new HitPolicyResultInterceptor(currentPolicy);
+            });
             AddUntilStep("Wait for completion", () => currentPlayer.ScoreProcessor.HasCompleted.Value);
         }
 
@@ -510,6 +572,34 @@ namespace osu.Game.Rulesets.Osu.Tests
                 })
             {
             }
+        }
+
+        private class HitPolicyResultInterceptor : IHitPolicy
+        {
+            public List<ClickAction> ClickActions { get; } = new List<ClickAction>();
+
+            private readonly IHitPolicy policy;
+
+            public HitPolicyResultInterceptor(IHitPolicy policy)
+            {
+                Debug.Assert(policy is StartTimeOrderedHitPolicy);
+                this.policy = policy;
+            }
+
+            public IHitObjectContainer HitObjectContainer
+            {
+                set => policy.HitObjectContainer = value;
+            }
+
+            public ClickAction CheckHittable(DrawableHitObject hitObject, double time, HitResult result)
+            {
+                var action = policy.CheckHittable(hitObject, time, result);
+                ClickActions.Add(action);
+                return action;
+            }
+
+            public void HandleHit(DrawableHitObject hitObject)
+                => policy.HandleHit(hitObject);
         }
     }
 }

--- a/osu.Game.Rulesets.Osu/UI/StartTimeOrderedHitPolicy.cs
+++ b/osu.Game.Rulesets.Osu/UI/StartTimeOrderedHitPolicy.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Osu.UI
     {
         public IHitObjectContainer? HitObjectContainer { get; set; }
 
-        public ClickAction CheckHittable(DrawableHitObject hitObject, double time, HitResult _)
+        public ClickAction CheckHittable(DrawableHitObject hitObject, double time, HitResult result)
         {
             if (HitObjectContainer == null)
                 throw new InvalidOperationException($"{nameof(HitObjectContainer)} should be set before {nameof(CheckHittable)} is called.");
@@ -36,15 +36,22 @@ namespace osu.Game.Rulesets.Osu.UI
                     blockingObject = obj;
             }
 
-            // If there is no previous hitobject, allow the hit.
-            if (blockingObject == null)
-                return ClickAction.Hit;
+            if (blockingObject != null)
+            {
+                // A hit is disallowed if:
+                // 1. The last blocking hitobject has not yet been judged.
+                // 2. The current time is before the last hitobject's start time.
+                //
+                // Hits at exactly the same time as the blocking hitobject are allowed for maps that contain simultaneous hitobjects (e.g. /b/372245).
+                if (!blockingObject.Judged && time < blockingObject.HitObject.StartTime)
+                    return ClickAction.Shake;
+            }
 
-            // A hit is allowed if:
-            // 1. The last blocking hitobject has been judged.
-            // 2. The current time is after the last hitobject's start time.
-            // Hits at exactly the same time as the blocking hitobject are allowed for maps that contain simultaneous hitobjects (e.g. /b/372245).
-            return (blockingObject.Judged || time >= blockingObject.HitObject.StartTime) ? ClickAction.Hit : ClickAction.Shake;
+            // Generally when the user has hit way too early.
+            if (result == HitResult.None)
+                return ClickAction.Shake;
+
+            return ClickAction.Hit;
         }
 
         public void HandleHit(DrawableHitObject hitObject)


### PR DESCRIPTION
Wow, I did not realise this was not working. This is a core gameplay UX feature which I don't want to see lost to history.

Addresses https://github.com/ppy/osu/discussions/38181.