### PR TITLE
Adjust positioning of taiko flashlight effect to match stable

### DIFF
--- a/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Mods/TestSceneTaikoModFlashlight.cs
@@ -71,12 +71,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Mods
 
         private partial class TestTaikoModFlashlight : TaikoModFlashlight
         {
-            protected override Flashlight CreateFlashlight() => new TestTaikoFlashlight(this, Playfield);
+            protected override Flashlight CreateFlashlight() => new TestTaikoFlashlight(this, DrawableRuleset);
 
             public partial class TestTaikoFlashlight : TaikoFlashlight
             {
-                public TestTaikoFlashlight(TaikoModFlashlight modFlashlight, TaikoPlayfield taikoPlayfield)
-                    : base(modFlashlight, taikoPlayfield)
+                public TestTaikoFlashlight(TaikoModFlashlight modFlashlight, DrawableTaikoRuleset drawableRuleset)
+                    : base(modFlashlight, drawableRuleset)
                 {
                 }
 

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -64,7 +64,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
                 if (!flashlightProperties.IsValid)
                 {
-                    FlashlightPosition = ToLocalSpace(taikoPlayfield.HitTarget.ScreenSpaceDrawQuad.Centre);
+                    // https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L480-L481
+                    // 1.6f is "magic factor" for matching stable positioning specs, see `OsuPlayfieldAdjustmentContainer` et al.
+                    FlashlightPosition = new Vector2(208 * 1.6f);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
                     FlashlightSize = new Vector2(0, GetSize());

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -25,25 +25,25 @@ namespace osu.Game.Rulesets.Taiko.Mods
 
         public override float DefaultFlashlightSize => 200;
 
-        protected override Flashlight CreateFlashlight() => new TaikoFlashlight(this, Playfield);
+        protected override Flashlight CreateFlashlight() => new TaikoFlashlight(this, DrawableRuleset);
 
-        protected TaikoPlayfield Playfield { get; private set; } = null!;
+        protected DrawableTaikoRuleset DrawableRuleset { get; private set; } = null!;
 
         public override void ApplyToDrawableRuleset(DrawableRuleset<TaikoHitObject> drawableRuleset)
         {
-            Playfield = (TaikoPlayfield)drawableRuleset.Playfield;
+            DrawableRuleset = (DrawableTaikoRuleset)drawableRuleset;
             base.ApplyToDrawableRuleset(drawableRuleset);
         }
 
         public partial class TaikoFlashlight : Flashlight
         {
             private readonly LayoutValue flashlightProperties = new LayoutValue(Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo);
-            private readonly TaikoPlayfield taikoPlayfield;
+            private readonly DrawableTaikoRuleset drawableRuleset;
 
-            public TaikoFlashlight(TaikoModFlashlight modFlashlight, TaikoPlayfield taikoPlayfield)
+            public TaikoFlashlight(TaikoModFlashlight modFlashlight, DrawableTaikoRuleset drawableRuleset)
                 : base(modFlashlight)
             {
-                this.taikoPlayfield = taikoPlayfield;
+                this.drawableRuleset = drawableRuleset;
 
                 FlashlightSize = new Vector2(0, GetSize());
                 FlashlightSmoothness = 1.4f;
@@ -66,7 +66,9 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 {
                     // https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Taiko/RulesetTaiko.cs#L480-L481
                     // 1.6f is "magic factor" for matching stable positioning specs, see `OsuPlayfieldAdjustmentContainer` et al.
-                    FlashlightPosition = new Vector2(208 * 1.6f);
+                    // the final factor is attempting to compensate for the aspect ratio clamping logic in `TaikoPlayfieldAdjustmentContainer`
+                    // such that it does not change the visible range of objects.
+                    FlashlightPosition = new Vector2(208 * 1.6f * drawableRuleset.PlayfieldAdjustmentContainer.Scale.X);
 
                     ClearTransforms(targetMember: nameof(FlashlightSize));
                     FlashlightSize = new Vector2(0, GetSize());


### PR DESCRIPTION
RFC.

This is what I interpret https://github.com/ppy/osu/discussions/36329#discussioncomment-17671102 to mean lacking further elaboration.

See comparison video: https://drive.google.com/file/d/1bLnkH8bAWlXwafw59O2uoroQp-53fkLF/view?usp=sharing (cannot embed directly due to size).

On "normal resolutions", i.e. anything between 4:3 and 16:9, this matches stable. On "abnormal resolutions" there is no stable to match and lazer has a bespoke behaviour of scaling the playfield, that I've attempted to compensate for in https://github.com/ppy/osu/commit/cc35065e960801cfd888019e2d33779ff81fe3c9. It *kind* of does the job but is not great.

https://github.com/user-attachments/assets/febe0e6c-4ece-4971-b477-95fca12faa54

What any of this means for any existing taiko flashlight scores is not for me to decide.

The other discrepancies pointed out in the discussion thread will be addressed separately because they have wider-ranging implications.

<details>
<summary>osu-resources diff for crosshair on flashlight</summary>

```diff
diff --git a/osu.Game.Resources/Shaders/sh_Flashlight.h b/osu.Game.Resources/Shaders/sh_Flashlight.h
index fcfc34d2..493effc9 100644
--- a/osu.Game.Resources/Shaders/sh_Flashlight.h
+++ b/osu.Game.Resources/Shaders/sh_Flashlight.h
@@ -17,6 +17,13 @@ void main(void)
 {
     // todo: workaround for a SPIR-V bug (https://github.com/ppy/osu-framework/issues/5719)
     float one = g_WrapModeS >= 0 ? 1 : 0;
-
-    o_Colour = mix(getColourAt(flashlightPos - v_Position, flashlightSize, v_Colour), vec4(0.0, 0.0, 0.0, v_Colour.a), flashlightDim) * one;
+    vec2 offset = flashlightPos - v_Position;
+    
+    o_Colour = mix(getColourAt(offset, flashlightSize, v_Colour), vec4(0.0, 0.0, 0.0, v_Colour.a), flashlightDim) * one;
+    
+    if (abs(offset.x) < 2.0 || abs(offset.y) < 2)
+        o_Colour = vec4(1);
+    
+    if (abs(length(offset) - length(flashlightSize * flashlightSmoothness)) < 2)
+       o_Colour = vec4(1);
 }
\ No newline at end of file

```

</details>