### PR TITLE
Adjust design of popup dialog buttons (including pause / fail menu)

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneGameplayMenuOverlay.cs
@@ -7,6 +7,8 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Screens.Play;
@@ -28,7 +30,10 @@ namespace osu.Game.Tests.Visual.Gameplay
         [BackgroundDependencyLoader]
         private void load(OsuGameBase game)
         {
-            Child = globalActionContainer = new GlobalActionContainer(game);
+            Children = new Drawable[]
+            {
+                globalActionContainer = new GlobalActionContainer(game)
+            };
         }
 
         [SetUp]
@@ -58,6 +63,19 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             InputManager.MoveMouseTo(Vector2.Zero);
         });
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("random background", () =>
+                ChangeBackgroundColour(new Colour4(RNG.NextSingle(), RNG.NextSingle(), RNG.NextSingle(), 1)));
+        }
+
+        [Test]
+        public void TestBasic()
+        {
+            showOverlay();
+        }
 
         [Test]
         public void TestAdjustRetryCount()

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Graphics.UserInterface
         private const float idle_width = 0.8f;
         private const float hover_width = 0.9f;
 
-        private const float hover_duration = 300;
+        private const float hover_duration = 400;
         private const float click_duration = 200;
 
         public event Action<SelectionState>? StateChanged;
@@ -67,6 +67,7 @@ namespace osu.Game.Graphics.UserInterface
                 {
                     RelativeSizeAxes = Axes.Both,
                     Width = 1f,
+                    Alpha = 0,
                     Children = new Drawable[]
                     {
                         background = new Box
@@ -78,8 +79,11 @@ namespace osu.Game.Graphics.UserInterface
                 },
                 glowContainer = new Container
                 {
+                    Origin = Anchor.Centre,
+                    Anchor = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    Width = 1f,
+                    Shear = OsuGame.SHEAR,
+                    Width = idle_width,
                     Alpha = 0f,
                     Children = new Drawable[]
                     {
@@ -116,17 +120,17 @@ namespace osu.Game.Graphics.UserInterface
                     {
                         ColourContainer = new Container
                         {
+                            CornerRadius = 5,
                             RelativeSizeAxes = Axes.Both,
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                             Width = idle_width,
                             Masking = true,
-                            MaskingSmoothness = 2,
                             EdgeEffect = new EdgeEffectParameters
                             {
                                 Type = EdgeEffectType.Shadow,
-                                Colour = Color4.Black.Opacity(0.2f),
-                                Radius = 5,
+                                Colour = Color4.Black.Opacity(0.05f),
+                                Radius = 6,
                             },
                             Colour = ButtonColour,
                             Shear = OsuGame.SHEAR,
@@ -144,11 +148,12 @@ namespace osu.Game.Graphics.UserInterface
                                     MaskingSmoothness = 0,
                                     Children = new[]
                                     {
-                                        new Triangles
+                                        new TrianglesV2
                                         {
                                             RelativeSizeAxes = Axes.Both,
-                                            TriangleScale = 4,
-                                            ColourDark = OsuColour.Gray(0.88f),
+                                            Alpha = 0.1f,
+                                            Velocity = 0.7f,
+                                            Blending = BlendingParameters.Additive,
                                             Shear = -OsuGame.SHEAR,
                                             ClampAxes = Axes.Y
                                         },
@@ -281,13 +286,18 @@ namespace osu.Game.Graphics.UserInterface
             if (newState == SelectionState.Selected)
             {
                 spriteText.TransformSpacingTo(hoverSpacing, hover_duration, Easing.OutQuint);
+                spriteText.ScaleTo(1.02f, hover_duration, Easing.OutQuint);
                 ColourContainer.ResizeWidthTo(hover_width, hover_duration, Easing.OutQuint);
+                glowContainer.ResizeWidthTo(hover_width * 1.08f, hover_duration, Easing.OutQuint);
                 glowContainer.FadeIn(hover_duration, Easing.OutQuint);
             }
             else
             {
                 ColourContainer.ResizeWidthTo(idle_width, hover_duration / 2, Easing.OutQuint);
+                glowContainer.ResizeWidthTo(idle_width * 1.08f, hover_duration, Easing.OutQuint);
+
                 spriteText.TransformSpacingTo(Vector2.Zero, hover_duration / 2, Easing.OutQuint);
+                spriteText.ScaleTo(1, hover_duration / 2, Easing.OutQuint);
                 glowContainer.FadeOut(hover_duration / 2, Easing.OutQuint);
             }
         }

--- a/osu.Game/Graphics/UserInterface/DialogButton.cs
+++ b/osu.Game/Graphics/UserInterface/DialogButton.cs
@@ -47,12 +47,10 @@ namespace osu.Game.Graphics.UserInterface
 
         protected readonly Container ColourContainer;
 
-        private readonly Container backgroundContainer;
         private readonly Container glowContainer;
         private readonly Box leftGlow;
         private readonly Box centerGlow;
         private readonly Box rightGlow;
-        private readonly Box background;
         private readonly SpriteText spriteText;
         private Vector2 hoverSpacing => new Vector2(1.4f, 0f);
 
@@ -63,20 +61,6 @@ namespace osu.Game.Graphics.UserInterface
 
             Children = new Drawable[]
             {
-                backgroundContainer = new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Width = 1f,
-                    Alpha = 0,
-                    Children = new Drawable[]
-                    {
-                        background = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = backgroundColour,
-                        },
-                    },
-                },
                 glowContainer = new Container
                 {
                     Origin = Anchor.Centre,
@@ -193,18 +177,6 @@ namespace osu.Game.Graphics.UserInterface
             }
         }
 
-        private Color4 backgroundColour = OsuColour.Gray(34);
-
-        public Color4 BackgroundColour
-        {
-            get => backgroundColour;
-            set
-            {
-                backgroundColour = value;
-                background.Colour = value;
-            }
-        }
-
         private LocalisableString text;
 
         public LocalisableString Text
@@ -222,8 +194,6 @@ namespace osu.Game.Graphics.UserInterface
             get => spriteText.Font.Size;
             set => spriteText.Font = spriteText.Font.With(size: value);
         }
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => backgroundContainer.ReceivePositionalInputAt(screenSpacePos);
 
         private bool clickAnimating;
 

--- a/osu.Game/Overlays/Dialog/PopupDialog.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialog.cs
@@ -169,7 +169,7 @@ namespace osu.Game.Overlays.Dialog
                             AutoSizeAxes = Axes.Y,
                             Direction = FillDirection.Vertical,
                             Spacing = new Vector2(0f, 10f),
-                            Padding = new MarginPadding { Vertical = 60 },
+                            Padding = new MarginPadding { Top = 60, Bottom = 30 },
                             Children = new Drawable[]
                             {
                                 new Container
@@ -237,6 +237,7 @@ namespace osu.Game.Overlays.Dialog
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
                                     Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(5),
                                     Padding = new MarginPadding { Top = 30 },
                                 },
                             },

--- a/osu.Game/Overlays/Dialog/PopupDialogButton.cs
+++ b/osu.Game/Overlays/Dialog/PopupDialogButton.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Game.Graphics.UserInterface;
 
 namespace osu.Game.Overlays.Dialog
@@ -12,7 +11,6 @@ namespace osu.Game.Overlays.Dialog
             : base(sampleSet)
         {
             Height = 50;
-            BackgroundColour = Color4Extensions.FromHex(@"150e14");
             TextSize = 18;
         }
     }

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -36,7 +36,7 @@ namespace osu.Game.Screens.Play
     {
         protected const int TRANSITION_DURATION = 200;
 
-        private const int button_height = 70;
+        private const int button_height = 80;
         private const float background_alpha = 0.75f;
 
         protected override bool BlockScrollInput => false;
@@ -119,8 +119,10 @@ namespace osu.Game.Screens.Play
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
                             RelativeSizeAxes = Axes.X,
+                            Width = 0.8f,
                             AutoSizeAxes = Axes.Y,
                             Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(2),
                             Masking = true,
                             EdgeEffect = new EdgeEffectParameters
                             {

--- a/osu.Game/Screens/Play/GameplayMenuOverlay.cs
+++ b/osu.Game/Screens/Play/GameplayMenuOverlay.cs
@@ -7,10 +7,8 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -23,12 +21,12 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
-using osuTK;
-using osuTK.Graphics;
 using osu.Game.Localisation;
 using osu.Game.Resources.Localisation.Web;
 using osu.Game.Skinning;
 using osu.Game.Utils;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Play
 {
@@ -101,7 +99,7 @@ namespace osu.Game.Screens.Play
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 50),
+                    Spacing = new Vector2(0, 100),
                     Origin = Anchor.Centre,
                     Anchor = Anchor.Centre,
                     Children = new Drawable[]
@@ -109,7 +107,8 @@ namespace osu.Game.Screens.Play
                         new OsuSpriteText
                         {
                             Text = Header,
-                            Font = OsuFont.GetFont(size: 48),
+                            Font = OsuFont.GetFont(typeface: Typeface.TorusAlternate, size: 48, weight: FontWeight.SemiBold),
+                            Spacing = new Vector2(5),
                             Origin = Anchor.TopCentre,
                             Anchor = Anchor.TopCentre,
                             Colour = colours.Yellow,
@@ -124,12 +123,6 @@ namespace osu.Game.Screens.Play
                             Direction = FillDirection.Vertical,
                             Spacing = new Vector2(2),
                             Masking = true,
-                            EdgeEffect = new EdgeEffectParameters
-                            {
-                                Type = EdgeEffectType.Shadow,
-                                Colour = Color4.Black.Opacity(0.6f),
-                                Radius = 50
-                            },
                         },
                         playInfoText = new OsuTextFlowContainer(cp => cp.Font = OsuFont.GetFont(size: 18))
                         {


### PR DESCRIPTION
Just some minor changes to bring things closer in line with to the latest design language.

| Before | After |
| :---: | :---: |
| <img width="1784" height="1420" alt="2026-07-21 01 45 21@2x" src="https://github.com/user-attachments/assets/8a61cab4-e655-4825-9712-8d21351f184d" /> | <img width="1784" height="1420" alt="2026-07-21 01 44 45@2x" src="https://github.com/user-attachments/assets/4db134a3-3aa4-4cbc-9223-39a7b8594be5" /> |

