### PR TITLE
Fix slider velocity preset parsing for comma-decimal locales

### DIFF
--- a/osu.Game/Beatmaps/Formats/Parsing.cs
+++ b/osu.Game/Beatmaps/Formats/Parsing.cs
@@ -17,8 +17,8 @@ namespace osu.Game.Beatmaps.Formats
 
         public static float ParseFloat(string input, float parseLimit = (float)MAX_PARSE_VALUE, bool allowNaN = false)
         {
-            string sanitizedInput = input.Replace(',','.');
-            float output = float.Parse(sanitizedInput, NumberStyles.Float,CultureInfo.InvariantCulture);
+            string sanitizedInput = input.Replace(',', '.');
+            float output = float.Parse(sanitizedInput, NumberStyles.Float, CultureInfo.InvariantCulture);
 
             if (output < -parseLimit) throw new OverflowException("Value is too low");
             if (output > parseLimit) throw new OverflowException("Value is too high");

--- a/osu.Game/Beatmaps/Formats/Parsing.cs
+++ b/osu.Game/Beatmaps/Formats/Parsing.cs
@@ -17,7 +17,8 @@ namespace osu.Game.Beatmaps.Formats
 
         public static float ParseFloat(string input, float parseLimit = (float)MAX_PARSE_VALUE, bool allowNaN = false)
         {
-            float output = float.Parse(input, CultureInfo.InvariantCulture);
+            string sanitizedInput = input.Replace(',','.');
+            float output = float.Parse(sanitizedInput, NumberStyles.Float,CultureInfo.InvariantCulture);
 
             if (output < -parseLimit) throw new OverflowException("Value is too low");
             if (output > parseLimit) throw new OverflowException("Value is too high");


### PR DESCRIPTION
https://github.com/ppy/osu/issues/38437 regarding this issue. The code was defaulting to defauly decimal value for all languages including german and czhech. leading to the multipliers to show up as 75,00 rather the 0,75 or 1,50. I fixed this via unding the parsing to handlre and account for both commas and decial based on the users locale.

I made sure that it didnt mess with any other code intact on other languages. Wouldf love some feedback and what do you guys think. (My first PR :))

<img width="1023" height="575" alt="image" src="https://github.com/user-attachments/assets/cd1de0a7-d500-4b1a-9d2d-a96aefbc3735" />
<img width="1024" height="576" alt="image" src="https://github.com/user-attachments/assets/a8d11283-6963-44f1-bb40-c796845f427c" />
