### PR TITLE
Implement crude memory caching of localised strings

### DIFF
--- a/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
+++ b/osu.Game/Localisation/ResourceManagerLocalisationStore.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -17,6 +15,7 @@ namespace osu.Game.Localisation
 {
     public class ResourceManagerLocalisationStore : ILocalisationStore
     {
+        private readonly Dictionary<string, string?> lookupCache = new Dictionary<string, string?>();
         private readonly Dictionary<string, ResourceManager> resourceManagers = new Dictionary<string, ResourceManager>();
 
         public ResourceManagerLocalisationStore(string cultureCode)
@@ -28,7 +27,28 @@ namespace osu.Game.Localisation
         {
         }
 
-        public string Get(string lookup)
+        public string? Get(string lookup)
+        {
+            lock (lookupCache)
+            {
+                if (lookupCache.TryGetValue(lookup, out string? cached))
+                    return cached;
+            }
+
+            string? result = getInternal(lookup);
+
+            lock (lookupCache)
+            {
+                // It's important to cache both lookup successes and failures here.
+                // The strings cannot really change under the game, so there's no risk of having a lookup fail now but succeed at some point later,
+                // and lookup failures are *more* costly than successes as they incur a scan of *all* strings in resources.
+                lookupCache[lookup] = result;
+            }
+
+            return result;
+        }
+
+        private string? getInternal(string lookup)
         {
             string[] split = lookup.Split(':');
 
@@ -83,7 +103,7 @@ namespace osu.Game.Localisation
             }
         }
 
-        public Task<string> GetAsync(string lookup, CancellationToken cancellationToken = default)
+        public Task<string?> GetAsync(string lookup, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(Get(lookup));
         }


### PR DESCRIPTION
RFC. This is coming from https://github.com/ppy/osu/issues/38351.

Of note, the reported issue is only reproducible with non-English language active.

The reason why "localisation is taking a long time to load" is that *the localisation is not there yet*. The localisation store attempts to scrape out the string from `ResourceManager`, which needs to walk all resource files to find the resource, and it can only return the `null` if every single lookup fails - and currently, for those particular strings, it does.

<img width="1056" height="409" alt="Screenshot 2026-07-21 at 10 46 53" src="https://github.com/user-attachments/assets/25223662-63dc-41bb-b2f8-7a1067d646d7" />

This is going to only get worse in time as we are overloaded with requests to merge localisation changes so I am proposing this naive caching scheme in earnest.

Of particular note, this still doesn't eliminate the spikes of update thread on filters in the key binding panel - those are still there due to copious (over)use of `ReadableKeyCombinationProvider` / `EnumExtensions.GetValuesInOrder()` underneath. But at least this is a return to baseline.

<img width="1058" height="451" alt="Screenshot 2026-07-21 at 10 47 14" src="https://github.com/user-attachments/assets/83bb5ad8-8998-4552-a4d1-3ef44b3287fe" />

When it comes to cache eviction, in very crude testing with Russian language (opening a bunch of screens to preload a bunch of strings) I got the manager instance to occupy ~170kB which is in the "probably fine to not worry about it" territory.

<img width="1858" height="230" alt="Screenshot 2026-07-21 at 10 46 18" src="https://github.com/user-attachments/assets/de572f91-d055-466c-ab7d-55dcae118ac0" />
