### PR TITLE
Add a `StartPos` mod

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModStartPos.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModStartPos.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+
+namespace osu.Game.Rulesets.Osu.Mods
+{
+    public class OsuModStartPos : ModStartPos
+    {
+        public override void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            base.ApplyToBeatmap(beatmap);
+
+            if (StartTime.Value <= 0)
+                return;
+
+            double offset = StartTime.Value * 1000 + FirstObjectTime;
+
+            if (beatmap is Beatmap<OsuHitObject> osuBeatmap)
+                osuBeatmap.HitObjects.RemoveAll(h => h.StartTime < offset);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -184,6 +184,7 @@ namespace osu.Game.Rulesets.Osu
                 case ModType.Conversion:
                     return new Mod[]
                     {
+                        new OsuModStartPos(),
                         new OsuModTargetPractice(),
                         new OsuModDifficultyAdjust(),
                         new OsuModClassic(),

--- a/osu.Game/Graphics/OsuIcon.cs
+++ b/osu.Game/Graphics/OsuIcon.cs
@@ -184,6 +184,7 @@ namespace osu.Game.Graphics
         public static IconUsage ModRelax => get(OsuIconMapping.ModRelax);
         public static IconUsage ModRepel => get(OsuIconMapping.ModRepel);
         public static IconUsage ModScoreV2 => get(OsuIconMapping.ModScoreV2);
+        public static IconUsage ModStartPos => get(OsuIconMapping.ModStartPos);
         public static IconUsage ModSevenKeys => get(OsuIconMapping.ModSevenKeys);
         public static IconUsage ModSimplifiedRhythm => get(OsuIconMapping.ModSimplifiedRhythm);
         public static IconUsage ModSingleTap => get(OsuIconMapping.ModSingleTap);
@@ -669,6 +670,9 @@ namespace osu.Game.Graphics
 
             [Description(@"Mods/mod-score-v2")]
             ModScoreV2,
+
+            [Description(@"Mods/mod-start-pos")]
+            ModStartPos,
 
             [Description(@"Mods/mod-seven-keys")]
             ModSevenKeys,

--- a/osu.Game/Rulesets/Mods/ModStartPos.cs
+++ b/osu.Game/Rulesets/Mods/ModStartPos.cs
@@ -1,0 +1,86 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Overlays.Settings;
+using osu.Game.Screens.Play;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public abstract partial class ModStartPos : Mod, IApplicableToBeatmap, IApplicableToPlayer
+    {
+        public override string Name => "Start Position";
+        public override string Acronym => "SP";
+        public override IconUsage? Icon => OsuIcon.ModStartPos;
+        public override ModType Type => ModType.Conversion;
+        public override LocalisableString Description => "Start from any point in the map.";
+        public override bool Ranked => UsesDefaultConfiguration;
+
+        [SettingSource("Start time", "The time from which to start the map.", SettingControlType = typeof(SettingsSlider<double, StartTimeSlider>))]
+        public BindableDouble StartTime { get; } = new BindableDouble(0)
+        {
+            MinValue = 0,
+            MaxValue = 300,
+            Precision = 1,
+        };
+
+        protected double FirstObjectTime { get; private set; }
+
+        public virtual void ApplyToBeatmap(IBeatmap beatmap)
+        {
+            if (beatmap.HitObjects.Count == 0)
+                return;
+
+            FirstObjectTime = beatmap.HitObjects.First().StartTime;
+            double lastObjectEnd = beatmap.GetLastObjectTime();
+            StartTime.MaxValue = Math.Ceiling((lastObjectEnd - FirstObjectTime) / 1000);
+        }
+
+        public void ApplyToPlayer(Player? player)
+        {
+            if (player == null || StartTime.Value <= 0)
+                return;
+
+            double seekTime = StartTime.Value * 1000 + FirstObjectTime;
+            player.OnGameplayStarted += () => player.Seek(seekTime);
+        }
+
+        public partial class StartTimeSlider : RoundedSliderBar<double>
+        {
+            [Resolved]
+            private IBindable<WorkingBeatmap> workingBeatmap { get; set; } = null!;
+
+            public StartTimeSlider()
+            {
+                KeyboardStep = 1;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                if (workingBeatmap.Value?.BeatmapInfo.Length > 0 && Current is BindableNumber<double> num)
+                    num.MaxValue = Math.Ceiling(workingBeatmap.Value.BeatmapInfo.Length / 1000);
+            }
+
+            public override LocalisableString TooltipText => FormatStartTime(Current.Value);
+
+            public static string FormatStartTime(double value)
+            {
+                int totalSeconds = (int)Math.Floor(value);
+                int minutes = totalSeconds / 60;
+                int seconds = totalSeconds % 60;
+                return $"{minutes:D2}:{seconds:D2}";
+            }
+        }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModStartPos.cs
+++ b/osu.Game/Rulesets/Mods/ModStartPos.cs
@@ -22,10 +22,10 @@ namespace osu.Game.Rulesets.Mods
         public override string Acronym => "SP";
         public override IconUsage? Icon => OsuIcon.ModStartPos;
         public override ModType Type => ModType.Conversion;
-        public override LocalisableString Description => "Start from any point in the map.";
+        public override LocalisableString Description => "Start from any point in the beatmap.";
         public override bool Ranked => UsesDefaultConfiguration;
 
-        [SettingSource("Start time", "The time from which to start the map.", SettingControlType = typeof(SettingsSlider<double, StartTimeSlider>))]
+        [SettingSource("Start time", "The time from which to start the beatmap.", SettingControlType = typeof(SettingsSlider<double, StartTimeSlider>))]
         public BindableDouble StartTime { get; } = new BindableDouble(0)
         {
             MinValue = 0,

--- a/osu.Game/Rulesets/Mods/ModStartPos.cs
+++ b/osu.Game/Rulesets/Mods/ModStartPos.cs
@@ -23,13 +23,12 @@ namespace osu.Game.Rulesets.Mods
         public override IconUsage? Icon => OsuIcon.ModStartPos;
         public override ModType Type => ModType.Conversion;
         public override LocalisableString Description => "Start from any point in the beatmap.";
-        public override bool Ranked => UsesDefaultConfiguration;
 
         [SettingSource("Start time", "The time from which to start the beatmap.", SettingControlType = typeof(SettingsSlider<double, StartTimeSlider>))]
         public BindableDouble StartTime { get; } = new BindableDouble(0)
         {
             MinValue = 0,
-            MaxValue = 300,
+            MaxValue = 1337,
             Precision = 1,
         };
 


### PR DESCRIPTION
Implementation for https://github.com/ppy/osu/discussions/13013

Often times than not, I wish I could start from any point in a beatmap, so I decided to make this mod. This is only a concept and I haven't made this for any other ruleset other than standard, and there is also no icon for it. Alternatives exist, but they are slow compared to simply using a mod. Hoping this won't get closed in the first 5 seconds as I am not exactly experienced, but I did my best to make this since other rythm games have that and I feel like this should exist here too.