### PR TITLE
Fix storyboard samples not playing when beatmap hitsounds disabled

### DIFF
--- a/osu.Game.Tests/Skins/TestSceneBeatmapSkinLookupDisables.cs
+++ b/osu.Game.Tests/Skins/TestSceneBeatmapSkinLookupDisables.cs
@@ -15,6 +15,7 @@ using osu.Framework.Testing;
 using osu.Game.Audio;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Skinning;
+using osu.Game.Storyboards;
 using osu.Game.Tests.Beatmaps;
 using osu.Game.Tests.Visual;
 
@@ -59,6 +60,27 @@ namespace osu.Game.Tests.Skins
             AddAssert("Check lookup is from correct source", () => requester.FindProvider(s => s.GetDrawableComponent(new TestSkinComponentLookup()) != null) == expected());
         }
 
+        [Test]
+        public void TestHitsoundLookupEnabled()
+        {
+            AddStep("Set beatmap hitsounds to enabled", () => beatmapSkinProvider.BeatmapHitsounds.Value = true);
+            AddAssert("Check hitsound lookup succeeds", () => beatmapSkinProvider.GetSample(new HitSampleInfo("test")), () => Is.Not.Null);
+        }
+
+        [Test]
+        public void TestHitsoundLookupDisabled()
+        {
+            AddStep("Set beatmap hitsounds to disables", () => beatmapSkinProvider.BeatmapHitsounds.Value = false);
+            AddAssert("Check hitsound lookup fails", () => beatmapSkinProvider.GetSample(new HitSampleInfo("test")), () => Is.Null);
+        }
+
+        [Test]
+        public void TestStoryboardSoundLookupBypassesHitsoundDisable()
+        {
+            AddStep("Set beatmap hitsounds to disables", () => beatmapSkinProvider.BeatmapHitsounds.Value = false);
+            AddAssert("Check storyboard sound lookup succeeds", () => beatmapSkinProvider.GetSample(new StoryboardSampleInfo(StoryboardElementSource.Beatmap, "test", 0, 1)), () => Is.Not.Null);
+        }
+
         public class UserSkinSource : LegacySkin
         {
             public UserSkinSource()
@@ -70,6 +92,8 @@ namespace osu.Game.Tests.Skins
             {
                 return new Container { Name = "user" };
             }
+
+            public override ISample GetSample(ISampleInfo sampleInfo) => null;
         }
 
         public class BeatmapSkinSource : LegacyBeatmapSkin
@@ -83,6 +107,8 @@ namespace osu.Game.Tests.Skins
             {
                 return new Container { Name = "beatmap" };
             }
+
+            public override ISample GetSample(ISampleInfo sampleInfo) => new SampleVirtual();
         }
 
         public partial class SkinRequester : Drawable, ISkin

--- a/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
+++ b/osu.Game/Skinning/BeatmapSkinProvidingContainer.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Audio;
+using osu.Game.Storyboards;
 
 namespace osu.Game.Skinning
 {
@@ -24,7 +25,7 @@ namespace osu.Game.Skinning
 
         protected override bool AllowTextureLookup(string componentName) => BeatmapSkins.Value;
 
-        protected override bool AllowSampleLookup(ISampleInfo sampleInfo) => BeatmapHitsounds.Value;
+        protected override bool AllowSampleLookup(ISampleInfo sampleInfo) => sampleInfo is StoryboardSampleInfo || BeatmapHitsounds.Value;
 
         private readonly ISkin skin;
         private readonly ISkin? classicFallback;


### PR DESCRIPTION
Restores the check for storyboard samples that was accidentally dropped in 0457cb9.

As originally intended in dc21c89, storyboard samples should always play regardless of whether beatmap hitsounds are enabled. Without this check, turning off beatmap hitsounds in settings would also prevent storyboard samples from playing during gameplay.