### PR TITLE
Change song select click-to-search behaviour to append rather than replace

### DIFF
--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.cs
@@ -351,12 +351,12 @@ namespace osu.Game.Screens.Select
             creator.Data = (metadata.Author.Username, () => linkHandler?.HandleLink(new LinkDetails(LinkAction.OpenUserProfile, metadata.Author)));
 
             if (!string.IsNullOrEmpty(metadata.Source))
-                source.Data = (metadata.Source, () => songSelect?.Search(metadata.Source));
+                source.Data = (metadata.Source, () => songSelect?.AddToSearch(metadata.Source));
             else
                 source.Data = ("-", null);
 
             if (!string.IsNullOrEmpty(metadata.Tags))
-                mapperTags.Tags = (metadata.Tags.Split(' '), t => songSelect?.Search(t));
+                mapperTags.Tags = (metadata.Tags.Split(' '), t => songSelect?.AddToSearch(t));
             else
                 mapperTags.Tags = (Array.Empty<string>(), _ => { });
 
@@ -388,8 +388,8 @@ namespace osu.Game.Screens.Select
                 var onlineBeatmapSet = onlineLookupResult.Value.Result;
                 var onlineBeatmap = onlineBeatmapSet.Beatmaps.SingleOrDefault(b => b.OnlineID == beatmapInfo.OnlineID);
 
-                genre.Data = (onlineBeatmapSet.Genre.Name, () => songSelect?.Search(onlineBeatmapSet.Genre.Name));
-                language.Data = (onlineBeatmapSet.Language.Name, () => songSelect?.Search(onlineBeatmapSet.Language.Name));
+                genre.Data = (onlineBeatmapSet.Genre.Name, () => songSelect?.AddToSearch(onlineBeatmapSet.Genre.Name));
+                language.Data = (onlineBeatmapSet.Language.Name, () => songSelect?.AddToSearch(onlineBeatmapSet.Language.Name));
 
                 if (onlineBeatmap != null)
                 {
@@ -434,7 +434,7 @@ namespace osu.Game.Screens.Select
                     }
 
                     userTags.FadeIn(transition_duration, Easing.OutQuint);
-                    userTags.Tags = (tags, tag => songSelect?.Search($@"tag=""{tag}""!"));
+                    userTags.Tags = (tags, tag => songSelect?.AddToSearch($@"tag=""{tag}""!"));
                 });
             }, token);
         }

--- a/osu.Game/Screens/Select/BeatmapTitleWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapTitleWedge.cs
@@ -230,7 +230,7 @@ namespace osu.Game.Screens.Select
                 Shadow = true,
                 Font = OsuFont.Style.Title,
             };
-            titleLink.Action = () => songSelect?.Search(titleText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript));
+            titleLink.Action = () => songSelect?.AddToSearch(titleText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript));
             DisplayedTitle = titleText.ToString();
 
             var artistText = new RomanisableString(metadata.ArtistUnicode, metadata.Artist);
@@ -240,7 +240,7 @@ namespace osu.Game.Screens.Select
                 Shadow = true,
                 Font = OsuFont.Style.Heading2,
             };
-            artistLink.Action = () => songSelect?.Search(artistText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript));
+            artistLink.Action = () => songSelect?.AddToSearch(artistText.GetPreferred(localisation.CurrentParameters.Value.PreferOriginalScript));
             DisplayedArtist = artistText.ToString();
 
             updateLengthAndBpmStatistics();

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -348,6 +348,20 @@ namespace osu.Game.Screens.Select
             searchTextBox.Current.Value = query;
         }
 
+        /// <summary>
+        /// Set the query to the search text box.
+        /// </summary>
+        /// <param name="query">The string to search.</param>
+        public void AddToSearch(string query)
+        {
+            string existingQuery = searchTextBox.Current.Value;
+
+            if (existingQuery.Contains(query))
+                return;
+
+            searchTextBox.Current.Value = string.Join(' ', existingQuery.Trim(), query);
+        }
+
         protected override void PopIn()
         {
             this.MoveToX(0, SongSelect.ENTER_DURATION, Easing.OutQuint)

--- a/osu.Game/Screens/Select/ISongSelect.cs
+++ b/osu.Game/Screens/Select/ISongSelect.cs
@@ -44,9 +44,9 @@ namespace osu.Game.Screens.Select
         void PresentScore(ScoreInfo score, ScorePresentType presentType = ScorePresentType.Results);
 
         /// <summary>
-        /// Set the current filter text query to the provided string.
+        /// Add provided string to the current filter text query.
         /// </summary>
-        void Search(string query);
+        void AddToSearch(string query);
 
         /// <summary>
         /// Gets relevant actionable items for beatmap context menus, based on the type of song select.

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1151,7 +1151,7 @@ namespace osu.Game.Screens.Select
 
         #region Implementation of ISongSelect
 
-        void ISongSelect.Search(string query) => FilterControl.Search(query);
+        void ISongSelect.AddToSearch(string query) => FilterControl.AddToSearch(query);
 
         bool ISongSelect.CanPresentScore => true;
 


### PR DESCRIPTION
As raised in https://github.com/ppy/osu/discussions/38216, with significant upvotes. Agree that the existing behaviour was sub-optimal – it's easy enough for a user to clear search if they want to do so before starting a fresh one.

https://github.com/user-attachments/assets/b61ff093-19c6-4b2a-b514-6a67108fc8a3

