### PR TITLE
Delay switchover of spectator client to new spectator server instance until current score is done

### DIFF
--- a/osu.Game/Online/Spectator/SpectatorClient.cs
+++ b/osu.Game/Online/Spectator/SpectatorClient.cs
@@ -453,7 +453,7 @@ namespace osu.Game.Online.Spectator
 
         Task IStatefulUserHubClient.ServerShuttingDown()
         {
-            this.ReconnectWhenReady(IsConnected, () => watchedUsersRefCounts.Count == 0, Reconnect);
+            this.ReconnectWhenReady(IsConnected, () => !isPlaying && watchedUsersRefCounts.Count == 0, Reconnect);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Noticed through monitoring datadog metrics after a deploy.

The client not waiting for the play to complete before switching over to a new instance of spectator server would cause the replay to get split in half; the half prior to the switchover would be discarded by the old instance, while only the half after the switchover would be recorded and saved to a replay.

Have half-tested via local environment (on master, shutting down spectator during a play will cause it to start spewing errors instantly due to attempting to reconnect to a shutting-down instance; with this change, that only occurs on the next started play).