### PR TITLE
Add actual distance snap value to the osu hitobject inspector

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         private readonly Bindable<TernaryState> rectangularGridSnapToggle = new Bindable<TernaryState>();
 
-        protected override Drawable CreateHitObjectInspector() => new OsuHitObjectInspector();
+        protected override Drawable CreateHitObjectInspector() => new OsuHitObjectInspector(DistanceSnapProvider);
 
         protected override IEnumerable<Drawable> CreateTernaryButtons()
             => base.CreateTernaryButtons()

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -10,8 +10,15 @@ using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
-    public partial class OsuHitObjectInspector(OsuDistanceSnapProvider snapProvider) : HitObjectInspector
+    public partial class OsuHitObjectInspector : HitObjectInspector
     {
+        private readonly OsuDistanceSnapProvider snapProvider;
+
+        public OsuHitObjectInspector(OsuDistanceSnapProvider snapProvider)
+        {
+            this.snapProvider = snapProvider;
+        }
+
         protected override void AddInspectorValues(HitObject[] objects)
         {
             base.AddInspectorValues(objects);

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -29,13 +29,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (precedingObject != null && precedingObject is not Spinner)
                 {
                     AddHeader("From previous");
-                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection).ToLocalisableString("N2")} ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection).ToLocalisableString("N2")}x ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
                 }
 
                 if (nextObject != null && nextObject is not Spinner)
                 {
                     AddHeader("To next");
-                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject).ToLocalisableString("N2")} ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject).ToLocalisableString("N2")}x ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
                 }
             }
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -3,13 +3,14 @@
 
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
 
 namespace osu.Game.Rulesets.Osu.Edit
 {
-    public partial class OsuHitObjectInspector : HitObjectInspector
+    public partial class OsuHitObjectInspector(OsuDistanceSnapProvider snapProvider) : HitObjectInspector
     {
         protected override void AddInspectorValues(HitObject[] objects)
         {
@@ -28,13 +29,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (precedingObject != null && precedingObject is not Spinner)
                 {
                     AddHeader("From previous");
-                    AddValue($"{(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection).ToLocalisableString(@"0.##x")} ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
                 }
 
                 if (nextObject != null && nextObject is not Spinner)
                 {
                     AddHeader("To next");
-                    AddValue($"{(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject).ToLocalisableString(@"0.##x")} ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
                 }
             }
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Linq;
-using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Screens.Edit.Compose.Components;
@@ -36,13 +35,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (precedingObject != null && precedingObject is not Spinner)
                 {
                     AddHeader("From previous");
-                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection).ToLocalisableString("N2")}x ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection):N2}x ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
                 }
 
                 if (nextObject != null && nextObject is not Spinner)
                 {
                     AddHeader("To next");
-                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject).ToLocalisableString("N2")}x ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject):N2}x ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
                 }
             }
         }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectInspector.cs
@@ -29,13 +29,13 @@ namespace osu.Game.Rulesets.Osu.Edit
                 if (precedingObject != null && precedingObject is not Spinner)
                 {
                     AddHeader("From previous");
-                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection).ToLocalisableString(@"0.##x")} ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(precedingObject, firstInSelection).ToLocalisableString("N2")} ({(firstInSelection.StackedPosition - precedingObject.StackedEndPosition).Length:#,0.##}px)");
                 }
 
                 if (nextObject != null && nextObject is not Spinner)
                 {
                     AddHeader("To next");
-                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject).ToLocalisableString(@"0.##x")} ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
+                    AddValue($"{snapProvider.ReadCurrentDistanceSnap(lastInSelection, nextObject).ToLocalisableString("N2")} ({(nextObject.StackedPosition - lastInSelection.StackedEndPosition).Length:#,0.##}px)");
                 }
             }
         }


### PR DESCRIPTION
Adds the actual DS instead of just the raw pixel distance from/to previous and next hitobjects on the hitobject inspector. Works like stable does (accounts for the entire selection), since it's very useful for lower diff modding.
<img width="910" height="364" alt="image" src="https://github.com/user-attachments/assets/73fa5253-f425-4258-9f87-0f2e0f6f3cb8" />

I've looked for issues and discussions containing something related to it and found this [discussion](https://github.com/ppy/osu/discussions/36415) and [this](https://discord.com/channels/90072389919997952/1259818301517725707/1517134677633138718) discord internal discussion. 

Also i was a little bit confused if i was supposed to use the localisable numeric string or just format the number like how the pixel values were, ended up deciding to use the former to keep it consistent with how we are used to on stable (two decimal cases) and how the current value is displayed in the distance snap widget.

<img width="300" height="auto" alt="image" src="https://github.com/user-attachments/assets/3564a1b1-e17f-4a68-b824-23331b163689" />
