### PR TITLE
Fix editor treating valid audio files with uppercase extension as "corrupted" because of taglib internals

### DIFF
--- a/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
+++ b/osu.Game/Screens/Edit/Setup/ResourcesSection.cs
@@ -255,14 +255,14 @@ namespace osu.Game.Screens.Edit.Setup
             if (source != null)
             {
                 // Choose a new filename that doesn't clash with any other existing files.
-                newFilename = $"{baseFilename}{source.Extension}";
+                newFilename = $@"{baseFilename}{source.Extension.ToLowerInvariant()}";
 
                 if (set.GetFile(newFilename) != null)
                 {
                     string[] existingFilenames = set.Files.Select(f => f.Filename).Where(f =>
                         f.StartsWith(baseFilename, StringComparison.OrdinalIgnoreCase) &&
                         f.EndsWith(source.Extension, StringComparison.OrdinalIgnoreCase)).ToArray();
-                    newFilename = NamingUtils.GetNextBestFilename(existingFilenames, $@"{baseFilename}{source.Extension}");
+                    newFilename = NamingUtils.GetNextBestFilename(existingFilenames, newFilename);
                 }
 
                 using (var stream = source.OpenRead())

--- a/osu.Game/Utils/TagLibUtils.cs
+++ b/osu.Game/Utils/TagLibUtils.cs
@@ -30,7 +30,7 @@ namespace osu.Game.Utils
             File.Create(filePath, getMimeType(filePath), ReadStyle.Average | ReadStyle.PictureLazy);
 
         // Manual MIME type resolution to avoid culture variance (ie. https://github.com/ppy/osu/issues/32962)
-        private static string getMimeType(string fileName) => @"taglib/" + Path.GetExtension(fileName).TrimStart('.');
+        private static string getMimeType(string fileName) => @"taglib/" + Path.GetExtension(fileName.ToLowerInvariant()).TrimStart('.');
 
         private class StreamFileAbstraction : File.IFileAbstraction
         {


### PR DESCRIPTION
Fixes https://osu.ppy.sh/community/forums/topics/2227414.

See also: https://github.com/mono/taglib-sharp/blob/da41dc30756189217624d8fdde3c70956e7341f9/src/TaglibSharp/File.cs#L1263