### PR TITLE
Fix multiple instances of culture variance in format encoding & decoding

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyBeatmapEncoderTest.cs
@@ -271,6 +271,31 @@ namespace osu.Game.Tests.Beatmaps.Formats
             Assert.That(decodedAfterEncode.Beatmap.HitObjects[2].Samples[0].UseBeatmapSamples, Is.True);
         }
 
+        [Test]
+        [SetCulture("pl-PL")]
+        public void TestSliderVelocityPresetCultureInvariance()
+        {
+            var beatmap = new Beatmap();
+
+            var encoded = EncodeToLegacy(new BeatmapComponents(beatmap, new TestLegacySkin(beatmaps_resource_store, string.Empty), new Storyboard()));
+            var decodedAfterEncode = DecodeFromLegacy(encoded, beatmaps_resource_store, string.Empty);
+
+            Assert.That(decodedAfterEncode.Beatmap.SliderVelocityPresets, Is.EquivalentTo(beatmap.SliderVelocityPresets));
+        }
+
+        [TestCaseSource(nameof(allBeatmaps))]
+        [SetCulture("pl-PL")]
+        public void TestCultureInvariance(string name)
+        {
+            var decoded = DecodeFromLegacy(beatmaps_resource_store.GetStream(name), beatmaps_resource_store, name);
+            var decodedAfterEncode = DecodeFromLegacy(EncodeToLegacy(decoded), beatmaps_resource_store, name);
+
+            Sort(decoded.Beatmap);
+            Sort(decodedAfterEncode.Beatmap);
+
+            CompareBeatmaps(decoded, decodedAfterEncode);
+        }
+
         private static bool areComboColoursEqual(IHasComboColours a, IHasComboColours b)
         {
             // equal to null, no need to SequenceEqual

--- a/osu.Game.Tests/Beatmaps/Formats/LegacySkinEncoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacySkinEncoderTest.cs
@@ -23,7 +23,13 @@ namespace osu.Game.Tests.Beatmaps.Formats
         private static IEnumerable<string> allIniFiles = resource_store.GetAvailableResources().Where(res => res.EndsWith(".ini", StringComparison.Ordinal));
 
         [TestCaseSource(nameof(allIniFiles))]
-        public void TestEncodeDecodeStability(string name)
+        public void TestEncodeDecodeStability(string name) => runEncodeDecodeStabilityCheck(name);
+
+        [TestCaseSource(nameof(allIniFiles))]
+        [SetCulture("pl-PL")]
+        public void TestCultureInvariance(string name) => runEncodeDecodeStabilityCheck(name);
+
+        private void runEncodeDecodeStabilityCheck(string name)
         {
             using var sourceStream = resource_store.GetStream(name);
 

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapDecoder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using osu.Framework.Extensions;
@@ -316,7 +317,7 @@ namespace osu.Game.Beatmaps.Formats
                 case @"Bookmarks":
                     beatmap.Bookmarks = pair.Value.Split(',').Select(v =>
                     {
-                        bool result = int.TryParse(v, out int val);
+                        bool result = int.TryParse(v, NumberStyles.Integer, CultureInfo.InvariantCulture, out int val);
                         return new { result, val };
                     }).Where(p => p.result).Select(p => p.val).ToArray();
                     break;
@@ -324,7 +325,7 @@ namespace osu.Game.Beatmaps.Formats
                 case @"VelocityPresets":
                     beatmap.SliderVelocityPresets = pair.Value.Split(',').Select(v =>
                     {
-                        bool result = double.TryParse(v, out double val);
+                        bool result = double.TryParse(v, NumberStyles.Float, CultureInfo.InvariantCulture, out double val);
                         return new { result, val };
                     }).Where(p => p.result).Select(p => p.val).ToArray();
                     break;

--- a/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyBeatmapEncoder.cs
@@ -124,12 +124,12 @@ namespace osu.Game.Beatmaps.Formats
             writer.WriteLine("[Editor]");
 
             if (beatmap.Bookmarks.Length > 0)
-                writer.WriteLine(FormattableString.Invariant($"Bookmarks: {string.Join(',', beatmap.Bookmarks)}"));
+                writer.WriteLine(FormattableString.Invariant($"Bookmarks: {string.Join(',', beatmap.Bookmarks.Select(b => b.ToString(CultureInfo.InvariantCulture)))}"));
             writer.WriteLine(FormattableString.Invariant($"DistanceSpacing: {beatmap.DistanceSpacing}"));
             writer.WriteLine(FormattableString.Invariant($"BeatDivisor: {beatmap.BeatmapInfo.BeatDivisor}"));
             writer.WriteLine(FormattableString.Invariant($"GridSize: {beatmap.GridSize}"));
             writer.WriteLine(FormattableString.Invariant($"TimelineZoom: {beatmap.TimelineZoom}"));
-            writer.WriteLine(FormattableString.Invariant($@"VelocityPresets: {string.Join(',', beatmap.SliderVelocityPresets)}"));
+            writer.WriteLine(FormattableString.Invariant($@"VelocityPresets: {string.Join(',', beatmap.SliderVelocityPresets.Select(sv => sv.ToString(CultureInfo.InvariantCulture)))}"));
         }
 
         private void handleMetadata(TextWriter writer)

--- a/osu.Game/Skinning/LegacySkinEncoder.cs
+++ b/osu.Game/Skinning/LegacySkinEncoder.cs
@@ -191,7 +191,8 @@ namespace osu.Game.Skinning
 
         private float undoPositionScaleFactor(float f) => f / LegacyManiaSkinConfiguration.POSITION_SCALE_FACTOR;
 
-        private string enumerableToString<T>(IEnumerable<T> ts)
-            => string.Join(',', ts.Select(t => t?.ToString()));
+        private string enumerableToString<T>(IEnumerable<T?> ts)
+            where T : IFormattable
+            => string.Join(',', ts.Select(t => t?.ToString(null, CultureInfo.InvariantCulture)));
     }
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38437.

`string.Join()` is not safe to use on arbitrary objects even inside of `FormattableString.Invariant()` invocations. What actually happens is that the result of `string.Join()` is computed first before any of the `FormattableString.Invariant()` machinery kicks in, which means that the values being joined will be formatted using the ambient culture rather than the invariant one.

Additionally the hand-rolled parsing in `LegacyBeatmapDecoder` (done manually because `Parsing` helper methods do not return whether the parsing failed) was culture-sensitive.