### PR TITLE
Improve legibility and understandability of some settings

### DIFF
--- a/osu.Game/Localisation/GeneralSettingsStrings.cs
+++ b/osu.Game/Localisation/GeneralSettingsStrings.cs
@@ -75,6 +75,11 @@ namespace osu.Game.Localisation
         public static LocalisableString ChangeFolderLocation => new TranslatableString(getKey(@"change_folder_location"), @"Change folder location...");
 
         /// <summary>
+        /// "Move your current data to a new folder, or point osu! to backed-up data at an existing location."
+        /// </summary>
+        public static LocalisableString ChangeFolderLocationTooltip => new TranslatableString(getKey(@"change_folder_location_tooltip"), @"Move your current data to a new folder, or point osu! to backed-up data at an existing location.");
+
+        /// <summary>
         /// "Run setup wizard"
         /// </summary>
         public static LocalisableString RunSetupWizard => new TranslatableString(getKey(@"run_setup_wizard"), @"Run setup wizard");

--- a/osu.Game/Localisation/GraphicsSettingsStrings.cs
+++ b/osu.Game/Localisation/GraphicsSettingsStrings.cs
@@ -130,9 +130,9 @@ namespace osu.Game.Localisation
         public static LocalisableString ShowCursorInScreenshots => new TranslatableString(getKey(@"show_cursor_in_screenshots"), @"Show menu cursor in screenshots");
 
         /// <summary>
-        /// "Video"
+        /// "Video Playback"
         /// </summary>
-        public static LocalisableString VideoHeader => new TranslatableString(getKey(@"video_header"), @"Video");
+        public static LocalisableString VideoHeader => new TranslatableString(getKey(@"video_header"), @"Video Playback");
 
         /// <summary>
         /// "Use hardware acceleration"

--- a/osu.Game/Localisation/OnlineSettingsStrings.cs
+++ b/osu.Game/Localisation/OnlineSettingsStrings.cs
@@ -50,14 +50,14 @@ namespace osu.Game.Localisation
         public static LocalisableString DiscordRichPresence => new TranslatableString(getKey(@"discord_rich_presence"), @"Discord Rich Presence");
 
         /// <summary>
-        /// "Web"
+        /// "External content and downloads"
         /// </summary>
-        public static LocalisableString WebHeader => new TranslatableString(getKey(@"web_header"), @"Web");
+        public static LocalisableString ContentDownloadsHeader => new TranslatableString(getKey(@"content_and_downloads"), @"External content and downloads");
 
         /// <summary>
-        /// "Warn about opening external links"
+        /// "Warn before opening external links"
         /// </summary>
-        public static LocalisableString ExternalLinkWarning => new TranslatableString(getKey(@"external_link_warning"), @"Warn about opening external links");
+        public static LocalisableString ExternalLinkWarning => new TranslatableString(getKey(@"external_link_warning"), @"Warn before opening external links");
 
         /// <summary>
         /// "Prefer downloads without video"
@@ -90,9 +90,9 @@ namespace osu.Game.Localisation
         public static LocalisableString DiscordPresenceOff => new TranslatableString(getKey(@"discord_presence_off"), @"Off");
 
         /// <summary>
-        /// "Hide country flags"
+        /// "Hide all country flags"
         /// </summary>
-        public static LocalisableString HideCountryFlags => new TranslatableString(getKey(@"hide_country_flags"), @"Hide country flags");
+        public static LocalisableString HideCountryFlags => new TranslatableString(getKey(@"hide_country_flags"), @"Hide all country flags");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Overlays/Settings/Sections/General/InstallationSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/General/InstallationSettings.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
@@ -31,6 +33,26 @@ namespace osu.Game.Overlays.Settings.Sections.General
             {
                 Text = GeneralSettingsStrings.ChangeFolderLocation,
                 Action = () => game?.PerformFromScreen(menu => menu.Push(new MigrationSelectScreen()))
+            });
+
+            // This is a temporary stand-in until we have a setup for `SettingsItemV2` which can handle buttons.
+            Add(new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = SettingsPanel.CONTENT_PADDING,
+                Children = new Drawable[]
+                {
+                    new SettingsNote
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Margin = new MarginPadding { Top = -SettingsSection.ITEM_SPACING_V2 },
+                        Current =
+                        {
+                            Value = new SettingsNote.Data(GeneralSettingsStrings.ChangeFolderLocationTooltip, SettingsNote.Type.Informational)
+                        }
+                    }
+                }
             });
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Online/AlertsAndPrivacySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/AlertsAndPrivacySettings.cs
@@ -35,11 +35,6 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                     HintText = OnlineSettingsStrings.NotifyOnFriendPresenceChangeTooltip,
                     Current = config.GetBindable<bool>(OsuSetting.NotifyOnFriendPresenceChange),
                 }),
-                new SettingsItemV2(new FormCheckBox
-                {
-                    Caption = OnlineSettingsStrings.HideCountryFlags,
-                    Current = config.GetBindable<bool>(OsuSetting.HideCountryFlags)
-                }),
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Online/ContentDownloadSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Online/ContentDownloadSettings.cs
@@ -10,9 +10,9 @@ using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.Online
 {
-    public partial class WebSettings : SettingsSubsection
+    public partial class ContentDownloadSettings : SettingsSubsection
     {
-        protected override LocalisableString Header => OnlineSettingsStrings.WebHeader;
+        protected override LocalisableString Header => OnlineSettingsStrings.ContentDownloadsHeader;
 
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
@@ -47,7 +47,12 @@ namespace osu.Game.Overlays.Settings.Sections.Online
                 })
                 {
                     Keywords = new[] { "nsfw", "18+", "offensive" },
-                }
+                },
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = OnlineSettingsStrings.HideCountryFlags,
+                    Current = config.GetBindable<bool>(OsuSetting.HideCountryFlags)
+                }),
             };
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/OnlineSection.cs
@@ -24,7 +24,7 @@ namespace osu.Game.Overlays.Settings.Sections
         {
             Children = new Drawable[]
             {
-                new WebSettings(),
+                new ContentDownloadSettings(),
                 new AlertsAndPrivacySettings(),
             };
 


### PR DESCRIPTION
### e7c048731ac31d6fa007624a610664eb0df94fa0 Update various terms and locations of some settings

Just some stuff I saw and couldn't ignore. Cases where localisation keys are not changed are intentional (will not remove translations) because they are very minor changes.

### b760afe0e5dde6f5d25fbfe674ca4f03fe8a3809 Add a note about using "change folder location" for existing data

Has come up a few times in help channels. I doubt this will do much to shift discoverability, but better than nothing?