### PR TITLE
Fix skin editor reset button not working

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneDialogOverlay.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneDialogOverlay.cs
@@ -151,6 +151,34 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestPushWhileOverlayActivationUserTriggered()
+        {
+            PopupDialog dialog = null;
+
+            AddStep("set activation mode user triggered", () => overlayActivationMode.Value = OverlayActivation.UserTriggered);
+
+            AddUntilStep("overlay not visible", () => overlay.State.Value, () => Is.EqualTo(Visibility.Hidden));
+
+            AddStep("push dialog", () =>
+            {
+                overlay.Push(dialog = new TestPopupDialog
+                {
+                    Buttons = new PopupDialogButton[]
+                    {
+                        new PopupDialogOkButton { Text = @"OK" },
+                    },
+                });
+            });
+
+            AddUntilStep("overlay visible", () => overlay.State.Value, () => Is.EqualTo(Visibility.Visible));
+            AddUntilStep("dialog displayed", () => dialog.State.Value, () => Is.EqualTo(Visibility.Visible));
+
+            AddStep("set activation mode disabled", () => overlayActivationMode.Value = OverlayActivation.Disabled);
+            AddUntilStep("dialog hidden", () => dialog.State.Value, () => Is.EqualTo(Visibility.Hidden));
+            AddAssert("dialog dismissed", () => overlay.CurrentDialog, () => Is.Null);
+        }
+
+        [Test]
         public void TestPushBeforeLoad()
         {
             PopupDialog dialog = null;

--- a/osu.Game/Overlays/DialogOverlay.cs
+++ b/osu.Game/Overlays/DialogOverlay.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Overlays
                                           // Without this, a dialog pushed during disabled overlay activation mode would be presented,
                                           // but immediately dismissed without ever being seen by the user (see
                                           // https://github.com/ppy/osu/blob/ce5e54c9d27b17d460d99e774de502f9480fb710/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs#L131-L136).
-                                          && OverlayActivationMode.Value == OverlayActivation.All;
+                                          && OverlayActivationMode.Value != OverlayActivation.Disabled;
 
         [CanBeNull]
         private IDisposable duckOperation;


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/38135
- Regressed in f1ffa0a67d4fae4c8447ba1ff23e7abd7d5de8af
- Suggested by @diquoks in https://github.com/ppy/osu/issues/38135#issuecomment-4988677743

Previously, if the overlay was opened with `OverlayActivation.UserTriggered`, an incorrect check would set `IsPresent = false` for all values, except `OverlayActivation.All`.
as follows from the comment above the check, it should have been done the opposite, and instead checked that the value is not equal to `OverlayActivation.Disabled`.

https://github.com/ppy/osu/blob/415ddf803b79a04d28770dff451a0a8f82911125/osu.Game/Graphics/Containers/OsuFocusedOverlayContainer.cs#L131

It also fixes cases when overlay can't appear during in-gameplay game state (as i've noticed during manual testing), e.g deleting skins when you've paused the beatmap.

Master:

https://github.com/user-attachments/assets/e6c72c60-ddba-414f-ad26-81b3b34ed182 

PR:

https://github.com/user-attachments/assets/d2464aa2-ada2-4b4d-ad89-2566467e59ec

