### PR TITLE
Add setting to disable/reduce osu! hitobject animations

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneHitCircle.cs
@@ -4,11 +4,13 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
@@ -64,6 +66,7 @@ namespace osu.Game.Rulesets.Osu.Tests
         public void TestHitLighting()
         {
             AddToggleStep("toggle hit lighting", v => config.SetValue(OsuSetting.HitLighting, v));
+            AddToggleStep("toggle hit animation", v => ((OsuRulesetConfigManager)RulesetConfigs.GetConfigFor(Ruleset.Value.CreateInstance()).AsNonNull()).SetValue(OsuRulesetSetting.HitAnimations, v));
             AddStep("Hit Big Single", () => SetContents(_ => testSingle(2, true)));
         }
 

--- a/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Osu/Configuration/OsuRulesetConfigManager.cs
@@ -19,6 +19,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
             base.InitialiseDefaults();
             SetDefault(OsuRulesetSetting.SnakingInSliders, true);
             SetDefault(OsuRulesetSetting.SnakingOutSliders, true);
+            SetDefault(OsuRulesetSetting.HitAnimations, true);
             SetDefault(OsuRulesetSetting.ShowCursorTrail, true);
             SetDefault(OsuRulesetSetting.ShowCursorRipples, false);
             SetDefault(OsuRulesetSetting.PlayfieldBorderStyle, PlayfieldBorderStyle.None);
@@ -35,6 +36,7 @@ namespace osu.Game.Rulesets.Osu.Configuration
     {
         SnakingInSliders,
         SnakingOutSliders,
+        HitAnimations,
         ShowCursorTrail,
         ShowCursorRipples,
         PlayfieldBorderStyle,

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
 
         [BackgroundDependencyLoader]
-        private void load(OsuRulesetConfigManager osuConfig)
+        private void load(OsuRulesetConfigManager? osuConfig)
         {
-            osuConfig.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
+            osuConfig?.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
 
             Origin = Anchor.Centre;
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Bindings;
@@ -13,6 +14,7 @@ using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Judgements;
 using osu.Game.Rulesets.Osu.Skinning;
 using osu.Game.Rulesets.Osu.Skinning.Default;
@@ -50,9 +52,16 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
+
+        [Resolved]
+        private OsuRulesetConfigManager osuConfig { get; set; } = null!;
+
         [BackgroundDependencyLoader]
         private void load()
         {
+            osuConfig.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
+
             Origin = Anchor.Centre;
 
             AddRangeInternal(new Drawable[]
@@ -211,6 +220,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             {
                 default:
                     ApproachCircle.FadeOut();
+
+                    if (!hitAnimations.Value)
+                        this.FadeOut(60, Easing.Out);
                     break;
 
                 case ArmedState.Idle:

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableHitCircle.cs
@@ -54,11 +54,8 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
 
         private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
 
-        [Resolved]
-        private OsuRulesetConfigManager osuConfig { get; set; } = null!;
-
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager osuConfig)
         {
             osuConfig.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
 

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.Diagnostics;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -23,10 +20,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
     {
         public new SliderTailCircle HitObject => (SliderTailCircle)base.HitObject;
 
-        [CanBeNull]
-        public Slider Slider => DrawableSlider?.HitObject;
+        public Slider? Slider => DrawableSlider?.HitObject;
 
-        protected DrawableSlider DrawableSlider => (DrawableSlider)ParentHitObject;
+        protected DrawableSlider? DrawableSlider => ParentHitObject as DrawableSlider;
 
         /// <summary>
         /// Whether the hit samples only play on successful hits.
@@ -34,9 +30,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         /// </summary>
         public bool SamplePlaysOnlyOnHit { get; set; } = true;
 
-        public SkinnableDrawable CirclePiece { get; private set; }
+        public SkinnableDrawable? CirclePiece { get; private set; }
 
-        private Container scaleContainer;
+        private Container scaleContainer = null!;
 
         public DrawableSliderTail()
             : base(null)
@@ -51,9 +47,9 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
 
         [BackgroundDependencyLoader]
-        private void load(OsuRulesetConfigManager osuConfig)
+        private void load(OsuRulesetConfigManager? osuConfig)
         {
-            osuConfig.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
+            osuConfig?.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
 
             Origin = Anchor.Centre;
             Size = OsuHitObject.OBJECT_DIMENSIONS;
@@ -124,7 +120,7 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
             }
         }
 
-        protected override void CheckForResult(bool userTriggered, double timeOffset) => DrawableSlider.SliderInputManager.TryJudgeNestedObject(this, timeOffset);
+        protected override void CheckForResult(bool userTriggered, double timeOffset) => DrawableSlider!.SliderInputManager.TryJudgeNestedObject(this, timeOffset);
 
         protected override void OnApply()
         {

--- a/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
+++ b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSliderTail.cs
@@ -6,11 +6,13 @@
 using System.Diagnostics;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Utils;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Skinning;
 using osuTK;
 using osuTK.Graphics;
@@ -46,9 +48,13 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
         {
         }
 
+        private readonly Bindable<bool> hitAnimations = new Bindable<bool>(true);
+
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuRulesetConfigManager osuConfig)
         {
+            osuConfig.BindWith(OsuRulesetSetting.HitAnimations, hitAnimations);
+
             Origin = Anchor.Centre;
             Size = OsuHitObject.OBJECT_DIMENSIONS;
 
@@ -106,8 +112,14 @@ namespace osu.Game.Rulesets.Osu.Objects.Drawables
                     break;
 
                 case ArmedState.Hit:
-                    // todo: temporary / arbitrary
-                    this.Delay(800).FadeOut();
+                    if (!hitAnimations.Value)
+                        this.FadeOut(60, Easing.Out);
+                    else
+                    {
+                        // todo: temporary / arbitrary
+                        this.Delay(800).FadeOut();
+                    }
+
                     break;
             }
         }

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -183,10 +183,11 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                             if (legacyVersion > 1.0m)
                             {
                                 // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
-                                // of note, if the hit animation setting is disabled, the fade should not be shortened to avoid applying twice the effect.
-                                if (osuConfig?.Get<bool>(OsuRulesetSetting.HitAnimations) == false)
-                                    hitCircleText.FadeOut(legacy_fade_duration);
-                                else
+                                //
+                                // if the new hit animation setting is disabled, the fade is bypassed here to avoid users abusing this to achieve "even better" results.
+                                // note that this means the number fades slightly slower than other components when hit animations are off.
+                                // in practice, the fade is so short this is not perceivable.
+                                if (osuConfig?.Get<bool>(OsuRulesetSetting.HitAnimations) != false)
                                     hitCircleText.FadeOut(legacy_fade_duration / 4);
                             }
                             else

--- a/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
+++ b/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Configuration;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Skinning;
@@ -45,6 +46,9 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
 
         [Resolved]
         private ISkinSource skin { get; set; } = null!;
+
+        [Resolved]
+        private OsuRulesetConfigManager? osuConfig { get; set; }
 
         public LegacyMainCirclePiece(string? priorityLookupPrefix = null, bool hasNumber = true)
         {
@@ -177,8 +181,14 @@ namespace osu.Game.Rulesets.Osu.Skinning.Legacy
                             decimal? legacyVersion = skin.GetConfig<SkinConfiguration.LegacySetting, decimal>(SkinConfiguration.LegacySetting.Version)?.Value;
 
                             if (legacyVersion > 1.0m)
+                            {
                                 // legacy skins of version 2.0 and newer only apply very short fade out to the number piece.
-                                hitCircleText.FadeOut(legacy_fade_duration / 4);
+                                // of note, if the hit animation setting is disabled, the fade should not be shortened to avoid applying twice the effect.
+                                if (osuConfig?.Get<bool>(OsuRulesetSetting.HitAnimations) == false)
+                                    hitCircleText.FadeOut(legacy_fade_duration);
+                                else
+                                    hitCircleText.FadeOut(legacy_fade_duration / 4);
+                            }
                             else
                             {
                                 // old skins scale and fade it normally along other pieces.

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -44,6 +44,12 @@ namespace osu.Game.Rulesets.Osu.UI
                 },
                 new SettingsItemV2(new FormCheckBox
                 {
+                    Caption = RulesetSettingsStrings.HitAnimations,
+                    HintText = RulesetSettingsStrings.HitAnimationsOsuTooltip,
+                    Current = config.GetBindable<bool>(OsuRulesetSetting.HitAnimations)
+                }),
+                new SettingsItemV2(new FormCheckBox
+                {
                     Caption = RulesetSettingsStrings.CursorTrail,
                     Current = config.GetBindable<bool>(OsuRulesetSetting.ShowCursorTrail)
                 }),

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -100,6 +100,11 @@ namespace osu.Game.Localisation
         public static LocalisableString HitAnimationsTaikoTooltip => new TranslatableString(getKey(@"hit_animations_taiko_tooltip"), @"When enabled, hits will fly off the screen. When disabled, hits will disappear immediately.");
 
         /// <summary>
+        /// "When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately"
+        /// </summary>
+        public static LocalisableString HitAnimationsOsuTooltip => new TranslatableString(getKey(@"hit_animations_osu_tooltip"), @"When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately");
+
+        /// <summary>
         /// "{0}ms (speed {1:N1})"
         /// </summary>
         public static LocalisableString ScrollSpeedTooltip(int scrollTime, double scrollSpeed) => new TranslatableString(getKey(@"ruleset"), @"{0}ms (speed {1:N1})", scrollTime, scrollSpeed);

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -100,9 +100,9 @@ namespace osu.Game.Localisation
         public static LocalisableString HitAnimationsTaikoTooltip => new TranslatableString(getKey(@"hit_animations_taiko_tooltip"), @"When enabled, hits will fly off the screen. When disabled, hits will disappear immediately.");
 
         /// <summary>
-        /// "When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately."
+        /// "When enabled, hit circles will play an animation when hit. When disabled, they will disappear almost immediately."
         /// </summary>
-        public static LocalisableString HitAnimationsOsuTooltip => new TranslatableString(getKey(@"hit_animations_osu_tooltip"), @"When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately.");
+        public static LocalisableString HitAnimationsOsuTooltip => new TranslatableString(getKey(@"hit_animations_osu_tooltip"), @"When enabled, hit circles will play an animation when hit. When disabled, they will disappear almost immediately.");
 
         /// <summary>
         /// "{0}ms (speed {1:N1})"

--- a/osu.Game/Localisation/RulesetSettingsStrings.cs
+++ b/osu.Game/Localisation/RulesetSettingsStrings.cs
@@ -100,9 +100,9 @@ namespace osu.Game.Localisation
         public static LocalisableString HitAnimationsTaikoTooltip => new TranslatableString(getKey(@"hit_animations_taiko_tooltip"), @"When enabled, hits will fly off the screen. When disabled, hits will disappear immediately.");
 
         /// <summary>
-        /// "When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately"
+        /// "When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately."
         /// </summary>
-        public static LocalisableString HitAnimationsOsuTooltip => new TranslatableString(getKey(@"hit_animations_osu_tooltip"), @"When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately");
+        public static LocalisableString HitAnimationsOsuTooltip => new TranslatableString(getKey(@"hit_animations_osu_tooltip"), @"When enabled, hitcircles will play an animation when hit. When disabled, they will disappear almost immediately.");
 
         /// <summary>
         /// "{0}ms (speed {1:N1})"


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu/pull/38358.

This is the most I'm willing to compromise. So we can take this in two directions:

- Add this in and see how many users end up finding it amicable as an alternative to skin hacks (not going to satisfy everyone as per referenced PR discussion).
- Close this and leave users to continue to hack via skins.

For what it's worth, using the skin number hack in stable/lazer classic skins is NOT and never has been "insta-fade", it's [still 60 ms](https://github.com/ppy/osu/blob/a4f66f5988d5079875ee2095b7333d05062596f5/osu.Game.Rulesets.Osu/Skinning/Legacy/LegacyMainCirclePiece.cs#L181). This change is actually making the fade out faster than that hack. The only difference is that a bit of animation remains.

I believe this should be amicable to a majority of users, which means we may be able to move forward with less hacky skins. 🤷 

Reviewer's note: A pass on code quality and general non-subjective checks would be appreciated, along with an approval. I'll make a final call as to whether to merge or not.