### PR TITLE
Fix multiplayer spectator stutter from player clocks double-counting elapsed time

### DIFF
--- a/osu.Game.Tests/OnlinePlay/SpectatorPlayerClockTest.cs
+++ b/osu.Game.Tests/OnlinePlay/SpectatorPlayerClockTest.cs
@@ -61,14 +61,19 @@ namespace osu.Game.Tests.OnlinePlay
         [Test]
         public void TestRepeatProcessFrameDoesNotAccumulateTwice()
         {
-            // ProcessFrame may run more than once without the master clock advancing, as FramedBeatmapClock
-            // calls ProcessFrame on its source on Start, Stop, Seek, Reset in addition to its own Update
             setMasterElapsed(20);
 
-            processFrame();
-            processFrame();
+            assertElapsedTime(0);
 
+            processFrame();
             assertCurrentTime(20);
+            assertElapsedTime(20);
+
+            // `ProcessFrame` may run more than once without the master clock advancing, as `FramedBeatmapClock`
+            // calls `ProcessFrame` on its source on Start, Stop, Seek, Reset in addition to its own Update
+            processFrame();
+            assertCurrentTime(20);
+            assertElapsedTime(0);
         }
 
         private void setMasterRate(double rate)
@@ -92,5 +97,8 @@ namespace osu.Game.Tests.OnlinePlay
 
         private void assertCurrentTime(double expected)
             => AddAssert($"current time is {expected}", () => clock.CurrentTime, () => Is.EqualTo(expected));
+
+        private void assertElapsedTime(double expected)
+            => AddAssert($"elapsed time is {expected}", () => clock.ElapsedFrameTime, () => Is.EqualTo(expected));
     }
 }

--- a/osu.Game.Tests/OnlinePlay/SpectatorPlayerClockTest.cs
+++ b/osu.Game.Tests/OnlinePlay/SpectatorPlayerClockTest.cs
@@ -58,6 +58,19 @@ namespace osu.Game.Tests.OnlinePlay
             assertCurrentTime(20 * SpectatorPlayerClock.CATCHUP_RATE);
         }
 
+        [Test]
+        public void TestRepeatProcessFrameDoesNotAccumulateTwice()
+        {
+            // ProcessFrame may run more than once without the master clock advancing, as FramedBeatmapClock
+            // calls ProcessFrame on its source on Start, Stop, Seek, Reset in addition to its own Update
+            setMasterElapsed(20);
+
+            processFrame();
+            processFrame();
+
+            assertCurrentTime(20);
+        }
+
         private void setMasterRate(double rate)
             => AddStep($"set master rate = {rate}", () => masterSource.Rate = rate);
 

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/Spectate/SpectatorPlayerClock.cs
@@ -40,9 +40,16 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
         /// </summary>
         public bool IsRunning { get; set; }
 
+        /// <summary>
+        /// The master clock time last seen by <see cref="ProcessFrame"/>. As <see cref="ProcessFrame"/> accumulates
+        /// elapsed time, it must only apply the master clock's elapsed time when the master clock has advanced.
+        /// </summary>
+        private double lastSeenMasterTime;
+
         public SpectatorPlayerClock(IFrameBasedClock masterClock)
         {
             this.masterClock = masterClock;
+            lastSeenMasterTime = masterClock.CurrentTime;
         }
 
         public void Reset() => CurrentTime = 0;
@@ -78,12 +85,25 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer.Spectate
 
         public void ProcessFrame()
         {
+            // ProcessFrame can get called more than once in a single update loop. Save the last seen master time
+            // to prevent double-accumulating elapsed time.
+            bool masterAdvanced = masterClock.CurrentTime != lastSeenMasterTime;
+            lastSeenMasterTime = masterClock.CurrentTime;
+
             if (IsRunning)
             {
-                // When in catch-up mode, the source is usually not running.
-                // In such a case, its elapsed time may be zero, which would cause catch-up to get stuck.
-                // To avoid this, calculate the "elapsed" time manually based on the difference with the master clock.
-                double elapsedSource = masterClock.ElapsedFrameTime != 0 ? masterClock.ElapsedFrameTime : Math.Clamp(masterClock.CurrentTime - CurrentTime, 0, 16);
+                double elapsedSource;
+
+                if (masterClock.ElapsedFrameTime != 0)
+                    elapsedSource = masterAdvanced ? masterClock.ElapsedFrameTime : 0;
+                else
+                {
+                    // When in catch-up mode, the source is usually not running.
+                    // In such a case, its elapsed time may be zero, which would cause catch-up to get stuck.
+                    // To avoid this, calculate the "elapsed" time manually based on the difference with the master clock.
+                    elapsedSource = Math.Clamp(masterClock.CurrentTime - CurrentTime, 0, 16);
+                }
+
                 double elapsed = elapsedSource * catchUpMultiplier;
 
                 CurrentTime += elapsed;


### PR DESCRIPTION
Tangentially related to #38359, as the symptom makes a player area appear to stutter while spectating a multiplayer room.

---

`SpectatorPlayerClock.ProcessFrame` accumulates the elapsed time from the master clock. In some cases, `ProcessFrame` is called more than once in the same Update loop, causing it to accumuate the elapsed time twice. For example:

When calling `GameplayClockContainer.Start` (e.g. resuming a player's clock after initial sync of players), 
 - `StartGameplayClock` is scheduled after children update via `SchedulerAfterChildren`
 - In the same Update loop, `FramedBeatmapClock.Update` calls `SpectatorPlayerClock.ProcessFrame`
 - Towards the end of the Update loop, the `StartGameplayClock` schedued earlier runs, which calls `SpectatorPlayerClock.ProcessFrame` again (2nd time in this Update loop)

In most cases, this stabilizes after a few start/stop loops as the elapsed time on the master clock is small, but when the update thread runs at a low frequency (e.g. 60Hz when tabbed out, common when streaming tournament matches with the client tabbed out), the master clock elapsed time overshoots `SpectatorSyncManager.SYNC_TARGET` and causes a player's clock to Start and Stop indefinitely.

| master | <video src="https://github.com/user-attachments/assets/93584955-7163-4989-b760-23c5bc77cbf1" /> |
| --- | --- |
| PR | <video src="https://github.com/user-attachments/assets/f53d66cb-c733-4d6e-acca-f8795c983f34" /> |