### PR TITLE
Fix long stutter when restoring all hidden difficulties of a beatmap with a lot of difficulties

### DIFF
--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -278,7 +278,7 @@ namespace osu.Game.Beatmaps
         /// Restore a beatmap set.
         /// </summary>
         /// <param name="beatmapSetInfo">The beatmap set to restore.</param>
-        public void RestoreBeatmapSet(BeatmapSetInfo beatmapSetInfo)
+        public void Restore(BeatmapSetInfo beatmapSetInfo)
         {
             Realm.Run(r =>
             {

--- a/osu.Game/Beatmaps/BeatmapManager.cs
+++ b/osu.Game/Beatmaps/BeatmapManager.cs
@@ -274,6 +274,27 @@ namespace osu.Game.Beatmaps
             });
         }
 
+        /// <summary>
+        /// Restore a beatmap set.
+        /// </summary>
+        /// <param name="beatmapSetInfo">The beatmap set to restore.</param>
+        public void RestoreBeatmapSet(BeatmapSetInfo beatmapSetInfo)
+        {
+            Realm.Run(r =>
+            {
+                using (var transaction = r.BeginWrite())
+                {
+                    if (!beatmapSetInfo.IsManaged)
+                        beatmapSetInfo = r.Find<BeatmapSetInfo>(beatmapSetInfo.ID)!;
+
+                    foreach (var beatmapInfo in beatmapSetInfo.Beatmaps.Where(b => b.Hidden))
+                        beatmapInfo.Hidden = false;
+
+                    transaction.Commit();
+                }
+            });
+        }
+
         public void RestoreAll()
         {
             Realm.Run(r =>

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1251,11 +1251,7 @@ namespace osu.Game.Screens.Select
 
         public void Delete(BeatmapSetInfo beatmapSet) => dialogOverlay?.Push(new BeatmapDeleteDialog(beatmapSet));
 
-        public void RestoreAllHidden(BeatmapSetInfo beatmapSet)
-        {
-            foreach (var b in beatmapSet.Beatmaps)
-                beatmaps.Restore(b);
-        }
+        public void RestoreAllHidden(BeatmapSetInfo beatmapSet) => beatmaps.RestoreBeatmapSet(beatmapSet);
 
         private GroupedBeatmap? beforeScopedSelection;
 

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1251,7 +1251,7 @@ namespace osu.Game.Screens.Select
 
         public void Delete(BeatmapSetInfo beatmapSet) => dialogOverlay?.Push(new BeatmapDeleteDialog(beatmapSet));
 
-        public void RestoreAllHidden(BeatmapSetInfo beatmapSet) => beatmaps.RestoreBeatmapSet(beatmapSet);
+        public void RestoreAllHidden(BeatmapSetInfo beatmapSet) => beatmaps.Restore(beatmapSet);
 
         private GroupedBeatmap? beforeScopedSelection;
 


### PR DESCRIPTION
Tested with https://osu.ppy.sh/beatmapsets/942714#osu/1991349.

Before:

https://github.com/user-attachments/assets/ef6419e8-c2d9-40d0-b9d6-16bded6ea784

After:

https://github.com/user-attachments/assets/623e2aed-ae96-4d4d-9ab7-aca94063177c

