### PR TITLE
Leaderboard visibility modes

### DIFF
--- a/osu.Game/Configuration/GameplayLeaderboardVisibilityMode.cs
+++ b/osu.Game/Configuration/GameplayLeaderboardVisibilityMode.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Localisation;
+using osu.Game.Localisation;
+
+namespace osu.Game.Configuration
+{
+    public enum GameplayLeaderboardVisibilityMode
+    {
+        [LocalisableDescription(typeof(GameplaySettingsStrings), nameof(GameplaySettingsStrings.ShowLeaderboardAlways))]
+        Always,
+
+        [LocalisableDescription(typeof(GameplaySettingsStrings), nameof(GameplaySettingsStrings.ShowLeaderboardMultiplayer))]
+        Multiplayer,
+
+        [LocalisableDescription(typeof(GameplaySettingsStrings), nameof(GameplaySettingsStrings.ShowLeaderboardNever))]
+        Never,
+    }
+}

--- a/osu.Game/Configuration/GameplayLeaderboardVisibilityModeExtensions.cs
+++ b/osu.Game/Configuration/GameplayLeaderboardVisibilityModeExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Game.Configuration
+{
+    public static class GameplayLeaderboardVisibilityModeExtensions
+    {
+        public static bool ShouldDisplay(this GameplayLeaderboardVisibilityMode mode, bool isMultiplayer)
+        {
+            return mode switch
+            {
+                GameplayLeaderboardVisibilityMode.Never => false,
+                GameplayLeaderboardVisibilityMode.Multiplayer => isMultiplayer,
+                GameplayLeaderboardVisibilityMode.Always => true,
+                _ => false,
+            };
+        }
+    }
+}

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -270,9 +270,9 @@ namespace osu.Game.Configuration
                 ),
                 new TrackedSetting<GameplayLeaderboardVisibilityMode>(OsuSetting.GameplayLeaderboardVisibilityMode, visibilityMode => new SettingDescription(
                     rawValue: visibilityMode,
-                    name: GlobalActionKeyBindingStrings.ToggleInGameLeaderboard,
+                    name: GlobalActionKeyBindingStrings.CycleInGameLeaderboardVisibilityMode,
                     value: visibilityMode.GetLocalisableDescription(),
-                    shortcut: LookupKeyBindings(GlobalAction.ToggleInGameLeaderboard))
+                    shortcut: LookupKeyBindings(GlobalAction.CycleInGameLeaderboardVisibilityMode))
                 ),
                 new TrackedSetting<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode, visibilityMode => new SettingDescription(
                     rawValue: visibilityMode,

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -152,7 +152,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.KeyOverlay, false);
             SetDefault(OsuSetting.ReplaySettingsOverlay, true);
             SetDefault(OsuSetting.ReplayPlaybackControlsExpanded, true);
-            SetDefault(OsuSetting.GameplayLeaderboard, true);
+            SetDefault(OsuSetting.GameplayLeaderboardVisibilityMode, GameplayLeaderboardVisibilityMode.Always);
             SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
 
             SetDefault(OsuSetting.FloatingComments, false);
@@ -267,10 +267,10 @@ namespace osu.Game.Configuration
                     value: disabledState ? CommonStrings.Disabled.ToLower() : CommonStrings.Enabled.ToLower(),
                     shortcut: LookupKeyBindings(GlobalAction.ToggleGameplayMouseButtons))
                 ),
-                new TrackedSetting<bool>(OsuSetting.GameplayLeaderboard, state => new SettingDescription(
-                    rawValue: state,
+                new TrackedSetting<GameplayLeaderboardVisibilityMode>(OsuSetting.GameplayLeaderboardVisibilityMode, visibilityMode => new SettingDescription(
+                    rawValue: visibilityMode,
                     name: GlobalActionKeyBindingStrings.ToggleInGameLeaderboard,
-                    value: state ? CommonStrings.Enabled.ToLower() : CommonStrings.Disabled.ToLower(),
+                    value: visibilityMode.GetLocalisableDescription(),
                     shortcut: LookupKeyBindings(GlobalAction.ToggleInGameLeaderboard))
                 ),
                 new TrackedSetting<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode, visibilityMode => new SettingDescription(
@@ -338,7 +338,8 @@ namespace osu.Game.Configuration
         LightenDuringBreaks,
         ShowStoryboard,
         KeyOverlay,
-        GameplayLeaderboard,
+        GameplayLeaderboard, // only used for migrating to `GameplayLeaderboardVisibilityMode`
+        GameplayLeaderboardVisibilityMode,
         PositionalHitsoundsLevel,
         AlwaysPlayFirstComboBreak,
         FloatingComments,

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -152,6 +152,7 @@ namespace osu.Game.Configuration
             SetDefault(OsuSetting.KeyOverlay, false);
             SetDefault(OsuSetting.ReplaySettingsOverlay, true);
             SetDefault(OsuSetting.ReplayPlaybackControlsExpanded, true);
+            SetDefault(OsuSetting.GameplayLeaderboard, true); // legacy migration only
             SetDefault(OsuSetting.GameplayLeaderboardVisibilityMode, GameplayLeaderboardVisibilityMode.Always);
             SetDefault(OsuSetting.AlwaysPlayFirstComboBreak, true);
 
@@ -339,7 +340,6 @@ namespace osu.Game.Configuration
         ShowStoryboard,
         KeyOverlay,
         GameplayLeaderboard, // only used for migrating to `GameplayLeaderboardVisibilityMode`
-        GameplayLeaderboardVisibilityMode,
         PositionalHitsoundsLevel,
         AlwaysPlayFirstComboBreak,
         FloatingComments,
@@ -470,5 +470,7 @@ namespace osu.Game.Configuration
 
         DashboardSortMode,
         DashboardDisplayStyle,
+
+        GameplayLeaderboardVisibilityMode,
     }
 }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -177,7 +177,7 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F3 }, GlobalAction.DecreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.IncreaseScrollSpeed),
             new KeyBinding(new[] { InputKey.Shift, InputKey.Tab }, GlobalAction.ToggleInGameInterface),
-            new KeyBinding(InputKey.Tab, GlobalAction.ToggleInGameLeaderboard),
+            new KeyBinding(InputKey.Tab, GlobalAction.CycleInGameLeaderboardVisibilityMode),
             new KeyBinding(InputKey.MouseMiddle, GlobalAction.PauseGameplay),
             new KeyBinding(InputKey.Control, GlobalAction.HoldForHUD),
             new KeyBinding(InputKey.Enter, GlobalAction.ToggleChatFocus),
@@ -442,8 +442,8 @@ namespace osu.Game.Input.Bindings
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleReplaySettings))]
         ToggleReplaySettings,
 
-        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.ToggleInGameLeaderboard))]
-        ToggleInGameLeaderboard,
+        [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.CycleInGameLeaderboardVisibilityMode))]
+        CycleInGameLeaderboardVisibilityMode,
 
         [LocalisableDescription(typeof(GlobalActionKeyBindingStrings), nameof(GlobalActionKeyBindingStrings.EditorToggleRotateControl))]
         EditorToggleRotateControl,

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -85,9 +85,24 @@ namespace osu.Game.Localisation
         public static LocalisableString AlwaysShowKeyOverlay => new TranslatableString(getKey(@"key_overlay"), @"Always show key overlay");
 
         /// <summary>
-        /// "Always show gameplay leaderboard"
+        /// "Gameplay leaderboard visibility mode"
         /// </summary>
-        public static LocalisableString AlwaysShowGameplayLeaderboard => new TranslatableString(getKey(@"gameplay_leaderboard"), @"Always show gameplay leaderboard");
+        public static LocalisableString GameplayLeaderboardVisibilityMode => new TranslatableString(getKey(@"gameplay_leaderboard_visibility_mode"), @"Gameplay leaderboard visibility mode");
+
+        /// <summary>
+        /// "Always"
+        /// </summary>
+        public static LocalisableString ShowLeaderboardAlways => new TranslatableString(getKey(@"show_leaderboard_always"), @"Always");
+
+        /// <summary>
+        /// "Multiplayer"
+        /// </summary>
+        public static LocalisableString ShowLeaderboardMultiplayer => new TranslatableString(getKey(@"show_leaderboard_multiplayer"), @"Multiplayer");
+
+        /// <summary>
+        /// "Disabled"
+        /// </summary>
+        public static LocalisableString ShowLeaderboardNever => new TranslatableString(getKey(@"show_leaderboard_never"), @"Disabled");
 
         /// <summary>
         /// "Always show hold for menu button"

--- a/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
+++ b/osu.Game/Localisation/GlobalActionKeyBindingStrings.cs
@@ -250,9 +250,9 @@ namespace osu.Game.Localisation
         public static LocalisableString ToggleInGameInterface => new TranslatableString(getKey(@"toggle_in_game_interface"), @"Toggle in-game interface");
 
         /// <summary>
-        /// "Toggle in-game leaderboard"
+        /// "Cycle in-game leaderboard visibility mode"
         /// </summary>
-        public static LocalisableString ToggleInGameLeaderboard => new TranslatableString(getKey(@"toggle_in_game_leaderboard"), @"Toggle in-game leaderboard");
+        public static LocalisableString CycleInGameLeaderboardVisibilityMode => new TranslatableString(getKey(@"cycle_in_game_leaderboard_visibility_mode"), @"Cycle in-game leaderboard visibility mode");
 
         /// <summary>
         /// "Toggle mod select"

--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1376,6 +1376,16 @@ namespace osu.Game
 
                 dialogOverlay.Push(new MigrateNewAudioDialog(wasAlreadyUsing));
             }
+
+            if (combined < 20260723)
+            {
+                bool oldValue = LocalConfig.Get<bool>(OsuSetting.GameplayLeaderboard);
+
+                LocalConfig.SetValue(
+                    OsuSetting.GameplayLeaderboardVisibilityMode,
+                    oldValue ? GameplayLeaderboardVisibilityMode.Always : GameplayLeaderboardVisibilityMode.Never
+                );
+            }
         }
 
         private void handleBackButton()

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/HUDSettings.cs
@@ -41,10 +41,10 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                 {
                     Keywords = new[] { "counter" },
                 },
-                new SettingsItemV2(new FormCheckBox
+                new SettingsItemV2(new FormEnumDropdown<GameplayLeaderboardVisibilityMode>
                 {
-                    Caption = GameplaySettingsStrings.AlwaysShowGameplayLeaderboard,
-                    Current = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard),
+                    Caption = GameplaySettingsStrings.GameplayLeaderboardVisibilityMode,
+                    Current = config.GetBindable<GameplayLeaderboardVisibilityMode>(OsuSetting.GameplayLeaderboardVisibilityMode)
                 }),
                 new SettingsItemV2(new FormCheckBox
                 {

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void updateVisibility()
         {
-            bool shouldDisplay = userScore != null && (leaderboardVisibility.Value.ShouldDisplay(true) || localUserPlayingState.Value == LocalUserPlayingState.Break);
+            bool shouldDisplay = userScore != null && (leaderboardVisibility.Value.ShouldDisplay(isMultiplayer: true) || localUserPlayingState.Value == LocalUserPlayingState.Break);
 
             State.Value = shouldDisplay ? Visibility.Visible : Visibility.Hidden;
         }

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
     {
         private readonly IBindable<APIUser> user = new Bindable<APIUser>();
         private readonly IBindableList<GameplayLeaderboardScore> scores = new BindableList<GameplayLeaderboardScore>();
-        private readonly Bindable<GameplayLeaderboardVisibilityMode> leaderboardVisibility = new();
+        private readonly Bindable<GameplayLeaderboardVisibilityMode> leaderboardVisibility = new Bindable<GameplayLeaderboardVisibilityMode>();
         private readonly IBindable<LocalUserPlayingState> localUserPlayingState = new Bindable<LocalUserPlayingState>();
 
         private readonly Bindable<int?> position = new Bindable<int?>();

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerPositionDisplay.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
     {
         private readonly IBindable<APIUser> user = new Bindable<APIUser>();
         private readonly IBindableList<GameplayLeaderboardScore> scores = new BindableList<GameplayLeaderboardScore>();
-        private readonly BindableBool showLeaderboard = new BindableBool();
+        private readonly Bindable<GameplayLeaderboardVisibilityMode> leaderboardVisibility = new();
         private readonly IBindable<LocalUserPlayingState> localUserPlayingState = new Bindable<LocalUserPlayingState>();
 
         private readonly Bindable<int?> position = new Bindable<int?>();
@@ -52,7 +52,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         {
             scores.BindTo(leaderboardProvider.Scores);
             user.BindTo(api.LocalUser);
-            configManager.BindWith(OsuSetting.GameplayLeaderboard, showLeaderboard);
+            configManager.BindWith(OsuSetting.GameplayLeaderboardVisibilityMode, leaderboardVisibility);
             localUserPlayingState.BindTo(gameplayState.PlayingState);
 
             AutoSizeAxes = Axes.Y;
@@ -105,7 +105,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
             user.BindValueChanged(_ => updateScoreBindings());
             scores.BindCollectionChanged((_, __) => updateScoreBindings(), true);
 
-            showLeaderboard.BindValueChanged(_ => updateVisibility());
+            leaderboardVisibility.BindValueChanged(_ => updateVisibility());
             localUserPlayingState.BindValueChanged(_ => updateVisibility(), true);
 
             State.BindValueChanged(_ => updatePosition());
@@ -126,7 +126,7 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
 
         private void updateVisibility()
         {
-            bool shouldDisplay = userScore != null && (showLeaderboard.Value || localUserPlayingState.Value == LocalUserPlayingState.Break);
+            bool shouldDisplay = userScore != null && (leaderboardVisibility.Value.ShouldDisplay(true) || localUserPlayingState.Value == LocalUserPlayingState.Break);
 
             State.Value = shouldDisplay ? Visibility.Visible : Visibility.Hidden;
         }

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -42,7 +42,7 @@ namespace osu.Game.Screens.Play.HUD
         private IGameplayLeaderboardProvider leaderboardProvider { get; set; } = null!;
 
         private readonly IBindableList<GameplayLeaderboardScore> scores = new BindableList<GameplayLeaderboardScore>();
-        private readonly Bindable<bool> configVisibility = new Bindable<bool>();
+        private readonly Bindable<GameplayLeaderboardVisibilityMode> configVisibility = new Bindable<GameplayLeaderboardVisibilityMode>();
         private readonly IBindable<LocalUserPlayingState> userPlayingState = new Bindable<LocalUserPlayingState>();
         private readonly IBindable<bool> holdingForHUD = new Bindable<bool>();
 
@@ -81,7 +81,7 @@ namespace osu.Game.Screens.Play.HUD
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config, GameplayState? gameplayState, HUDOverlay? hudOverlay)
         {
-            config.BindWith(OsuSetting.GameplayLeaderboard, configVisibility);
+            config.BindWith(OsuSetting.GameplayLeaderboardVisibilityMode, configVisibility);
 
             if (gameplayState != null)
                 userPlayingState.BindTo(gameplayState.PlayingState);
@@ -115,7 +115,8 @@ namespace osu.Game.Screens.Play.HUD
             if (Flow.Alpha < 1)
                 scroll.ScrollToStart(false);
 
-            Flow.FadeTo(player?.Configuration.ShowLeaderboard != false && (configVisibility.Value || AlwaysShown) ? 1 : 0, 100, Easing.OutQuint);
+            Flow.FadeTo(configVisibility.Value.ShouldDisplay(leaderboardProvider is MultiplayerLeaderboardProvider) ? 1 : 0, 100, Easing.OutQuint);
+
             expanded.Value = !CollapseDuringGameplay.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
         }
 

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -115,8 +115,7 @@ namespace osu.Game.Screens.Play.HUD
             if (Flow.Alpha < 1)
                 scroll.ScrollToStart(false);
 
-            Flow.FadeTo(player?.Configuration.ShowLeaderboard != false
-                && configVisibility.Value.ShouldDisplay(leaderboardProvider is MultiplayerLeaderboardProvider) ? 1 : 0, 100, Easing.OutQuint);
+            Flow.FadeTo(player?.Configuration.ShowLeaderboard != false && configVisibility.Value.ShouldDisplay(leaderboardProvider is MultiplayerLeaderboardProvider) ? 1 : 0, 100, Easing.OutQuint);
 
             expanded.Value = !CollapseDuringGameplay.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
         }

--- a/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
+++ b/osu.Game/Screens/Play/HUD/DrawableGameplayLeaderboard.cs
@@ -115,7 +115,8 @@ namespace osu.Game.Screens.Play.HUD
             if (Flow.Alpha < 1)
                 scroll.ScrollToStart(false);
 
-            Flow.FadeTo(configVisibility.Value.ShouldDisplay(leaderboardProvider is MultiplayerLeaderboardProvider) ? 1 : 0, 100, Easing.OutQuint);
+            Flow.FadeTo(player?.Configuration.ShowLeaderboard != false
+                && configVisibility.Value.ShouldDisplay(leaderboardProvider is MultiplayerLeaderboardProvider) ? 1 : 0, 100, Easing.OutQuint);
 
             expanded.Value = !CollapseDuringGameplay.Value || userPlayingState.Value != LocalUserPlayingState.Playing || holdingForHUD.Value;
         }

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -421,9 +421,11 @@ namespace osu.Game.Screens.Play
                         case GameplayLeaderboardVisibilityMode.Never:
                             configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Always;
                             break;
+
                         case GameplayLeaderboardVisibilityMode.Always:
                             configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Multiplayer;
                             break;
+
                         case GameplayLeaderboardVisibilityMode.Multiplayer:
                             configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Never;
                             break;

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Screens.Play
         public Bindable<bool> ShowHud { get; } = new BindableBool();
 
         private Bindable<HUDVisibilityMode> configVisibilityMode;
-        private Bindable<bool> configLeaderboardVisibility;
+        private Bindable<GameplayLeaderboardVisibilityMode> configLeaderboardVisibilityMode;
 
         private readonly BindableBool replayLoaded = new BindableBool();
 
@@ -194,7 +194,7 @@ namespace osu.Game.Screens.Play
             ModDisplay.Current.Value = mods;
 
             configVisibilityMode = config.GetBindable<HUDVisibilityMode>(OsuSetting.HUDVisibilityMode);
-            configLeaderboardVisibility = config.GetBindable<bool>(OsuSetting.GameplayLeaderboard);
+            configLeaderboardVisibilityMode = config.GetBindable<GameplayLeaderboardVisibilityMode>(OsuSetting.GameplayLeaderboardVisibilityMode);
 
             if (configVisibilityMode.Value == HUDVisibilityMode.Never && !hasShownNotificationOnce)
             {
@@ -416,7 +416,18 @@ namespace osu.Game.Screens.Play
                     return true;
 
                 case GlobalAction.ToggleInGameLeaderboard:
-                    configLeaderboardVisibility.Value = !configLeaderboardVisibility.Value;
+                    switch (configLeaderboardVisibilityMode.Value)
+                    {
+                        case GameplayLeaderboardVisibilityMode.Never:
+                            configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Multiplayer;
+                            break;
+                        case GameplayLeaderboardVisibilityMode.Multiplayer:
+                            configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Always;
+                            break;
+                        case GameplayLeaderboardVisibilityMode.Always:
+                            configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Never;
+                            break;
+                    }
                     return true;
             }
 

--- a/osu.Game/Screens/Play/HUDOverlay.cs
+++ b/osu.Game/Screens/Play/HUDOverlay.cs
@@ -415,16 +415,16 @@ namespace osu.Game.Screens.Play
 
                     return true;
 
-                case GlobalAction.ToggleInGameLeaderboard:
+                case GlobalAction.CycleInGameLeaderboardVisibilityMode:
                     switch (configLeaderboardVisibilityMode.Value)
                     {
                         case GameplayLeaderboardVisibilityMode.Never:
-                            configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Multiplayer;
-                            break;
-                        case GameplayLeaderboardVisibilityMode.Multiplayer:
                             configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Always;
                             break;
                         case GameplayLeaderboardVisibilityMode.Always:
+                            configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Multiplayer;
+                            break;
+                        case GameplayLeaderboardVisibilityMode.Multiplayer:
                             configLeaderboardVisibilityMode.Value = GameplayLeaderboardVisibilityMode.Never;
                             break;
                     }


### PR DESCRIPTION
# Option to display leaderboard in multiplayer games only

Expand the "Always show gameplay leaderboard" toggle option into a dropdown to allow users to display the gameplay leaderboard in multiplayer games, but have it disabled in singleplayer.

[GameplayLeaderboardVisibilityModeExtensions.cs](https://github.com/ppy/osu/compare/master...Nqtural:osu:feat/leaderboard-visibility-modes?expand=1#diff-d44a84ed8e55a71eec76ffbd07563b705a1de77f4da67304ee05050d93fb2759) was added to avoid logic duplication as this logic has two consumers: [DrawableGameplayLeaderboard.cs](https://github.com/ppy/osu/compare/master...Nqtural:osu:feat/leaderboard-visibility-modes?expand=1#diff-35741532593548b65392107e909ae35d83183a381a307d8c4b904a5f5540b57c) and [MultiplayerPositionDisplay.cs](https://github.com/ppy/osu/compare/master...Nqtural:osu:feat/leaderboard-visibility-modes?expand=1#diff-1c4b6571b202d300f45ac2c3f91b49aa32610177bd00c6d6cc77dcdfc28e3679).

## Keybinding

The old keybinding for toggling the leaderboard now cycles between the different visibility modes and is thus renamed to "Cycle in-game leaderboard visibility mode".

## Migration

Users who have "Always show gameplay leaderboard" toggled on (old default behavior) migrate to "Always", which is both the new default and identical to previous behavior. Users who have the option toggled off migrate to "Disabled", which is also identical to previous behavior.

The keybinding remains the same without needing a migration.