### PR TITLE
Add ability to lock object placement to hit area in taiko/catch/mania

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Catch.Objects;
@@ -46,9 +47,13 @@ namespace osu.Game.Rulesets.Catch.Edit
         {
         }
 
+        private Bindable<bool> limitPlacementToCurrentTime = null!;
+
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(OsuConfigManager config)
         {
+            limitPlacementToCurrentTime = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
+
             AddInternal(DistanceSnapProvider);
             DistanceSnapProvider.AttachToToolbox(RightToolbox);
 
@@ -70,6 +75,19 @@ namespace osu.Game.Rulesets.Catch.Edit
                 Catcher.BASE_DASH_SPEED, -Catcher.BASE_DASH_SPEED,
                 Catcher.BASE_WALK_SPEED, -Catcher.BASE_WALK_SPEED,
             }));
+        }
+
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        {
+            if (limitPlacementToCurrentTime.Value
+                && BlueprintContainer.CurrentHitObjectPlacement?.PlacementActive == PlacementBlueprint.PlacementState.Waiting)
+            {
+                var playfield = (CatchPlayfield)Playfield;
+                double time = BeatSnapProvider.SnapTime(EditorClock.CurrentTime);
+                return new SnapResult(playfield.ScreenSpacePositionAtTime(time), time, playfield);
+            }
+
+            return base.FindSnappedPositionAndTime(screenSpacePosition);
         }
 
         protected override Drawable CreateHitObjectInspector() => new CatchHitObjectInspector(DistanceSnapProvider);

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mania.Objects;
@@ -32,6 +34,29 @@ namespace osu.Game.Rulesets.Mania.Edit
         public ManiaHitObjectComposer(Ruleset ruleset)
             : base(ruleset)
         {
+        }
+
+        private Bindable<bool> limitPlacementToCurrentTime = null!;
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            limitPlacementToCurrentTime = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
+        }
+
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        {
+            if (limitPlacementToCurrentTime.Value
+                && BlueprintContainer.CurrentHitObjectPlacement?.PlacementActive == PlacementBlueprint.PlacementState.Waiting)
+            {
+                if (PlayfieldAtScreenSpacePosition(screenSpacePosition) is ScrollingPlayfield playfield)
+                {
+                    double time = BeatSnapProvider.SnapTime(EditorClock.CurrentTime);
+                    return base.FindSnappedPositionAndTime(playfield.ScreenSpacePositionAtTime(time));
+                }
+            }
+
+            return base.FindSnappedPositionAndTime(screenSpacePosition);
         }
 
         public new ManiaPlayfield Playfield => drawableRuleset.Playfield;

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorPlacement.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorPlacement.cs
@@ -3,9 +3,13 @@
 
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Allocation;
 using osu.Framework.Testing;
+using osu.Game.Configuration;
+using osu.Game.Rulesets.Taiko.Edit;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Objects.Drawables;
+using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Tests.Visual;
 using osuTK.Input;
 
@@ -13,6 +17,9 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
 {
     public partial class TestSceneEditorPlacement : EditorTestScene
     {
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
         protected override Ruleset CreateEditorRuleset() => new TaikoRuleset();
 
         [Test]
@@ -30,6 +37,52 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
             AddStep("hover over second hit", () => InputManager.MoveMouseTo(Editor.ChildrenOfType<DrawableHit>().ElementAt(0)));
             AddStep("right click", () => InputManager.Click(MouseButton.Right));
             AddUntilStep("second hit deleted", () => Editor.ChildrenOfType<DrawableHit>().Count(), () => Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestLockPlacementToHitAreaUsesClockTime()
+        {
+            TaikoPlayfield playfield = null!;
+            double placementTime = 0;
+
+            AddStep("enable lock", () => config.SetValue(OsuSetting.EditorTaikoLockPlacementToHitArea, true));
+            AddStep("disable auto seek", () => config.SetValue(OsuSetting.EditorAutoSeekOnPlacement, false));
+            AddStep("clear objects", () => EditorBeatmap.Clear());
+            AddStep("seek to first timing point", () =>
+            {
+                placementTime = EditorBeatmap.ControlPointInfo.TimingPoints.First().Time;
+                EditorClock.Seek(placementTime);
+            });
+            AddStep("get playfield", () => playfield = (TaikoPlayfield)Editor.ChildrenOfType<TaikoHitObjectComposer>().Single().Playfield);
+
+            AddStep("choose hit placement tool", () => InputManager.Key(Key.Number2));
+            AddStep("move to playfield", () => InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre));
+            AddStep("place hit", () => InputManager.Click(MouseButton.Left));
+            AddAssert("hit placed at clock time", () => EditorBeatmap.HitObjects.OfType<Hit>().Single().StartTime, () => Is.EqualTo(placementTime));
+
+            AddStep("seek forward", () =>
+            {
+                placementTime += 1000;
+                EditorClock.Seek(placementTime);
+            });
+            AddStep("choose drum roll tool", () => InputManager.Key(Key.Number3));
+            AddStep("move to playfield", () => InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre));
+            AddStep("start drum roll", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("drag to set duration", () => InputManager.MoveMouseTo(playfield.ScreenSpacePositionAtTime(placementTime + 500)));
+            AddStep("end drum roll", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("drum roll placed", () => EditorBeatmap.HitObjects.OfType<DrumRoll>().Single().Duration, () => Is.GreaterThan(0));
+
+            AddStep("seek forward", () =>
+            {
+                placementTime += 1000;
+                EditorClock.Seek(placementTime);
+            });
+            AddStep("choose swell tool", () => InputManager.Key(Key.Number4));
+            AddStep("move to playfield", () => InputManager.MoveMouseTo(playfield.ScreenSpaceDrawQuad.Centre));
+            AddStep("start swell", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("drag to set duration", () => InputManager.MoveMouseTo(playfield.ScreenSpacePositionAtTime(placementTime + 500)));
+            AddStep("end swell", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("swell placed", () => EditorBeatmap.HitObjects.OfType<Swell>().Single().Duration, () => Is.GreaterThan(0));
         }
     }
 }

--- a/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorPlacement.cs
+++ b/osu.Game.Rulesets.Taiko.Tests/Editor/TestSceneEditorPlacement.cs
@@ -40,12 +40,12 @@ namespace osu.Game.Rulesets.Taiko.Tests.Editor
         }
 
         [Test]
-        public void TestLockPlacementToHitAreaUsesClockTime()
+        public void TestLimitedDistanceSnapUsesClockTime()
         {
             TaikoPlayfield playfield = null!;
             double placementTime = 0;
 
-            AddStep("enable lock", () => config.SetValue(OsuSetting.EditorTaikoLockPlacementToHitArea, true));
+            AddStep("enable limited distance snap", () => config.SetValue(OsuSetting.EditorLimitedDistanceSnap, true));
             AddStep("disable auto seek", () => config.SetValue(OsuSetting.EditorAutoSeekOnPlacement, false));
             AddStep("clear objects", () => EditorBeatmap.Clear());
             AddStep("seek to first timing point", () =>

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
@@ -3,13 +3,21 @@
 
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Localisation;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Edit
 {
@@ -18,9 +26,43 @@ namespace osu.Game.Rulesets.Taiko.Edit
     {
         protected override bool ApplyHorizontalCentering => false;
 
+        private Bindable<bool> lockPlacementToHitArea = null!;
+        private readonly Bindable<TernaryState> lockPlacementState = new Bindable<TernaryState>();
+
         public TaikoHitObjectComposer(TaikoRuleset ruleset)
             : base(ruleset)
         {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager config)
+        {
+            LeftToolbox.Add(new EditorToolboxGroup("placement")
+            {
+                Child = new DrawableTernaryButton
+                {
+                    Current = lockPlacementState,
+                    Description = EditorStrings.TaikoLockPlacementToHitArea,
+                    CreateIcon = () => new SpriteIcon { Icon = FontAwesome.Solid.Lock },
+                }
+            });
+
+            lockPlacementToHitArea = config.GetBindable<bool>(OsuSetting.EditorTaikoLockPlacementToHitArea);
+            lockPlacementToHitArea.BindValueChanged(enabled => lockPlacementState.Value = enabled.NewValue ? TernaryState.True : TernaryState.False, true);
+            lockPlacementState.BindValueChanged(state => lockPlacementToHitArea.Value = state.NewValue == TernaryState.True, true);
+        }
+
+        public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        {
+            if (lockPlacementToHitArea.Value
+                && BlueprintContainer.CurrentHitObjectPlacement?.PlacementActive == PlacementBlueprint.PlacementState.Waiting)
+            {
+                var playfield = (TaikoPlayfield)Playfield;
+                double time = BeatSnapProvider.SnapTime(EditorClock.CurrentTime);
+                return new SnapResult(playfield.ScreenSpacePositionAtTime(time), time, playfield);
+            }
+
+            return base.FindSnappedPositionAndTime(screenSpacePosition);
         }
 
         protected override IReadOnlyList<CompositionTool> CompositionTools => new CompositionTool[]

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
@@ -4,18 +4,14 @@
 using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
-using osu.Game.Graphics.UserInterface;
-using osu.Game.Localisation;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -26,8 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
     {
         protected override bool ApplyHorizontalCentering => false;
 
-        private Bindable<bool> lockPlacementToHitArea = null!;
-        private readonly Bindable<TernaryState> lockPlacementState = new Bindable<TernaryState>();
+        private Bindable<bool> limitedDistanceSnap = null!;
 
         public TaikoHitObjectComposer(TaikoRuleset ruleset)
             : base(ruleset)
@@ -37,24 +32,12 @@ namespace osu.Game.Rulesets.Taiko.Edit
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            LeftToolbox.Add(new EditorToolboxGroup("placement")
-            {
-                Child = new DrawableTernaryButton
-                {
-                    Current = lockPlacementState,
-                    Description = EditorStrings.TaikoLockPlacementToHitArea,
-                    CreateIcon = () => new SpriteIcon { Icon = FontAwesome.Solid.Lock },
-                }
-            });
-
-            lockPlacementToHitArea = config.GetBindable<bool>(OsuSetting.EditorTaikoLockPlacementToHitArea);
-            lockPlacementToHitArea.BindValueChanged(enabled => lockPlacementState.Value = enabled.NewValue ? TernaryState.True : TernaryState.False, true);
-            lockPlacementState.BindValueChanged(state => lockPlacementToHitArea.Value = state.NewValue == TernaryState.True, true);
+            limitedDistanceSnap = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
         }
 
         public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
         {
-            if (lockPlacementToHitArea.Value
+            if (limitedDistanceSnap.Value
                 && BlueprintContainer.CurrentHitObjectPlacement?.PlacementActive == PlacementBlueprint.PlacementState.Waiting)
             {
                 var playfield = (TaikoPlayfield)Playfield;

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
     {
         protected override bool ApplyHorizontalCentering => false;
 
-        private Bindable<bool> limitedDistanceSnap = null!;
+        private Bindable<bool> limitPlacementToCurrentTime = null!;
 
         public TaikoHitObjectComposer(TaikoRuleset ruleset)
             : base(ruleset)
@@ -32,12 +32,12 @@ namespace osu.Game.Rulesets.Taiko.Edit
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            limitedDistanceSnap = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
+            limitPlacementToCurrentTime = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
         }
 
         public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
         {
-            if (limitedDistanceSnap.Value
+            if (limitPlacementToCurrentTime.Value
                 && BlueprintContainer.CurrentHitObjectPlacement?.PlacementActive == PlacementBlueprint.PlacementState.Waiting)
             {
                 var playfield = (TaikoPlayfield)Playfield;

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -203,6 +203,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorAutoSeekOnPlacement, true);
             SetDefault(OsuSetting.EditorLimitedDistanceSnap, false);
             SetDefault(OsuSetting.EditorShowSpeedChanges, false);
+            SetDefault(OsuSetting.EditorTaikoLockPlacementToHitArea, false);
             SetDefault(OsuSetting.EditorScaleOrigin, EditorOrigin.GridCentre);
             SetDefault(OsuSetting.EditorRotationOrigin, EditorOrigin.GridCentre);
             SetDefault(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges, true);
@@ -430,6 +431,7 @@ namespace osu.Game.Configuration
         ReplayPlaybackControlsExpanded,
         AutomaticallyDownloadMissingBeatmaps,
         EditorShowSpeedChanges,
+        EditorTaikoLockPlacementToHitArea,
         TouchDisableGameplayTaps,
         ModSelectTextSearchStartsActive,
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -203,7 +203,6 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.EditorAutoSeekOnPlacement, true);
             SetDefault(OsuSetting.EditorLimitedDistanceSnap, false);
             SetDefault(OsuSetting.EditorShowSpeedChanges, false);
-            SetDefault(OsuSetting.EditorTaikoLockPlacementToHitArea, false);
             SetDefault(OsuSetting.EditorScaleOrigin, EditorOrigin.GridCentre);
             SetDefault(OsuSetting.EditorRotationOrigin, EditorOrigin.GridCentre);
             SetDefault(OsuSetting.EditorAdjustExistingObjectsOnTimingChanges, true);
@@ -431,7 +430,6 @@ namespace osu.Game.Configuration
         ReplayPlaybackControlsExpanded,
         AutomaticallyDownloadMissingBeatmaps,
         EditorShowSpeedChanges,
-        EditorTaikoLockPlacementToHitArea,
         TouchDisableGameplayTaps,
         ModSelectTextSearchStartsActive,
 

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -145,6 +145,11 @@ namespace osu.Game.Localisation
         public static LocalisableString LimitedDistanceSnap => new TranslatableString(getKey(@"limited_distance_snap_grid"), @"Limit distance snap placement to current time");
 
         /// <summary>
+        /// "Lock to hit area"
+        /// </summary>
+        public static LocalisableString TaikoLockPlacementToHitArea => new TranslatableString(getKey(@"taiko_lock_to_hit_area"), @"Lock to hit area");
+
+        /// <summary>
         /// "Contract sidebars when not hovered"
         /// </summary>
         public static LocalisableString ContractSidebars => new TranslatableString(getKey(@"contract_sidebars"), @"Contract sidebars when not hovered");

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -140,14 +140,9 @@ namespace osu.Game.Localisation
         public static LocalisableString RotationSnapped(float newRotation) => new TranslatableString(getKey(@"rotation_snapped"), @"{0:0}° (snapped)", newRotation);
 
         /// <summary>
-        /// "Limit distance snap placement to current time"
+        /// "Limit placement to current time"
         /// </summary>
-        public static LocalisableString LimitedDistanceSnap => new TranslatableString(getKey(@"limited_distance_snap_grid"), @"Limit distance snap placement to current time");
-
-        /// <summary>
-        /// "Lock to hit area"
-        /// </summary>
-        public static LocalisableString TaikoLockPlacementToHitArea => new TranslatableString(getKey(@"taiko_lock_to_hit_area"), @"Lock to hit area");
+        public static LocalisableString LimitedDistanceSnap => new TranslatableString(getKey(@"limited_distance_snap_grid"), @"Limit placement to current time");
 
         /// <summary>
         /// "Contract sidebars when not hovered"

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -142,7 +142,7 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Limit placement to current time"
         /// </summary>
-        public static LocalisableString LimitedDistanceSnap => new TranslatableString(getKey(@"limited_distance_snap_grid"), @"Limit placement to current time");
+        public static LocalisableString LimitedDistanceSnap => new TranslatableString(getKey(@"limit_placement_to_current_time"), @"Limit placement to current time");
 
         /// <summary>
         /// "Contract sidebars when not hovered"

--- a/osu.Game/Rulesets/Edit/ScrollingHitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/ScrollingHitObjectComposer.cs
@@ -117,7 +117,7 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
-        public SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
+        public virtual SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
         {
             var scrollingPlayfield = PlayfieldAtScreenSpacePosition(screenSpacePosition) as ScrollingPlayfield;
             if (scrollingPlayfield == null)


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/discussions/38191

forwarding my thoughts from the issue for visibility:

I thought about this idea and I strongly think it'd improve familiarity for mappers coming from stable, it mimics stable's UX of focusing on the timeline when placing objects and not having to pay attention to placement on the playfield.

I tried mapping with it a bit and I found it significantly more natural as a long-time stable mapper trying to move to lazer.

one may wonder why not just have your cursor stationary on the hit area? from my experience mapping multiple times on lazer, I found this to be one extra thing to focus on having correct which gets annoying in prolonged sessions. the way this mimics stable's UX makes it all that natural IMO.

This is a default-off setting with it being under the "show speed changes" one.