### PR TITLE
Fix settings sections sometimes not being highlighted when scrolling to a setting programmatically

### DIFF
--- a/osu.Game.Tests/Visual/UserInterface/TestSceneSectionsContainer.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneSectionsContainer.cs
@@ -99,6 +99,15 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestScrollToSectionChildren()
+        {
+            AddRepeatStep("add many sections", () => append(1f), 3);
+            AddStep("scroll to first section", () => container.ScrollTo(container.Children.First()));
+            AddStep("scroll to final section's text", () => container.ScrollTo(container.Children.Last().ChildrenOfType<OsuSpriteText>().Single()));
+            AddUntilStep("correct section selected", () => container.SelectedSection.Value == container.Children.Last());
+        }
+
+        [Test]
         public void TestSelection()
         {
             AddStep("clear", () => container.Clear());

--- a/osu.Game/Graphics/Containers/SectionsContainer.cs
+++ b/osu.Game/Graphics/Containers/SectionsContainer.cs
@@ -164,7 +164,7 @@ namespace osu.Game.Graphics.Containers
         {
             Logger.Log($"Scrolling to {target}..");
 
-            lastKnownScroll = null;
+            InvalidateScrollPosition();
 
             float scrollTarget = getScrollTargetForDrawable(target);
 


### PR DESCRIPTION
To reproduce the bug, you first need to select a section (by sidebar or by clicking a dimmed section).

Before:

https://github.com/user-attachments/assets/9704927c-28f4-46da-9326-261af8b4887c

After:

https://github.com/user-attachments/assets/6f45f1ae-87a1-49ee-85c6-5a9db6671484
