### PR TITLE
Fix multiplayer spectator clock drift causing stutters when rate-adjust mods are active

### DIFF
--- a/osu.Game.Tests/OnlinePlay/SpectatorPlayerClockTest.cs
+++ b/osu.Game.Tests/OnlinePlay/SpectatorPlayerClockTest.cs
@@ -1,0 +1,83 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Tests.OnlinePlay
+{
+    [HeadlessTest]
+    public partial class SpectatorPlayerClockTest : OsuTestScene
+    {
+        private ManualClock masterSource = null!;
+        private FramedClock master = null!;
+        private SpectatorPlayerClock clock = null!;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            master = new FramedClock(masterSource = new ManualClock { IsRunning = true });
+            clock = new SpectatorPlayerClock(master) { IsRunning = true };
+        });
+
+        [Test]
+        public void TestRateIncludesMasterRate()
+        {
+            setMasterRate(1.5);
+            assertRate(1.5);
+
+            setCatchingUp(true);
+            assertRate(1.5 * SpectatorPlayerClock.CATCHUP_RATE);
+        }
+
+        [Test]
+        public void TestProcessFrameDoesNotReapplyMasterRate()
+        {
+            // master clock elapsed time already accounts for rate-adjust, so ProcessFrame must not scale elapsed time
+            // by the master rate a second time
+            setMasterRate(1.5);
+            setMasterElapsed(20);
+
+            processFrame();
+
+            assertCurrentTime(20);
+        }
+
+        [Test]
+        public void TestProcessFrameAppliesCatchUpButNotMasterRate()
+        {
+            setMasterRate(1.5);
+            setMasterElapsed(20);
+            setCatchingUp(true);
+
+            processFrame();
+
+            assertCurrentTime(20 * SpectatorPlayerClock.CATCHUP_RATE);
+        }
+
+        private void setMasterRate(double rate)
+            => AddStep($"set master rate = {rate}", () => masterSource.Rate = rate);
+
+        private void setMasterElapsed(double elapsed)
+            => AddStep($"set master elapsed = {elapsed}", () =>
+            {
+                masterSource.CurrentTime += elapsed;
+                master.ProcessFrame();
+            });
+
+        private void setCatchingUp(bool catchingUp)
+            => AddStep($"set catching up = {catchingUp}", () => clock.IsCatchingUp = catchingUp);
+
+        private void processFrame()
+            => AddStep("ProcessFrame", () => clock.ProcessFrame());
+
+        private void assertRate(double expected)
+            => AddAssert($"rate is {expected}", () => clock.Rate, () => Is.EqualTo(expected));
+
+        private void assertCurrentTime(double expected)
+            => AddAssert($"current time is {expected}", () => clock.CurrentTime, () => Is.EqualTo(expected));
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
@@ -69,9 +69,11 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
         }
 
+        private double catchUpMultiplier => IsCatchingUp ? catchup_rate : 1;
+
         public double Rate
         {
-            get => IsCatchingUp ? catchup_rate : 1;
+            get => masterClock.Rate * catchUpMultiplier;
             set => throw new NotImplementedException();
         }
 
@@ -84,7 +86,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
                 // To avoid this, use a constant 16ms elapsed time for now. Probably not too correct, but this whole logic isn't too correct anyway.
                 // Clamping is required to ensure that player clocks don't get too far ahead if ProcessFrame is run multiple times.
                 double elapsedSource = masterClock.ElapsedFrameTime != 0 ? masterClock.ElapsedFrameTime : Math.Clamp(masterClock.CurrentTime - CurrentTime, 0, 16);
-                double elapsed = elapsedSource * Rate;
+                double elapsed = elapsedSource * catchUpMultiplier;
 
                 CurrentTime += elapsed;
                 ElapsedFrameTime = elapsed;

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Logging;
 using osu.Framework.Timing;
-using osu.Game.Screens.Play;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 {
@@ -16,9 +15,9 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// <summary>
         /// The catch up rate.
         /// </summary>
-        private const double catchup_rate = 2;
+        public const double CATCHUP_RATE = 2;
 
-        private readonly GameplayClockContainer masterClock;
+        private readonly IFrameBasedClock masterClock;
 
         public double CurrentTime { get; private set; }
 
@@ -41,7 +40,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public bool IsRunning { get; set; }
 
-        public SpectatorPlayerClock(GameplayClockContainer masterClock)
+        public SpectatorPlayerClock(IFrameBasedClock masterClock)
         {
             this.masterClock = masterClock;
         }
@@ -69,7 +68,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         {
         }
 
-        private double catchUpMultiplier => IsCatchingUp ? catchup_rate : 1;
+        private double catchUpMultiplier => IsCatchingUp ? CATCHUP_RATE : 1;
 
         public double Rate
         {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
@@ -82,8 +82,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
             {
                 // When in catch-up mode, the source is usually not running.
                 // In such a case, its elapsed time may be zero, which would cause catch-up to get stuck.
-                // To avoid this, use a constant 16ms elapsed time for now. Probably not too correct, but this whole logic isn't too correct anyway.
-                // Clamping is required to ensure that player clocks don't get too far ahead if ProcessFrame is run multiple times.
+                // To avoid this, calculate the "elapsed" time manually based on the difference with the master clock.
                 double elapsedSource = masterClock.ElapsedFrameTime != 0 ? masterClock.ElapsedFrameTime : Math.Clamp(masterClock.CurrentTime - CurrentTime, 0, 16);
                 double elapsed = elapsedSource * catchUpMultiplier;
 


### PR DESCRIPTION
Rate-adjust mods cause multiplayer spectating to stutter: hit objects, approach circles, and cursor advance unevenly (especially visible with slider balls).

With rate-adjust, `SpectatorPlayerClock` and `InterpolatingFramedClock` drift out of sync and snap back in sync once the drift exceeds `InterpolatingFramedClock.AllowableErrorMilliseconds`.

0.2x playback speed:
| master (b11b274d) | <video src="https://github.com/user-attachments/assets/fc67035d-7af6-412c-b82f-a4a94549b996"/> |
| - | - |
| PR | <video src="https://github.com/user-attachments/assets/c6376dc1-7cba-415c-b62c-371ad5f57e3b" /> | 

