### PR TITLE
Add store for caching online assets to disk

### DIFF
--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -110,6 +110,13 @@ namespace osu.Game.Database
         /// </summary>
         private readonly SemaphoreSlim realmRetrievalLock = new SemaphoreSlim(1);
 
+        /// <summary>
+        /// This <see cref="CancellationTokenSource"/> is cancelled on disposal
+        /// so that all callers of <see cref="getRealmInstance"/> who are blocked on <see cref="realmRetrievalLock"/>
+        /// can hard-fail the retrieval rather than spin on the semaphore forever.
+        /// </summary>
+        private readonly CancellationTokenSource realmRetrievalCancellation = new CancellationTokenSource();
+
         private readonly CountdownEvent pendingAsyncOperations = new CountdownEvent(0);
 
         /// <summary>
@@ -778,7 +785,7 @@ namespace osu.Game.Database
                 // Ensure that the thread that currently has the `realmRetrievalLock` can retrieve nested contexts and not deadlock on itself.
                 if (!currentThreadHasRealmRetrievalLock.Value)
                 {
-                    realmRetrievalLock.Wait();
+                    realmRetrievalLock.Wait(realmRetrievalCancellation.Token);
                     currentThreadHasRealmRetrievalLock.Value = true;
                     tookSemaphoreLock = true;
                 }
@@ -1515,6 +1522,8 @@ namespace osu.Game.Database
                 // intentionally block realm retrieval indefinitely. this ensures that nothing can start consuming a new instance after disposal.
                 realmRetrievalLock.Wait();
                 realmRetrievalLock.Dispose();
+                // also unblock all readers who may be spinning on realm retrieval.
+                realmRetrievalCancellation.Cancel();
 
                 isDisposed = true;
             }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -781,8 +781,6 @@ namespace osu.Game.Database
                     realmRetrievalLock.Wait();
                     currentThreadHasRealmRetrievalLock.Value = true;
                     tookSemaphoreLock = true;
-
-                    ObjectDisposedException.ThrowIf(isDisposed, this);
                 }
                 else
                 {

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -778,7 +778,7 @@ namespace osu.Game.Database
                 // Ensure that the thread that currently has the `realmRetrievalLock` can retrieve nested contexts and not deadlock on itself.
                 if (!currentThreadHasRealmRetrievalLock.Value)
                 {
-                    realmRetrievalLock.Wait(10000);
+                    realmRetrievalLock.Wait();
                     currentThreadHasRealmRetrievalLock.Value = true;
                     tookSemaphoreLock = true;
                 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -781,6 +781,8 @@ namespace osu.Game.Database
                     realmRetrievalLock.Wait();
                     currentThreadHasRealmRetrievalLock.Value = true;
                     tookSemaphoreLock = true;
+
+                    ObjectDisposedException.ThrowIf(isDisposed, this);
                 }
                 else
                 {

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -778,7 +778,7 @@ namespace osu.Game.Database
                 // Ensure that the thread that currently has the `realmRetrievalLock` can retrieve nested contexts and not deadlock on itself.
                 if (!currentThreadHasRealmRetrievalLock.Value)
                 {
-                    realmRetrievalLock.Wait();
+                    realmRetrievalLock.Wait(10000);
                     currentThreadHasRealmRetrievalLock.Value = true;
                     tookSemaphoreLock = true;
                 }

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -101,8 +101,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2026-07-28    Add RealmOnlineAsset.
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -412,6 +413,12 @@ namespace osu.Game.Database
 
                     foreach (var s in pendingDeletePresets)
                         realm.Remove(s);
+
+                    var onlineAssetAccessCutoff = DateTimeOffset.Now.AddMonths(-1);
+                    var pendingDeleteOnlineAssets = realm.All<RealmOnlineAsset>().Where(a => a.LastAccessed < onlineAssetAccessCutoff);
+
+                    foreach (var a in pendingDeleteOnlineAssets)
+                        realm.Remove(a);
 
                     transaction.Commit();
                 }

--- a/osu.Game/Database/RealmObjectExtensions.cs
+++ b/osu.Game/Database/RealmObjectExtensions.cs
@@ -180,6 +180,7 @@ namespace osu.Game.Database
             c.CreateMap<RealmUser, RealmUser>();
             c.CreateMap<RealmFile, RealmFile>();
             c.CreateMap<RealmNamedFileUsage, RealmNamedFileUsage>();
+            c.CreateMap<RealmOnlineAsset, RealmOnlineAsset>();
             c.CreateMap<SkinInfo, SkinInfo>();
         }
 

--- a/osu.Game/Graphics/OnlineAssetCachingStore.cs
+++ b/osu.Game/Graphics/OnlineAssetCachingStore.cs
@@ -1,0 +1,87 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Game.Database;
+using osu.Game.Extensions;
+using osu.Game.Models;
+using osu.Game.Online;
+using Realms;
+
+namespace osu.Game.Graphics
+{
+    /// <summary>
+    /// <para>
+    /// Store for retrieval and caching of assets (background, avatars, covers) retrieved from the web to disk.
+    /// </para>
+    /// <para>
+    /// This store assumes relies on the uniqueness of the URL of retrieved assets to determine identity.
+    /// Therefore, this store <b>MUST</b> only be used with URLs that are content-addressed in some way
+    /// (by containing a content-based hash in the filename, or a cache-busting query string based on time of last update).
+    /// </para>
+    /// <para>
+    /// This store <b>MUST NOT</b> be used with URLs containing naive cache-busting strings (e.g. <c>test.jpg?TIMESTAMP</c>)
+    /// as it both makes the caching ineffective <b>AND</b> trashes the cache with entries that will never be used again.
+    /// </para>
+    /// </summary>
+    public class OnlineAssetCachingStore
+    {
+        private readonly RealmAccess realmAccess;
+        private readonly OnlineStore onlineStore;
+        private readonly RealmFileStore fileStore;
+        private readonly LargeTextureStore largeTextureStore;
+
+        public OnlineAssetCachingStore(GameHost host, RealmAccess realmAccess)
+        {
+            this.realmAccess = realmAccess;
+            onlineStore = new TrustedDomainOnlineStore();
+            fileStore = new RealmFileStore(realmAccess, host.Storage);
+            largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(new StorageBackedResourceStore(fileStore.Storage)));
+        }
+
+        public Texture? Get(string url)
+        {
+            var existingAsset = realmAccess.Write(r =>
+            {
+                var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
+                if (a != null)
+                    a.LastAccessed = DateTimeOffset.Now;
+                return a?.Detach();
+            });
+
+            if (existingAsset == null)
+            {
+                var onlineStream = onlineStore.GetStream(url);
+
+                if (onlineStream == null)
+                    return null;
+
+                existingAsset = realmAccess.Write(r =>
+                {
+                    var file = fileStore.Add(onlineStream, r);
+                    var newAsset = new RealmOnlineAsset(file, url);
+                    r.Add(newAsset);
+                    return newAsset.Detach();
+                });
+            }
+            else
+            {
+                Logger.Log($"Online asset {url} retrieved from {nameof(OnlineAssetCachingStore)}.", LoggingTarget.Network);
+            }
+
+            string path = existingAsset.File.File.GetStoragePath();
+            return largeTextureStore.Get(path);
+        }
+
+        public void Dispose()
+        {
+            onlineStore.Dispose();
+            largeTextureStore.Dispose();
+        }
+    }
+}

--- a/osu.Game/Graphics/OnlineAssetCachingStore.cs
+++ b/osu.Game/Graphics/OnlineAssetCachingStore.cs
@@ -29,12 +29,14 @@ namespace osu.Game.Graphics
     /// as it both makes the caching ineffective <b>AND</b> trashes the cache with entries that will never be used again.
     /// </para>
     /// </summary>
-    public class OnlineAssetCachingStore
+    public sealed class OnlineAssetCachingStore
     {
         private readonly RealmAccess realmAccess;
         private readonly OnlineStore onlineStore;
         private readonly RealmFileStore fileStore;
         private readonly LargeTextureStore largeTextureStore;
+
+        private bool disposed;
 
         public OnlineAssetCachingStore(GameHost host, RealmAccess realmAccess)
         {
@@ -46,6 +48,8 @@ namespace osu.Game.Graphics
 
         public Texture? Get(string url)
         {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
             var existingAsset = realmAccess.Write(r =>
             {
                 var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
@@ -82,6 +86,7 @@ namespace osu.Game.Graphics
         {
             onlineStore.Dispose();
             largeTextureStore.Dispose();
+            disposed = true;
         }
     }
 }

--- a/osu.Game/Graphics/OnlineAssetCachingStore.cs
+++ b/osu.Game/Graphics/OnlineAssetCachingStore.cs
@@ -29,14 +29,12 @@ namespace osu.Game.Graphics
     /// as it both makes the caching ineffective <b>AND</b> trashes the cache with entries that will never be used again.
     /// </para>
     /// </summary>
-    public sealed class OnlineAssetCachingStore
+    public class OnlineAssetCachingStore
     {
         private readonly RealmAccess realmAccess;
         private readonly OnlineStore onlineStore;
         private readonly RealmFileStore fileStore;
         private readonly LargeTextureStore largeTextureStore;
-
-        private bool disposed;
 
         public OnlineAssetCachingStore(GameHost host, RealmAccess realmAccess)
         {
@@ -48,8 +46,6 @@ namespace osu.Game.Graphics
 
         public Texture? Get(string url)
         {
-            ObjectDisposedException.ThrowIf(disposed, this);
-
             var existingAsset = realmAccess.Write(r =>
             {
                 var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
@@ -86,7 +82,6 @@ namespace osu.Game.Graphics
         {
             onlineStore.Dispose();
             largeTextureStore.Dispose();
-            disposed = true;
         }
     }
 }

--- a/osu.Game/Models/RealmOnlineAsset.cs
+++ b/osu.Game/Models/RealmOnlineAsset.cs
@@ -26,6 +26,7 @@ namespace osu.Game.Models
         /// Assets that have not been accessed for over a month are purged
         /// (<see cref="RealmAccess.cleanupPendingDeletions"/>).
         /// </remarks>
+        [Indexed]
         public DateTimeOffset LastAccessed { get; set; } = DateTimeOffset.Now;
 
         [UsedImplicitly]

--- a/osu.Game/Models/RealmOnlineAsset.cs
+++ b/osu.Game/Models/RealmOnlineAsset.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using JetBrains.Annotations;
+using osu.Game.Database;
+using Realms;
+
+namespace osu.Game.Models
+{
+    /// <summary>
+    /// Describes an online asset (background image, user avatar, cover...) which is persisted to disk
+    /// to reduce the number of online requests and shorten retrieval time.
+    /// </summary>
+    public class RealmOnlineAsset : RealmObject
+    {
+        /// <summary>
+        /// Contains information about the original URL of the file and its location on disk.
+        /// </summary>
+        public RealmNamedFileUsage File { get; set; } = null!;
+
+        /// <summary>
+        /// Contains the last time of access of this asset.
+        /// </summary>
+        /// <remarks>
+        /// Assets that have not been accessed for over a month are purged
+        /// (<see cref="RealmAccess.cleanupPendingDeletions"/>).
+        /// </remarks>
+        public DateTimeOffset LastAccessed { get; set; } = DateTimeOffset.Now;
+
+        [UsedImplicitly]
+        private RealmOnlineAsset()
+        {
+        }
+
+        public RealmOnlineAsset(RealmFile localFile, string remoteUrl)
+        {
+            File = new RealmNamedFileUsage(localFile, remoteUrl);
+        }
+    }
+}

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -291,6 +291,8 @@ namespace osu.Game
             largeStore.AddTextureSource(Host.CreateTextureLoaderStore(CreateOnlineStore()));
             dependencies.Cache(largeStore);
 
+            dependencies.Cache(new OnlineAssetCachingStore(Host, realm));
+
             dependencies.CacheAs(LocalConfig);
             dependencies.CacheAs<IGameplaySettings>(LocalConfig);
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -208,8 +208,6 @@ namespace osu.Game
         private BeatmapDifficultyCache difficultyCache;
         private IBeatmapUpdater beatmapUpdater;
 
-        private OnlineAssetCachingStore onlineAssetCache;
-
         private UserLookupCache userCache;
         private BeatmapLookupCache beatmapCache;
         protected LeaderboardManager LeaderboardManager { get; private set; }
@@ -293,7 +291,7 @@ namespace osu.Game
             largeStore.AddTextureSource(Host.CreateTextureLoaderStore(CreateOnlineStore()));
             dependencies.Cache(largeStore);
 
-            dependencies.Cache(onlineAssetCache = new OnlineAssetCachingStore(Host, realm));
+            dependencies.Cache(new OnlineAssetCachingStore(Host, realm));
 
             dependencies.CacheAs(LocalConfig);
             dependencies.CacheAs<IGameplaySettings>(LocalConfig);
@@ -792,7 +790,6 @@ namespace osu.Game
             LocalConfig?.Dispose();
 
             beatmapUpdater?.Dispose();
-            onlineAssetCache?.Dispose();
 
             realm?.Dispose();
 

--- a/osu.Game/OsuGameBase.cs
+++ b/osu.Game/OsuGameBase.cs
@@ -208,6 +208,8 @@ namespace osu.Game
         private BeatmapDifficultyCache difficultyCache;
         private IBeatmapUpdater beatmapUpdater;
 
+        private OnlineAssetCachingStore onlineAssetCache;
+
         private UserLookupCache userCache;
         private BeatmapLookupCache beatmapCache;
         protected LeaderboardManager LeaderboardManager { get; private set; }
@@ -291,7 +293,7 @@ namespace osu.Game
             largeStore.AddTextureSource(Host.CreateTextureLoaderStore(CreateOnlineStore()));
             dependencies.Cache(largeStore);
 
-            dependencies.Cache(new OnlineAssetCachingStore(Host, realm));
+            dependencies.Cache(onlineAssetCache = new OnlineAssetCachingStore(Host, realm));
 
             dependencies.CacheAs(LocalConfig);
             dependencies.CacheAs<IGameplaySettings>(LocalConfig);
@@ -790,6 +792,7 @@ namespace osu.Game
             LocalConfig?.Dispose();
 
             beatmapUpdater?.Dispose();
+            onlineAssetCache?.Dispose();
 
             realm?.Dispose();
 

--- a/osu.Game/Users/Drawables/DrawableAvatar.cs
+++ b/osu.Game/Users/Drawables/DrawableAvatar.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
+using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Users.Drawables
@@ -31,12 +32,12 @@ namespace osu.Game.Users.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(LargeTextureStore textures)
+        private void load(LargeTextureStore textures, OnlineAssetCachingStore onlineTextures)
         {
             if (user != null && user.OnlineID > 1)
                 // TODO: The fallback here should not need to exist. Users should be looked up and populated via UserLookupCache or otherwise
                 // in remaining cases where this is required (chat tabs, local leaderboard), at which point this should be removed.
-                Texture = textures.Get((user as APIUser)?.AvatarUrl ?? $@"https://a.ppy.sh/{user.OnlineID}");
+                Texture = onlineTextures.Get((user as APIUser)?.AvatarUrl ?? $@"https://a.ppy.sh/{user.OnlineID}");
 
             Texture ??= textures.Get(@"Online/avatar-guest");
         }

--- a/osu.Game/Users/Drawables/DrawableTeamFlag.cs
+++ b/osu.Game/Users/Drawables/DrawableTeamFlag.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
+using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 
 namespace osu.Game.Users.Drawables
@@ -44,9 +44,9 @@ namespace osu.Game.Users.Drawables
         }
 
         [BackgroundDependencyLoader]
-        private void load(LargeTextureStore textures)
+        private void load(OnlineAssetCachingStore textures)
         {
-            if (team != null)
+            if (team?.FlagUrl != null)
                 sprite.Texture = textures.Get(team.FlagUrl);
         }
     }

--- a/osu.Game/Users/UserCoverBackground.cs
+++ b/osu.Game/Users/UserCoverBackground.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
+using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osuTK.Graphics;
 
@@ -51,7 +51,7 @@ namespace osu.Game.Users
             }
 
             [BackgroundDependencyLoader]
-            private void load(LargeTextureStore textures)
+            private void load(OnlineAssetCachingStore textures)
             {
                 if (user == null)
                 {


### PR DESCRIPTION
RFC.

Previously: https://github.com/ppy/osu/pull/35892

The reason why I am coming back to this is the following excerpt from https://github.com/ppy/osu/issues/36527#issuecomment-5066182655:

> maybe a good time to setup a local cache for this + seasonal backgrounds which are currently *fetch every time*??

This would be one way to make this happen.

## Changes from previous attempt

This PR incorporates the following pieces of feedback from the previous round:
- No longer trying to impose structure on the incoming URLs, instead treating them as an opaque content address from the start
- No longer trying to impose a separate hierarchical structure on the disk storage, instead using the same file store as beatmap / skin content
- Using a time-based expiry scheme (files not accessed for over 1 month are purged)

## Open questions:

### Content addressability via the URL

For this cache to work well, the URLs it fetches must be "content address-like". To explain in more human terms what that means: If an asset is assigned an URL once and fetched via this cache, then its assigned URL should ideally never be reused for a new asset (practically, at least no sooner than after a month of ceasing use of the old asset).

The following types of online assets already meet this standard:
- User avatars (cache-busting time-of-update-based query string)
- User covers (hash of raw content in the filename)
- Team flags (hash of raw content in the filename)

The following types of online assets *probably* meet this standard:
- Beatmap covers (looks like cache-busting time-of-update-based query string)
- Placeholder assets (example: `https://osu.ppy.sh/assets/images/0.b3bb5a86.jpg`; seems to contain a hash-like string)

In general determining whether it is permissible to use this cache is difficult to ascertain in some cases.

### Expiry scheme

The 1 month time-based threshold is arbitrary. It can be tweaked as desired.

### Extent of use & potential resulting impact on performance

This PR is *not* using a "separate realm or sqlite database" as mentioned [here](https://github.com/ppy/osu/pull/35892#issuecomment-3625260786). Whether this is acceptable likely depends on frequency of use. If we only decide to put background in this, it's probably okay to disregard performance; if user avatars and/or beatmap covers are to live here too, it becomes a larger concern.

There is also the open question as to whether we want to allow user-submitted content to be stored on other users' drives.

To that end, please treat https://github.com/ppy/osu/commit/c44d33d3e3e0ca0b8ca4b3aefc766ea294f4b8a4 as a proof of concept of how this cache is to be used at most and a vehicle to easily test its operation, rather than a serious statement on any of the above questions.