### PR TITLE
Fix collection sorting to be case-insensitive

### DIFF
--- a/osu.Game/Collections/DrawableCollectionList.cs
+++ b/osu.Game/Collections/DrawableCollectionList.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -54,7 +55,7 @@ namespace osu.Game.Collections
         {
             base.LoadComplete();
 
-            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.Name), collectionsChanged);
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>(), collectionsChanged);
         }
 
         /// <summary>
@@ -79,11 +80,19 @@ namespace osu.Game.Collections
             }
         }
 
+        private void SortItems()
+        {
+            var sorted = Items.OrderBy(item => item.Value.Name, StringComparer.OrdinalIgnoreCase).ToList();
+            Items.Clear();
+            Items.AddRange(sorted);
+        }
+
         private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes)
         {
             if (changes == null)
             {
                 Items.AddRange(collections.AsEnumerable().Select(c => c.ToLive(realm)));
+                SortItems();
                 return;
             }
 
@@ -93,9 +102,6 @@ namespace osu.Game.Collections
             foreach (int i in changes.InsertedIndices)
                 Items.Insert(i, collections[i].ToLive(realm));
 
-            if (changes.InsertedIndices.Length == 1)
-                lastCreated = collections[changes.InsertedIndices[0]].ID;
-
             foreach (int i in changes.NewModifiedIndices)
             {
                 var updatedItem = collections[i];
@@ -103,6 +109,11 @@ namespace osu.Game.Collections
                 Items.RemoveAt(i);
                 Items.Insert(i, updatedItem.ToLive(realm));
             }
+
+            SortItems();
+
+            if (changes.InsertedIndices.Length == 1)
+                lastCreated = collections[changes.InsertedIndices[0]].ID;
         }
 
         protected override OsuRearrangeableListItem<Live<BeatmapCollection>> CreateOsuDrawable(Live<BeatmapCollection> item) =>

--- a/osu.Game/Collections/DrawableCollectionList.cs
+++ b/osu.Game/Collections/DrawableCollectionList.cs
@@ -89,31 +89,9 @@ namespace osu.Game.Collections
 
         private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes)
         {
-            if (changes == null)
-            {
-                Items.AddRange(collections.AsEnumerable().Select(c => c.ToLive(realm)));
-                SortItems();
-                return;
-            }
-
-            foreach (int i in changes.DeletedIndices.OrderDescending())
-                Items.RemoveAt(i);
-
-            foreach (int i in changes.InsertedIndices)
-                Items.Insert(i, collections[i].ToLive(realm));
-
-            foreach (int i in changes.NewModifiedIndices)
-            {
-                var updatedItem = collections[i];
-
-                Items.RemoveAt(i);
-                Items.Insert(i, updatedItem.ToLive(realm));
-            }
-
+            Items.Clear();
+            Items.AddRange(collections.Select(c => c.ToLive(realm)));
             SortItems();
-
-            if (changes.InsertedIndices.Length == 1)
-                lastCreated = collections[changes.InsertedIndices[0]].ID;
         }
 
         protected override OsuRearrangeableListItem<Live<BeatmapCollection>> CreateOsuDrawable(Live<BeatmapCollection> item) =>

--- a/osu.Game/Screens/Select/CollectionDropdown.cs
+++ b/osu.Game/Screens/Select/CollectionDropdown.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Transactions;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -87,42 +88,30 @@ namespace osu.Game.Screens.Select
             }
             else
             {
-                foreach (int i in changes.DeletedIndices.OrderDescending())
-                    filters.RemoveAt(i + 1);
+                var selectedId = SelectedItem?.Value?.Collection?.ID;
 
-                foreach (int i in changes.InsertedIndices)
-                    filters.Insert(i + 1, new CollectionFilterMenuItem(collections[i].ToLive(realm)));
+                // rebuild list
+                filters.Clear();
+                filters.Add(allBeatmapsItem);
+                filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
 
-                var selectedItem = SelectedItem?.Value;
-
-                foreach (int i in changes.NewModifiedIndices)
-                {
-                    var updatedItem = collections[i];
-
-                    // This is responsible for updating the state of the +/- button and the collection's name.
-                    // TODO: we can probably make the menu items update with changes to avoid this.
-                    filters.RemoveAt(i + 1);
-                    filters.Insert(i + 1, new CollectionFilterMenuItem(updatedItem.ToLive(realm)));
-
-                    if (updatedItem.ID == selectedItem?.Collection?.ID)
-                    {
-                        // This current update and schedule is required to work around dropdown headers not updating text even when the selected item
-                        // changes. It's not great but honestly the whole dropdown menu structure isn't great. This needs to be fixed, but I'll issue
-                        // a warning that it's going to be a frustrating journey.
-                        Current.Value = allBeatmapsItem;
-                        Schedule(() =>
-                        {
-                            // current may have changed before the scheduled call is run.
-                            if (Current.Value != allBeatmapsItem)
-                                return;
-
-                            Current.Value = filters.SingleOrDefault(f => f.Collection?.ID == selectedItem.Collection?.ID) ?? filters[0];
-                        });
-
-                        break;
-                    }
-                }
+                if (ShowManageCollectionsItem)
+                    filters.Add(new ManageCollectionsFilterMenuItem());
                 SortFilters();
+
+                // if still exists
+                if (selectedId.HasValue)
+                {
+                    var selectedFilter = filters.FirstOrDefault(filter => filter.Collection?.ID == selectedId);
+                    if (selectedFilter != null)
+                        Current.Value = selectedFilter;
+                    else
+                        Current.Value = allBeatmapsItem;
+                }
+                else
+                {
+                    Current.Value = allBeatmapsItem;
+                }
             }
         }
 

--- a/osu.Game/Screens/Select/CollectionDropdown.cs
+++ b/osu.Game/Screens/Select/CollectionDropdown.cs
@@ -60,9 +60,18 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
 
-            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.Name), collectionsChanged);
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>(), collectionsChanged);
 
             Current.BindValueChanged(selectionChanged);
+        }
+
+        private void SortFilters()
+        {
+            var sorted = filters.ToList()
+                .OrderBy(filter => filter.CollectionName.ToString(), StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            filters.Clear();
+            filters.AddRange(sorted);
         }
 
         private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes)
@@ -74,6 +83,7 @@ namespace osu.Game.Screens.Select
                 filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
                 if (ShowManageCollectionsItem)
                     filters.Add(new ManageCollectionsFilterMenuItem());
+                SortFilters();
             }
             else
             {
@@ -112,6 +122,7 @@ namespace osu.Game.Screens.Select
                         break;
                     }
                 }
+                SortFilters();
             }
         }
 

--- a/osu.Game/Screens/Select/CollectionDropdown.cs
+++ b/osu.Game/Screens/Select/CollectionDropdown.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Transactions;
+using Microsoft.VisualBasic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
@@ -68,50 +69,52 @@ namespace osu.Game.Screens.Select
 
         private void SortFilters()
         {
-            var sorted = filters.ToList()
+            var allItem = filters.FirstOrDefault(filter => filter is AllBeatmapsCollectionFilterMenuItem);
+            var manageItem = filters.FirstOrDefault(filter => filter is ManageCollectionsFilterMenuItem);
+
+            var collectionItems = filters
+                .Where(filter => filter is not AllBeatmapsCollectionFilterMenuItem && filter is not ManageCollectionsFilterMenuItem)
+                .ToList()
                 .OrderBy(filter => filter.CollectionName.ToString(), StringComparer.OrdinalIgnoreCase)
                 .ToList();
+
             filters.Clear();
-            filters.AddRange(sorted);
+            if (allItem != null)
+                filters.Add(allItem);
+            filters.AddRange(collectionItems);
+            if (manageItem != null)
+                filters.Add(manageItem);
         }
 
         private void collectionsChanged(IRealmCollection<BeatmapCollection> collections, ChangeSet? changes)
         {
-            if (changes == null)
+            Guid? selectedId = null;
+            var selectedItem = SelectedItem?.Value;
+            if (selectedItem?.Collection != null)
             {
-                filters.Clear();
-                filters.Add(allBeatmapsItem);
-                filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
-                if (ShowManageCollectionsItem)
-                    filters.Add(new ManageCollectionsFilterMenuItem());
-                SortFilters();
+                var collectionId = selectedItem.Collection.ID;
+                if (collections.Any(c => c.ID == collectionId))
+                    selectedId = collectionId;
+            }
+
+            // rebuild list
+            filters.Clear();
+            filters.Add(allBeatmapsItem);
+            filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
+
+            if (ShowManageCollectionsItem)
+                filters.Add(new ManageCollectionsFilterMenuItem());
+            SortFilters();
+
+            // if still exists, return selected filter
+            if (selectedId.HasValue)
+            {
+                var selectedFilter = filters.FirstOrDefault(f => f.Collection?.ID == selectedId);
+                Current.Value = selectedFilter ?? allBeatmapsItem;
             }
             else
             {
-                var selectedId = SelectedItem?.Value?.Collection?.ID;
-
-                // rebuild list
-                filters.Clear();
-                filters.Add(allBeatmapsItem);
-                filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
-
-                if (ShowManageCollectionsItem)
-                    filters.Add(new ManageCollectionsFilterMenuItem());
-                SortFilters();
-
-                // if still exists
-                if (selectedId.HasValue)
-                {
-                    var selectedFilter = filters.FirstOrDefault(filter => filter.Collection?.ID == selectedId);
-                    if (selectedFilter != null)
-                        Current.Value = selectedFilter;
-                    else
-                        Current.Value = allBeatmapsItem;
-                }
-                else
-                {
-                    Current.Value = allBeatmapsItem;
-                }
+                Current.Value = allBeatmapsItem;
             }
         }
 


### PR DESCRIPTION
- Closes #38323
------
Currently `osu.Game/Collections/DrawableCollectionList.cs` and `osu.Game/Screens/Select/CollectionDropdown.cs` are using *case-sensitive* sorting logic so I changed it to more intuitive *case-insensitive* and changed collectionsChanged function to be more intuitive with SortItems and SortFilters helper functions
### Screenshots:
![sidebar](https://github.com/user-attachments/assets/05b5b565-d01a-4912-91d9-09a7edface3d)
![dropdown](https://github.com/user-attachments/assets/93acb811-ae2a-4f1c-9c98-9fbeb98be954)