### PR TITLE
Add ability to adjust mods during replay

### DIFF
--- a/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModHidden.cs
@@ -18,7 +18,7 @@ using osu.Game.Rulesets.Osu.Skinning;
 
 namespace osu.Game.Rulesets.Osu.Mods
 {
-    public class OsuModHidden : ModHidden, IHidesApproachCircles
+    public class OsuModHidden : ModHidden, IHidesApproachCircles, IAdjustableWhenReplay
     {
         [SettingSource("Only fade approach circles", "The main object body will not fade when enabled.")]
         public Bindable<bool> OnlyFadeApproachCircles { get; } = new BindableBool();
@@ -29,6 +29,8 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         public const double FADE_IN_DURATION_MULTIPLIER = 0.4;
         public const double FADE_OUT_DURATION_MULTIPLIER = 0.3;
+
+        public BindableBool IsDisabled { get; } = new BindableBool();
 
         protected override bool IsFirstAdjustableObject(HitObject hitObject) => !(hitObject is Spinner || hitObject is SpinnerTick);
 
@@ -62,6 +64,9 @@ namespace osu.Game.Rulesets.Osu.Mods
 
         private void applyHiddenState(DrawableHitObject drawableObject, bool increaseVisibility)
         {
+            if (IsDisabled.Value)
+                return;
+
             if (!(drawableObject is DrawableOsuHitObject drawableOsuObject))
                 return;
 

--- a/osu.Game.Tests/Visual/Mods/TestSceneModDisable.cs
+++ b/osu.Game.Tests/Visual/Mods/TestSceneModDisable.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.UI;
+
+namespace osu.Game.Tests.Visual.Mods
+{
+    public partial class TestSceneModDisable : ModTestScene
+    {
+        protected override Ruleset CreatePlayerRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestDisableAvailableInReplay()
+        {
+            CreateModTest(new ModTestData
+            {
+                Autoplay = true,
+                Mod = new OsuModFlashlight(),
+                PassCondition = () => getMod<OsuModFlashlight>().IsDisabled.Value,
+            });
+
+            clickMod<OsuModFlashlight>();
+        }
+
+        [Test]
+        public void TestDisableAvailableNotInReplay()
+        {
+            CreateModTest(new ModTestData
+            {
+                Autoplay = false,
+                Mod = new OsuModFlashlight(),
+                PassCondition = () => !getMod<OsuModFlashlight>().IsDisabled.Value,
+            });
+
+            clickMod<OsuModFlashlight>();
+        }
+
+        private void clickMod<T>()
+            where T : IAdjustableWhenReplay
+        {
+            AddStep("click mod", () => Player.ChildrenOfType<ModIcon>().Single(icon => icon.Mod is T).TriggerClick());
+        }
+
+        private T getMod<T>()
+            where T : IAdjustableWhenReplay
+            => (T)Player.ChildrenOfType<ModIcon>().Single(icon => icon.Mod is T).Mod;
+    }
+}

--- a/osu.Game/Rulesets/Mods/IAdjustableWhenReplay.cs
+++ b/osu.Game/Rulesets/Mods/IAdjustableWhenReplay.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Game.Rulesets.Mods
+{
+    public interface IAdjustableWhenReplay : IApplicableMod
+    {
+        BindableBool IsDisabled { get; }
+    }
+}

--- a/osu.Game/Rulesets/Mods/ModDoubleTime.cs
+++ b/osu.Game/Rulesets/Mods/ModDoubleTime.cs
@@ -12,7 +12,7 @@ using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModDoubleTime : ModRateAdjust
+    public abstract class ModDoubleTime : ModRateAdjust, IAdjustableWhenReplay
     {
         public override string Name => "Double Time";
         public override string Acronym => "DT";
@@ -44,12 +44,15 @@ namespace osu.Game.Rulesets.Mods
             }
         }
 
+        public BindableBool IsDisabled { get; } = new BindableBool();
+
         private readonly RateAdjustModHelper rateAdjustHelper;
 
         protected ModDoubleTime()
         {
             rateAdjustHelper = new RateAdjustModHelper(SpeedChange);
             rateAdjustHelper.HandleAudioAdjustments(AdjustPitch);
+            rateAdjustHelper.DisableSpeedChange.BindTo(IsDisabled);
         }
 
         public override void ApplyToTrack(IAdjustableAudioComponent track)

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -50,7 +50,7 @@ namespace osu.Game.Rulesets.Mods
         public abstract float DefaultFlashlightSize { get; }
     }
 
-    public abstract partial class ModFlashlight<T> : ModFlashlight, IApplicableToDrawableRuleset<T>, IApplicableToScoreProcessor
+    public abstract partial class ModFlashlight<T> : ModFlashlight, IApplicableToDrawableRuleset<T>, IApplicableToScoreProcessor, IAdjustableWhenReplay
         where T : HitObject
     {
         public const double FLASHLIGHT_FADE_DURATION = 800;
@@ -100,9 +100,16 @@ namespace osu.Game.Rulesets.Mods
                 // NegativeInfinity is not used to allow one more thing drawn on top (used in replay analysis overlay in osu!).
                 Depth = float.MinValue,
             });
+
+            IsDisabled.BindValueChanged(_ =>
+            {
+                flashlight.FadeTo(IsDisabled.Value ? 0.3f : 1.0f, 50);
+            }, true);
         }
 
         protected abstract Flashlight CreateFlashlight();
+
+        public BindableBool IsDisabled { get; } = new BindableBool();
 
         public abstract partial class Flashlight : Drawable
         {

--- a/osu.Game/Rulesets/Mods/ModHalfTime.cs
+++ b/osu.Game/Rulesets/Mods/ModHalfTime.cs
@@ -12,7 +12,7 @@ using osu.Game.Overlays.Settings;
 
 namespace osu.Game.Rulesets.Mods
 {
-    public abstract class ModHalfTime : ModRateAdjust
+    public abstract class ModHalfTime : ModRateAdjust, IAdjustableWhenReplay
     {
         public override string Name => "Half Time";
         public override string Acronym => "HT";
@@ -44,12 +44,15 @@ namespace osu.Game.Rulesets.Mods
             }
         }
 
+        public BindableBool IsDisabled { get; } = new BindableBool();
+
         private readonly RateAdjustModHelper rateAdjustHelper;
 
         protected ModHalfTime()
         {
             rateAdjustHelper = new RateAdjustModHelper(SpeedChange);
             rateAdjustHelper.HandleAudioAdjustments(AdjustPitch);
+            rateAdjustHelper.DisableSpeedChange.BindTo(IsDisabled);
         }
 
         public override void ApplyToTrack(IAdjustableAudioComponent track)

--- a/osu.Game/Rulesets/Mods/RateAdjustModHelper.cs
+++ b/osu.Game/Rulesets/Mods/RateAdjustModHelper.cs
@@ -14,6 +14,14 @@ namespace osu.Game.Rulesets.Mods
     {
         public readonly IBindableNumber<double> SpeedChange;
 
+        private readonly BindableNumber<double> speedChange = new BindableNumber<double>();
+
+        /// <summary>
+        /// Use with mods containing <see cref="IAdjustableWhenReplay"/>.
+        /// When it set to true, speed change will be 1.0.
+        /// </summary>
+        public BindableBool DisableSpeedChange = new BindableBool();
+
         private IAdjustableAudioComponent? track;
 
         private BindableBool? adjustPitch;
@@ -25,6 +33,14 @@ namespace osu.Game.Rulesets.Mods
         public RateAdjustModHelper(IBindableNumber<double> speedChange)
         {
             SpeedChange = speedChange;
+
+            SpeedChange.BindValueChanged(_ => updateSpeedChange(), true);
+            DisableSpeedChange.BindValueChanged(_ => updateSpeedChange(), true);
+        }
+
+        private void updateSpeedChange()
+        {
+            speedChange.Value = DisableSpeedChange.Value ? 1 : SpeedChange.Value;
         }
 
         /// <summary>
@@ -39,8 +55,8 @@ namespace osu.Game.Rulesets.Mods
             // When switching between pitch adjust, we need to update adjustments to time-shift or frequency-scale.
             adjustPitch.BindValueChanged(adjustPitchSetting =>
             {
-                track?.RemoveAdjustment(adjustmentForPitchSetting(adjustPitchSetting.OldValue), SpeedChange);
-                track?.AddAdjustment(adjustmentForPitchSetting(adjustPitchSetting.NewValue), SpeedChange);
+                track?.RemoveAdjustment(adjustmentForPitchSetting(adjustPitchSetting.OldValue), speedChange);
+                track?.AddAdjustment(adjustmentForPitchSetting(adjustPitchSetting.NewValue), speedChange);
 
                 AdjustableProperty adjustmentForPitchSetting(bool adjustPitchSettingValue)
                     => adjustPitchSettingValue ? AdjustableProperty.Frequency : AdjustableProperty.Tempo;

--- a/osu.Game/Rulesets/UI/ClickableModIcon.cs
+++ b/osu.Game/Rulesets/UI/ClickableModIcon.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Game.Rulesets.Mods;
+using osu.Framework.Input.Events;
+
+namespace osu.Game.Rulesets.UI
+{
+    /// <summary>
+    /// Display the specified mod at a fixed size.
+    /// </summary>
+    public partial class ClickableModIcon : ModIcon
+    {
+        public Action? Action;
+
+        public ClickableModIcon(IMod mod, bool showTooltip = true, bool showExtendedInformation = true)
+            : base(mod, showTooltip, showExtendedInformation)
+        {
+        }
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            Action?.Invoke();
+            return true;
+        }
+    }
+}

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Mods;
@@ -24,7 +25,7 @@ namespace osu.Game.Rulesets.UI
     /// <summary>
     /// Display the specified mod at a fixed size.
     /// </summary>
-    public partial class ModIcon : Container, IHasCustomTooltip<Mod>
+    public partial class ModIcon : OsuClickableContainer, IHasCustomTooltip<Mod>
     {
         public readonly BindableBool Selected = new BindableBool();
 

--- a/osu.Game/Rulesets/UI/ModIcon.cs
+++ b/osu.Game/Rulesets/UI/ModIcon.cs
@@ -13,7 +13,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
-using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Mods;
@@ -25,7 +24,7 @@ namespace osu.Game.Rulesets.UI
     /// <summary>
     /// Display the specified mod at a fixed size.
     /// </summary>
-    public partial class ModIcon : OsuClickableContainer, IHasCustomTooltip<Mod>
+    public partial class ModIcon : Container, IHasCustomTooltip<Mod>
     {
         public readonly BindableBool Selected = new BindableBool();
 

--- a/osu.Game/Screens/Play/HUD/HudModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HudModDisplay.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Bindables;
+using osu.Game.Graphics;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.UI;
+using osuTK.Graphics;
+
+namespace osu.Game.Screens.Play.HUD
+{
+    public partial class HudModDisplay : ModDisplay
+    {
+        private readonly Bindable<bool> replayLoaded = new Bindable<bool>();
+
+        public HudModDisplay(Bindable<bool> replayLoaded, bool showExtendedInformation = true)
+            : base(showExtendedInformation)
+        {
+            this.replayLoaded.BindTo(replayLoaded);
+        }
+
+        protected override void UpdateDisplay(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        {
+            base.UpdateDisplay(mods);
+
+            foreach (ModIcon modIcon in IconsContainer)
+            {
+                if (modIcon.Mod is not IAdjustableWhenReplay dmod)
+                    continue;
+
+                dmod.IsDisabled.BindValueChanged(_ => modIcon.Colour = dmod.IsDisabled.Value ? OsuColour.Gray(0.7f) : Color4.White, true);
+
+                modIcon.Action = () =>
+                {
+                    if (!replayLoaded.Value)
+                        return;
+
+                    dmod.IsDisabled.Toggle();
+                };
+            }
+        }
+    }
+}

--- a/osu.Game/Screens/Play/HUD/HudModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/HudModDisplay.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Bindables;
 using osu.Game.Graphics;
 using osu.Game.Rulesets.Mods;
@@ -20,15 +19,12 @@ namespace osu.Game.Screens.Play.HUD
             this.replayLoaded.BindTo(replayLoaded);
         }
 
-        protected override void UpdateDisplay(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        protected override ModIcon CreateModIcon(Mod mod, bool showExtendedInformation)
         {
-            base.UpdateDisplay(mods);
+            var modIcon = new ClickableModIcon(mod, showExtendedInformation);
 
-            foreach (ModIcon modIcon in IconsContainer)
+            if (modIcon.Mod is IAdjustableWhenReplay dmod)
             {
-                if (modIcon.Mod is not IAdjustableWhenReplay dmod)
-                    continue;
-
                 dmod.IsDisabled.BindValueChanged(_ => modIcon.Colour = dmod.IsDisabled.Value ? OsuColour.Gray(0.7f) : Color4.White, true);
 
                 modIcon.Action = () =>
@@ -39,6 +35,8 @@ namespace osu.Game.Screens.Play.HUD
                     dmod.IsDisabled.Toggle();
                 };
             }
+
+            return modIcon;
         }
     }
 }

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -62,18 +62,18 @@ namespace osu.Game.Screens.Play.HUD
             set
             {
                 showExtendedInformation = value;
-                foreach (var icon in IconsContainer)
+                foreach (var icon in iconsContainer)
                     icon.ShowExtendedInformation = value;
             }
         }
 
         public FillDirection FillDirection
         {
-            get => IconsContainer.Direction;
-            set => IconsContainer.Direction = value;
+            get => iconsContainer.Direction;
+            set => iconsContainer.Direction = value;
         }
 
-        protected readonly FillFlowContainer<ModIcon> IconsContainer;
+        private readonly FillFlowContainer<ModIcon> iconsContainer;
 
         public ModDisplay(bool showExtendedInformation = true)
         {
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Play.HUD
 
             AutoSizeAxes = Axes.Both;
 
-            InternalChild = IconsContainer = new ReverseChildIDFillFlowContainer<ModIcon>
+            InternalChild = iconsContainer = new ReverseChildIDFillFlowContainer<ModIcon>
             {
                 AutoSizeAxes = Axes.Both,
                 Direction = FillDirection.Horizontal,
@@ -92,17 +92,19 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            Current.BindValueChanged(UpdateDisplay, true);
+            Current.BindValueChanged(updateDisplay, true);
             updateExpansionMode(0);
         }
 
-        protected virtual void UpdateDisplay(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        private void updateDisplay(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
-            IconsContainer.Clear();
+            iconsContainer.Clear();
 
             foreach (Mod mod in mods.NewValue.AsOrdered())
-                IconsContainer.Add(new ModIcon(mod, showExtendedInformation: showExtendedInformation) { Scale = new Vector2(MOD_ICON_SCALE) });
+                iconsContainer.Add(CreateModIcon(mod, showExtendedInformation).With(m => m.Scale = new Vector2(MOD_ICON_SCALE)));
         }
+
+        protected virtual ModIcon CreateModIcon(Mod mod, bool showExtendedInformation) => new ModIcon(mod, showExtendedInformation);
 
         private void updateExpansionMode(double duration = 500)
         {
@@ -128,13 +130,13 @@ namespace osu.Game.Screens.Play.HUD
         private void expand(double duration = 500)
         {
             if (ExpansionMode != ExpansionMode.AlwaysContracted)
-                IconsContainer.TransformSpacingTo(new Vector2(5, -10), duration, Easing.OutQuint);
+                iconsContainer.TransformSpacingTo(new Vector2(5, -10), duration, Easing.OutQuint);
         }
 
         private void contract(double duration = 500)
         {
             if (ExpansionMode != ExpansionMode.AlwaysExpanded)
-                IconsContainer.TransformSpacingTo(new Vector2(-25), duration, Easing.OutQuint);
+                iconsContainer.TransformSpacingTo(new Vector2(-25), duration, Easing.OutQuint);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Screens/Play/HUD/ModDisplay.cs
+++ b/osu.Game/Screens/Play/HUD/ModDisplay.cs
@@ -62,18 +62,18 @@ namespace osu.Game.Screens.Play.HUD
             set
             {
                 showExtendedInformation = value;
-                foreach (var icon in iconsContainer)
+                foreach (var icon in IconsContainer)
                     icon.ShowExtendedInformation = value;
             }
         }
 
         public FillDirection FillDirection
         {
-            get => iconsContainer.Direction;
-            set => iconsContainer.Direction = value;
+            get => IconsContainer.Direction;
+            set => IconsContainer.Direction = value;
         }
 
-        private readonly FillFlowContainer<ModIcon> iconsContainer;
+        protected readonly FillFlowContainer<ModIcon> IconsContainer;
 
         public ModDisplay(bool showExtendedInformation = true)
         {
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Play.HUD
 
             AutoSizeAxes = Axes.Both;
 
-            InternalChild = iconsContainer = new ReverseChildIDFillFlowContainer<ModIcon>
+            InternalChild = IconsContainer = new ReverseChildIDFillFlowContainer<ModIcon>
             {
                 AutoSizeAxes = Axes.Both,
                 Direction = FillDirection.Horizontal,
@@ -92,16 +92,16 @@ namespace osu.Game.Screens.Play.HUD
         {
             base.LoadComplete();
 
-            Current.BindValueChanged(updateDisplay, true);
+            Current.BindValueChanged(UpdateDisplay, true);
             updateExpansionMode(0);
         }
 
-        private void updateDisplay(ValueChangedEvent<IReadOnlyList<Mod>> mods)
+        protected virtual void UpdateDisplay(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
-            iconsContainer.Clear();
+            IconsContainer.Clear();
 
             foreach (Mod mod in mods.NewValue.AsOrdered())
-                iconsContainer.Add(new ModIcon(mod, showExtendedInformation: showExtendedInformation) { Scale = new Vector2(MOD_ICON_SCALE) });
+                IconsContainer.Add(new ModIcon(mod, showExtendedInformation: showExtendedInformation) { Scale = new Vector2(MOD_ICON_SCALE) });
         }
 
         private void updateExpansionMode(double duration = 500)
@@ -128,13 +128,13 @@ namespace osu.Game.Screens.Play.HUD
         private void expand(double duration = 500)
         {
             if (ExpansionMode != ExpansionMode.AlwaysContracted)
-                iconsContainer.TransformSpacingTo(new Vector2(5, -10), duration, Easing.OutQuint);
+                IconsContainer.TransformSpacingTo(new Vector2(5, -10), duration, Easing.OutQuint);
         }
 
         private void contract(double duration = 500)
         {
             if (ExpansionMode != ExpansionMode.AlwaysExpanded)
-                iconsContainer.TransformSpacingTo(new Vector2(-25), duration, Easing.OutQuint);
+                IconsContainer.TransformSpacingTo(new Vector2(-25), duration, Easing.OutQuint);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -380,7 +380,7 @@ namespace osu.Game.Screens.Play
             Origin = Anchor.BottomRight,
         };
 
-        protected ModDisplay CreateModsContainer() => new ModDisplay
+        protected ModDisplay CreateModsContainer() => new HudModDisplay(replayLoaded)
         {
             Anchor = Anchor.TopRight,
             Origin = Anchor.TopRight,


### PR DESCRIPTION
- close https://github.com/ppy/osu/issues/8357
- supersede https://github.com/ppy/osu/pull/19925

create a new interface named `IAdjustableWhenReplay`

This pr only implements a small number of mods to facilitate review and determine interface.

`IAdjustableWhenReplay` now only have `IsDisabled`. However, in the future, it might be possible to adjust other parameters based on specific mods like [NoScope](https://github.com/ppy/osu/pull/28485)