### PR TITLE
Implement storyboard passing, failing, & hit object hit triggers

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneDrawableStoryboardSprite.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,10 +17,15 @@ using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play;
 using osu.Game.Storyboards;
 using osu.Game.Storyboards.Drawables;
+using osu.Game.Tests.Gameplay;
 using osu.Game.Tests.Resources;
 using osuTK;
 
@@ -31,6 +37,9 @@ namespace osu.Game.Tests.Visual.Gameplay
 
         [Cached(typeof(Storyboard))]
         private TestStoryboard storyboard { get; set; } = new TestStoryboard();
+
+        [Cached]
+        private GameplayState gameplayState = TestGameplayState.Create(new OsuRuleset());
 
         private IEnumerable<DrawableStoryboardSprite> sprites => this.ChildrenOfType<DrawableStoryboardSprite>();
 
@@ -244,6 +253,99 @@ namespace osu.Game.Tests.Visual.Gameplay
                 s.FlipV = true;
             }));
             AddAssert("origin back", () => sprites.All(s => s.Origin == Anchor.TopLeft));
+        }
+
+        [Test]
+        public void TestPassingFailingTriggers()
+        {
+            AddStep("allow all lookups", () =>
+            {
+                storyboard.UseSkinSprites = false;
+                storyboard.ProvideResources = true;
+            });
+
+            AddStep("create sprites", () => SetContents(_ =>
+            {
+                var layer = storyboard.GetLayer("Background");
+
+                var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, lookup_name, Anchor.TopLeft, Vector2.Zero);
+                var loop = sprite.AddLoopingGroup(Time.Current, 100);
+                loop.AddAlpha(Easing.None, 0, 10000, 1, 1);
+                var passTrigger = sprite.AddTriggerGroup(@"Passing", 0, 0, 0);
+                passTrigger.AddFlipV(Easing.None, 0, 0, false, false);
+                var failTrigger = sprite.AddTriggerGroup(@"Failing", 0, 0, 0);
+                failTrigger.AddFlipV(Easing.None, 0, 0, true, true);
+
+                layer.Elements.Clear();
+                layer.Add(sprite);
+
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        storyboard.CreateDrawable()
+                    }
+                };
+            }));
+
+            AddStep("failing", () => gameplayState.HealthProcessor.Health.Value = 0.3);
+            AddAssert("all sprites flipped", () => this.ChildrenOfType<DrawableStoryboardSprite>().All(s => s.FlipV));
+
+            AddStep("passing", () => gameplayState.HealthProcessor.Health.Value = 0.8);
+            AddAssert("all sprites unflipped", () => this.ChildrenOfType<DrawableStoryboardSprite>().All(s => !s.FlipV));
+        }
+
+        [Test]
+        public void TestHitObjectHitTrigger()
+        {
+            AddStep("allow all lookups", () =>
+            {
+                storyboard.UseSkinSprites = false;
+                storyboard.ProvideResources = true;
+            });
+
+            AddStep("create sprites", () => SetContents(_ =>
+            {
+                var layer = storyboard.GetLayer("Background");
+
+                var sprite = new StoryboardSprite(StoryboardElementSource.Beatmap, lookup_name, Anchor.TopLeft, Vector2.Zero);
+                var loop = sprite.AddLoopingGroup(Time.Current, 100);
+                loop.AddAlpha(Easing.None, 0, 10000, 1, 1);
+                var hitObjectHitTrigger = sprite.AddTriggerGroup(@"HitObjectHit", 0, 2000, 0);
+                hitObjectHitTrigger.AddColour(Easing.None, 0, 2000, Colour4.Red, Colour4.White);
+
+                layer.Elements.Clear();
+                layer.Add(sprite);
+
+                return new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        storyboard.CreateDrawable()
+                    }
+                };
+            }));
+
+            AddStep("new scorable hit", () => ((Bindable<JudgementResult>)gameplayState.LastJudgementResult).Value = new JudgementResult(new HitObject(), new Judgement())
+            {
+                Type = HitResult.Great
+            });
+            AddAssert("colour changed", () => this.ChildrenOfType<DrawableStoryboardSprite>().All(s => s.Colour != Colour4.White));
+            AddUntilStep("colour eventually reverts", () => this.ChildrenOfType<DrawableStoryboardSprite>().All(s => s.Colour == Colour4.White));
+
+            AddStep("new non-scorable hit", () => ((Bindable<JudgementResult>)gameplayState.LastJudgementResult).Value = new JudgementResult(new HitObject(), new Judgement())
+            {
+                Type = HitResult.IgnoreMiss
+            });
+            AddAssert("colour not changed", () => this.ChildrenOfType<DrawableStoryboardSprite>().All(s => s.Colour == Colour4.White));
+
+            AddStep("new scorable miss", () => ((Bindable<JudgementResult>)gameplayState.LastJudgementResult).Value = new JudgementResult(new HitObject(), new Judgement())
+            {
+                Type = HitResult.Miss
+            });
+            AddAssert("colour not changed", () => this.ChildrenOfType<DrawableStoryboardSprite>().All(s => s.Colour == Colour4.White));
         }
 
         private Drawable createSprite(string lookupName, Anchor origin, Vector2 initialPosition)

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -26,6 +26,9 @@ namespace osu.Game.Storyboards.Drawables
         [Cached(typeof(Storyboard))]
         public Storyboard Storyboard { get; }
 
+        [Cached(typeof(StoryboardTriggerController))]
+        public StoryboardTriggerController TriggerController { get; }
+
         /// <summary>
         /// Whether the storyboard is considered finished.
         /// </summary>
@@ -77,6 +80,10 @@ namespace osu.Game.Storyboards.Drawables
                 RelativeSizeAxes = Axes.Both,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
+            });
+            AddInternal(TriggerController = new StoryboardTriggerController
+            {
+                Passing = passing,
             });
         }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboard.cs
@@ -114,7 +114,14 @@ namespace osu.Game.Storyboards.Drawables
         {
             base.LoadComplete();
 
-            health.BindValueChanged(val => passing.Value = val.NewValue >= 0.5, true);
+            health.BindValueChanged(val =>
+            {
+                // TODO: this is very arbitrary and doesn't work how it is historically supposed to.
+                // - For taiko ruleset, this will cause the first half of a perfect play to be "failing".
+                // - For all cases, it can flip-flop states too often (on stable it only updated at end of combo).
+                // - Also, in stable a different condition was used for non-break-time passing state (local combo performance).
+                passing.Value = val.NewValue >= 0.5;
+            }, true);
             passing.BindValueChanged(_ => updateLayerVisibility(), true);
         }
 

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardAnimation.cs
@@ -114,7 +114,7 @@ namespace osu.Game.Storyboards.Drawables
         private TextureStore textureStore { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(Storyboard storyboard)
+        private void load(Storyboard storyboard, StoryboardTriggerController triggerController)
         {
             if (storyboard.UseSkinSprites)
             {
@@ -124,7 +124,7 @@ namespace osu.Game.Storyboards.Drawables
             else
                 addFramesFromStoryboardSource();
 
-            Animation.ApplyTransforms(this);
+            Animation.ApplyTransforms(this, triggerController);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardSprite.cs
@@ -107,7 +107,7 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(Storyboard storyboard)
+        private void load(Storyboard storyboard, StoryboardTriggerController triggerController)
         {
             if (storyboard.UseSkinSprites)
             {
@@ -117,7 +117,7 @@ namespace osu.Game.Storyboards.Drawables
             else
                 Texture = textureStore.Get(Sprite.Path, WrapMode.ClampToEdge, WrapMode.ClampToEdge);
 
-            Sprite.ApplyTransforms(this);
+            Sprite.ApplyTransforms(this, triggerController);
         }
 
         private void skinSourceChanged()

--- a/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
+++ b/osu.Game/Storyboards/Drawables/DrawableStoryboardVideo.cs
@@ -40,7 +40,7 @@ namespace osu.Game.Storyboards.Drawables
         }
 
         [BackgroundDependencyLoader(true)]
-        private void load(TextureStore textureStore)
+        private void load(TextureStore textureStore, StoryboardTriggerController triggerController)
         {
             var stream = textureStore.GetStream(Video.Path);
 
@@ -56,7 +56,7 @@ namespace osu.Game.Storyboards.Drawables
                 Alpha = 0,
             };
 
-            Video.ApplyTransforms(drawableVideo);
+            Video.ApplyTransforms(drawableVideo, triggerController);
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Storyboards/Drawables/StoryboardTriggerController.cs
+++ b/osu.Game/Storyboards/Drawables/StoryboardTriggerController.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Game.Storyboards.Commands;
+
+namespace osu.Game.Storyboards.Drawables
+{
+    public partial class StoryboardTriggerController : Component
+    {
+        public Bindable<bool> Passing
+        {
+            get => passing.Current;
+            set => passing.Current = value;
+        }
+
+        private readonly BindableWithCurrent<bool> passing = new BindableWithCurrent<bool>();
+
+        public void Bind<TDrawable>(TDrawable drawable, StoryboardTriggerGroup triggerGroup)
+            where TDrawable : Drawable, IFlippable, IVectorScalable
+        {
+            switch (triggerGroup.TriggerName)
+            {
+                case @"Passing":
+                    bindPassing(drawable, triggerGroup, true);
+                    break;
+
+                case @"Failing":
+                    bindPassing(drawable, triggerGroup, false);
+                    break;
+            }
+        }
+
+        private void bindPassing<TDrawable>(TDrawable drawable, StoryboardTriggerGroup triggerGroup, bool passing)
+            where TDrawable : Drawable, IFlippable, IVectorScalable
+        {
+            this.passing.BindValueChanged(val =>
+            {
+                if (val.NewValue != passing)
+                    return;
+
+                playTrigger(drawable, triggerGroup);
+            });
+        }
+
+        private static void playTrigger<TDrawable>(TDrawable drawable, StoryboardTriggerGroup triggerGroup)
+            where TDrawable : Drawable, IFlippable, IVectorScalable
+        {
+            using (drawable.BeginDelayedSequence(0))
+            {
+                foreach (var command in triggerGroup.AllCommands.OrderBy(c => c.StartTime))
+                    command.ApplyTransforms(drawable);
+            }
+        }
+    }
+}

--- a/osu.Game/Storyboards/Drawables/StoryboardTriggerController.cs
+++ b/osu.Game/Storyboards/Drawables/StoryboardTriggerController.cs
@@ -2,8 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Screens.Play;
 using osu.Game.Storyboards.Commands;
 
 namespace osu.Game.Storyboards.Drawables
@@ -18,6 +23,15 @@ namespace osu.Game.Storyboards.Drawables
 
         private readonly BindableWithCurrent<bool> passing = new BindableWithCurrent<bool>();
 
+        private readonly IBindable<JudgementResult> lastJudgementResult = new Bindable<JudgementResult>();
+
+        [BackgroundDependencyLoader]
+        private void load(GameplayState? gameplayState)
+        {
+            if (gameplayState != null)
+                lastJudgementResult.BindTo(gameplayState.LastJudgementResult);
+        }
+
         public void Bind<TDrawable>(TDrawable drawable, StoryboardTriggerGroup triggerGroup)
             where TDrawable : Drawable, IFlippable, IVectorScalable
         {
@@ -29,6 +43,14 @@ namespace osu.Game.Storyboards.Drawables
 
                 case @"Failing":
                     bindPassing(drawable, triggerGroup, false);
+                    break;
+
+                case @"HitObjectHit":
+                    lastJudgementResult.BindValueChanged(val =>
+                    {
+                        if (val.NewValue.IsNotNull() && val.NewValue.IsHit && val.NewValue.Type.IsScorable())
+                            playTrigger(drawable, triggerGroup);
+                    });
                     break;
             }
         }

--- a/osu.Game/Storyboards/StoryboardSprite.cs
+++ b/osu.Game/Storyboards/StoryboardSprite.cs
@@ -135,7 +135,7 @@ namespace osu.Game.Storyboards
             return trigger;
         }
 
-        public void ApplyTransforms<TDrawable>(TDrawable drawable)
+        public void ApplyTransforms<TDrawable>(TDrawable drawable, StoryboardTriggerController triggerController)
             where TDrawable : Drawable, IFlippable, IVectorScalable
         {
             HashSet<string> appliedProperties = new HashSet<string>();
@@ -153,6 +153,9 @@ namespace osu.Game.Storyboards
                 using (drawable.BeginAbsoluteSequence(command.StartTime))
                     command.ApplyTransforms(drawable);
             }
+
+            foreach (var triggerGroup in TriggerGroups)
+                triggerController.Bind(drawable, triggerGroup);
         }
     }
 }


### PR DESCRIPTION
RFC

Part of https://github.com/ppy/osu/issues/2084

## [Passing & failing triggers](https://github.com/ppy/osu/commit/d84cbec4c0eebe6275c3ec8df1357f0a6651db7d)

Caveats here are very similar to https://github.com/ppy/osu/pull/28480 in that when these are triggered *will* not match stable because stable's code surrounding that area is one of the worst parts of stable I've ever seen (`Player.UpdatePassing()`, `Ruleset.IsPassing`, `Player.Passing`, none of those three behaving in organoleptically observable practice as I would expect them based on source inspection...) and I have well run out of my "getting through stable code" juice for this week.

This implementation is very simple: HP above half = passing, HP below half = failing.

## [Hit object hit triggers](https://github.com/ppy/osu/commit/df549d7a24bf7a45120126afa3eaf212fc6a0101)

For whatever reason these do not appear to work on stable at all in catch or mania, but they will work fine with this implementation. On osu! and taiko this implementation should probably be close enough to not need getting touched in the future, though I have not tested that very much.

## Hit sound triggers: [The rest of the proverbial owl](https://knowyourmeme.com/photos/572078-how-to-draw-an-owl)

These are not implemented here for two reasons:

- The logic to when these fire is significantly more complicated conceptually than the other two based on source inspection
- I have no idea how I am going to couple hit sound playing with storyboard triggering. On stable, which treats component layering as a loose suggestion at best, this is not as much of a problem - but when you want to actually separate concerns, it's a bigger pickle. The closest thing lazer has that *may* somehow be usable here is `DrawableHitObject.PlaySamples()` but I generally just do not want to get into those weeds too deep at this point in time as this is an L-size diff stat anyhow.