### PR TITLE
Allow using hitsounding hotkeys while sample popover volume text box is focused

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -763,6 +763,36 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
                     return base.OnPressed(e);
                 }
+
+                protected override bool OnKeyDown(KeyDownEvent e)
+                {
+                    // mappers wish to be able to use sample sound / bank toggles while this text box is focused
+                    // to facilitate this, only use standard text box handling for relevant inputs
+                    // and let all other inputs fall through unhandled so that overarching composer elements
+                    // can handle the hitsounding toggles
+                    switch (e.Key)
+                    {
+                        // inputting volume number
+                        case >= Key.Keypad0 and <= Key.Keypad9:
+                        case >= Key.Number0 and <= Key.Number9:
+                        // committing the number
+                        case Key.Enter:
+                        case Key.KeypadEnter:
+                        // releasing focus
+                        case Key.Escape:
+                            return base.OnKeyDown(e);
+
+                        default:
+                            return false;
+                    }
+                }
+
+                protected override void NotifyInputError()
+                {
+                    // base call intentionally suppressed.
+                    // as most keypresses are allowed to fall through this text box to allow other interactions via composer elements,
+                    // it feels wrong to have those fall-through inputs additionally flash this text box red as if something bad happened.
+                }
             }
         }
     }


### PR DESCRIPTION
Requested in https://github.com/ppy/osu/discussions/31263, and in https://github.com/ppy/osu/pull/38304#issuecomment-5013047162.

Somewhat hacky but it is what it is. As far as I'm concerned it's a miracle that anything works here at all to achieve the end effect (unless i18n kills this, which could very well still happen).

I'd add a test for this but for reasons I would rather not investigate the test I wrote already passes on `master` via `ManualInputManager` and I cannot do what the test is doing manually, so there's some difference in input handling there. Probably something to do with activating text input or similar.

I'm also using the weird switch syntax that it was agreed not to use but my options are either this or a weird gonky `if` condition, so pick your poison.