### PR TITLE
Add Hit Animations Toggle To Osu!Standard

### DIFF
--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
             base.InitialiseDefaults();
             SetDefault(OsuRulesetSetting.SnakingInSliders, true);
             SetDefault(OsuRulesetSetting.SnakingOutSliders, true);
+            SetDefault(OsuRulesetSetting.HitAnimations, true);
             SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
             SetDefault(OsuRulesetSetting.ShowCursorRipples, false);
             SetDefault(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
@@ -35,6 +36,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
     {
         SnakingInSliders,
         SnakingOutSliders,
+        HitAnimations,
         ShowCursorTrail,
         ShowCursorRipples,
         PlayfieldBorderStyle,

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -170,11 +170,6 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 switch (state)
                 {
                     case ArmedState.Hit:
-                        if (!hitAnimations.Value)
-                        {
-                            Hide();
-                            break;
-                        }
 
                         // Fade out time is at a maximum of 800. Must match `DrawableHitCircle`'s arbitrary lifetime spec.
                         const double fade_out_time = 800;
@@ -182,6 +177,35 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                         const double resize_duration = 400;
 
                         const float shrink_size = 0.8f;
+
+                        if (!hitAnimations.Value)
+                        {
+                            const double fade_out_no_anim = 50;
+
+                            flash.HitLighting = configHitLighting.Value;
+
+                            if (configHitLighting.Value)
+                            {
+                                flash.FadeTo(1, fade_out_no_anim, Easing.OutQuint);
+                            }
+                            else
+                            {
+                                flash.FadeTo(1, fade_out_no_anim, Easing.OutQuint)
+                                     .Then()
+                                     .FadeOut(fade_out_no_anim, Easing.OutQuint);
+                            }
+
+                            // To keep hit lighting on Argon we must fade the components before the main object.
+                            number.FadeOut(fade_out_no_anim);
+                            border.FadeOut(fade_out_no_anim);
+                            innerFill.FadeOut(fade_out_no_anim);
+                            outerFill.FadeOut(fade_out_no_anim);
+                            innerGradient.FadeOut(fade_out_no_anim);
+                            outerGradient.FadeOut(fade_out_no_anim);
+
+                            this.FadeOut(fade_out_time);
+                            break;
+                        }
 
                         // Animating with the number present is distracting.
                         // The number disappearing is hidden by the bright flash.

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -14,6 +14,7 @@ using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Skinning.Default;
@@ -52,6 +53,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
 
         [Resolved]
         private DrawableHitObject drawableObject { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private OsuRulesetConfigManager? rulesetConfig { get; set; }
+
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
 
         public ArgonMainCirclePiece(bool withOuterFill)
         {
@@ -121,6 +127,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
 
             configHitLighting = config.GetBindable<bool>(OsuSetting.HitLighting);
+
+            rulesetConfig?.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
         }
 
         protected override void LoadComplete()
@@ -162,6 +170,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                 switch (state)
                 {
                     case ArmedState.Hit:
+                        if (!hitAnimations.Value)
+                        {
+                            this.FadeOut(100);
+                            break;
+                        }
+
                         // Fade out time is at a maximum of 800. Must match `DrawableHitCircle`'s arbitrary lifetime spec.
                         const double fade_out_time = 800;
                         const double flash_in_duration = 150;

--- a/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Argon/ArgonMainCirclePiece.cs
@@ -172,7 +172,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Argon
                     case ArmedState.Hit:
                         if (!hitAnimations.Value)
                         {
-                            this.FadeOut(100);
+                            Hide();
                             break;
                         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -90,12 +90,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 switch (state)
                 {
                     case ArmedState.Hit:
-                        if (!hitAnimations.Value)
-                        {
-                            Hide();
-                            break;
-                        }
-
+                        const double fade_out_time = 800;
                         const double flash_in = 40;
                         const double flash_out = 100;
 
@@ -104,6 +99,20 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                              .FadeOut(flash_out);
 
                         explode.FadeIn(flash_in);
+
+                        if (!hitAnimations.Value)
+                        {
+                            const double fade_out_no_anim = 50;
+
+                            // To keep hit lighting we must fade the components before the main object.
+                            ring.FadeOut(fade_out_no_anim);
+                            circle.FadeOut(fade_out_no_anim);
+                            number.FadeOut(fade_out_no_anim);
+
+                            this.FadeOut(fade_out_time);
+                            break;
+                        }
+
                         this.ScaleTo(1.5f, 400, Easing.OutQuad);
 
                         using (BeginDelayedSequence(flash_in))
@@ -113,7 +122,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                             circle.FadeOut();
                             number.FadeOut();
 
-                            this.FadeOut(800);
+                            this.FadeOut(fade_out_time);
                         }
 
                         break;

--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osuTK.Graphics;
@@ -46,6 +47,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
         [Resolved]
         private DrawableHitObject drawableObject { get; set; } = null!;
 
+        [Resolved(canBeNull: true)]
+        private OsuRulesetConfigManager? rulesetConfig { get; set; }
+
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -53,6 +59,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
 
             accentColour.BindTo(drawableObject.AccentColour);
             indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
+
+            rulesetConfig?.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
         }
 
         protected override void LoadComplete()
@@ -82,6 +90,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                 switch (state)
                 {
                     case ArmedState.Hit:
+                        if (!hitAnimations.Value)
+                        {
+                            this.FadeOut(100);
+                            break;
+                        }
+
                         const double flash_in = 40;
                         const double flash_out = 100;
 

--- a/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Default/MainCirclePiece.cs
@@ -92,7 +92,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Default
                     case ArmedState.Hit:
                         if (!hitAnimations.Value)
                         {
-                            this.FadeOut(100);
+                            Hide();
                             break;
                         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -176,7 +176,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     case ArmedState.Hit:
                         if (!hitAnimations.Value)
                         {
-                            this.FadeOut(100);
+                            Hide();
                             break;
                         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -168,6 +168,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
         private void updateStateTransforms(DrawableHitObject drawableHitObject, ArmedState state)
         {
             const double legacy_fade_duration = 240;
+            const double fade_out_no_anim = 50;
 
             using (BeginAbsoluteSequence(drawableObject.AsNonNull().HitStateUpdateTime))
             {
@@ -176,7 +177,7 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                     case ArmedState.Hit:
                         if (!hitAnimations.Value)
                         {
-                            Hide();
+                            this.FadeOut(fade_out_no_anim);
                             break;
                         }
 

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
@@ -45,6 +46,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
+
+        [Resolved(canBeNull: true)]
+        private OsuRulesetConfigManager? rulesetConfig { get; set; }
+
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
 
         public LegacyMainCirclePiece(string? priorityLookupPrefix = null, bool hasNumber = true)
         {
@@ -126,6 +132,8 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 accentColour.BindTo(drawableOsuObject.AccentColour);
                 indexInCurrentCombo.BindTo(drawableOsuObject.IndexInCurrentComboBindable);
             }
+
+            rulesetConfig?.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
         }
 
         protected override void LoadComplete()
@@ -166,6 +174,12 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                 switch (state)
                 {
                     case ArmedState.Hit:
+                        if (!hitAnimations.Value)
+                        {
+                            this.FadeOut(100);
+                            break;
+                        }
+
                         CircleSprite.FadeOut(legacy_fade_duration);
                         CircleSprite.ScaleTo(1.4f, legacy_fade_duration, Easing.Out);
 

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -44,6 +44,11 @@ namespace osu.Game.Rulesets.Osu.UI
                 },
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = RulesetSettingsStrings.HitAnimations,
+                    Current = config.GetBindable<bool>(OsuRulesetSetting.HitAnimations)
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = RulesetSettingsStrings.CursorTrail,
                     Current = config.GetBindable<bool>(OsuRulesetSetting.ShowCursorTrail)
                 }),

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -25,6 +25,11 @@ namespace osu.Game.Localisation
         public static LocalisableString SnakingOutSliders => new TranslatableString(getKey(@"snaking_out_sliders"), @"Snaking out sliders");
 
         /// <summary>
+        /// "Hit animations"
+        /// </summary>
+        public static LocalisableString HitAnimations => new TranslatableString(getKey(@"hit_animations"), @"Hit animations");
+
+        /// <summary>
         /// "Cursor trail"
         /// </summary>
         public static LocalisableString CursorTrail => new TranslatableString(getKey(@"cursor_trail"), @"Cursor trail");


### PR DESCRIPTION

https://github.com/user-attachments/assets/3bcbbb6f-add2-45c3-98c1-cbb22d3a440e

Simple toggle that replaces hit animations on Argon, legacy, and normal skins with a 100ms fadeout.

Differences from last hit animation PRs:
- Now located inside the Osu! ruleset options instead of Gameplay options.
- Applies equally to all skin types, rather than just legacy.

Why this should be considered:
- I and many others feel like we should be able to toggle hit animations on Standard for easier readability.
- Overlapping notes on lower AR values become difficult to read due to longer hit animations, often times obstructing the visible number underneath with the scaling fade-out, causing a misread.
- Taiko getting a hit animation "toggle" gives way for this discussion to be opened back up in my opinion.
- I understand from a design perspective why this wouldn't want to be implemented, like how "It looks bad", but I think there are plenty of examples of players in any competitive game sacrificing fidelity and quality for better readability.
- Players have already been playing without hit animations for years using glitchy "insta-fade" skins, this would make it so it's no longer gate-kept behind specific skin hacks.