### PR TITLE
Make performance of "select all" in editor a little less laughably bad

### DIFF
--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -242,6 +242,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 DragBox.HandleDrag(lastDragEvent);
                 UpdateSelectionFromDragBox(selectionBeforeDrag);
             }
+
+            SelectionBlueprints.AddRange(blueprintsToAdd);
+            blueprintsToAdd.Clear();
+
+            SelectionBlueprints.RemoveRange(blueprintsToRemove, true);
+            blueprintsToRemove.Clear();
         }
 
         /// <summary>
@@ -311,6 +317,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Blueprint Addition/Removal
 
+        private List<SelectionBlueprint<T>> blueprintsToAdd = new List<SelectionBlueprint<T>>();
+        private List<SelectionBlueprint<T>> blueprintsToRemove = new List<SelectionBlueprint<T>>();
+
         protected virtual void AddBlueprintFor(T item)
         {
             if (blueprintMap.ContainsKey(item))
@@ -325,7 +334,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             blueprint.Selected += OnBlueprintSelected;
             blueprint.Deselected += OnBlueprintDeselected;
 
-            SelectionBlueprints.Add(blueprint);
+            blueprintsToAdd.Add(blueprint);
 
             if (SelectionHandler.SelectedItems.Contains(item))
                 blueprint.Select();
@@ -342,7 +351,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             blueprintToRemove.Selected -= OnBlueprintSelected;
             blueprintToRemove.Deselected -= OnBlueprintDeselected;
 
-            SelectionBlueprints.Remove(blueprintToRemove, true);
+            blueprintsToRemove.Add(blueprintToRemove);
 
             if (movementBlueprints?.Any(m => m.blueprint == blueprintToRemove) == true)
                 finishSelectionMovement();

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -243,11 +244,16 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 UpdateSelectionFromDragBox(selectionBeforeDrag);
             }
 
-            SelectionBlueprints.AddRange(blueprintsToAdd);
-            blueprintsToAdd.Clear();
+            if (!blueprintsPending.IsValid)
+            {
+                SelectionBlueprints.AddRange(blueprintsToAdd);
+                blueprintsToAdd.Clear();
 
-            SelectionBlueprints.RemoveRange(blueprintsToRemove, true);
-            blueprintsToRemove.Clear();
+                SelectionBlueprints.RemoveRange(blueprintsToRemove, true);
+                blueprintsToRemove.Clear();
+
+                blueprintsPending.Validate();
+            }
         }
 
         /// <summary>
@@ -317,6 +323,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Blueprint Addition/Removal
 
+        private readonly Cached blueprintsPending = new Cached();
         private readonly List<SelectionBlueprint<T>> blueprintsToAdd = new List<SelectionBlueprint<T>>();
         private readonly List<SelectionBlueprint<T>> blueprintsToRemove = new List<SelectionBlueprint<T>>();
 
@@ -335,6 +342,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             blueprint.Deselected += OnBlueprintDeselected;
 
             blueprintsToAdd.Add(blueprint);
+            blueprintsPending.Invalidate();
 
             if (SelectionHandler.SelectedItems.Contains(item))
                 blueprint.Select();
@@ -352,6 +360,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             blueprintToRemove.Deselected -= OnBlueprintDeselected;
 
             blueprintsToRemove.Add(blueprintToRemove);
+            blueprintsPending.Invalidate();
 
             if (movementBlueprints?.Any(m => m.blueprint == blueprintToRemove) == true)
                 finishSelectionMovement();

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -317,8 +317,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Blueprint Addition/Removal
 
-        private List<SelectionBlueprint<T>> blueprintsToAdd = new List<SelectionBlueprint<T>>();
-        private List<SelectionBlueprint<T>> blueprintsToRemove = new List<SelectionBlueprint<T>>();
+        private readonly List<SelectionBlueprint<T>> blueprintsToAdd = new List<SelectionBlueprint<T>>();
+        private readonly List<SelectionBlueprint<T>> blueprintsToRemove = new List<SelectionBlueprint<T>>();
 
         protected virtual void AddBlueprintFor(T item)
         {

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/TimelineBlueprintContainer.cs
@@ -387,6 +387,9 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
 
             public Vector2 ContentRelativeToAbsoluteFactor => Content.RelativeToAbsoluteFactor;
 
+            [Resolved]
+            private EditorBeatmap editorBeatmap { get; set; }
+
             public TimelineSelectionBlueprintContainer()
             {
                 AddInternal(new TimelinePart<SelectionBlueprint<HitObject>>(Content = new HitObjectOrderedSelectionContainer { RelativeSizeAxes = Axes.Both }) { RelativeSizeAxes = Axes.Both });
@@ -400,8 +403,10 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 // it is possible for `Content`'s children to become unsorted when the user moves the placement around,
                 // which can culminate in a critical failure when attempting to binary-search children here
                 // using `HitObjectOrderedSelectionContainer`'s custom comparer.
-                // thus, always force a re-sort of objects before attempting to change child depth to avoid this scenario.
-                Content.Sort();
+                // thus, always force a re-sort of objects before attempting to change child depth when a placement is active
+                // to avoid this scenario.
+                if (editorBeatmap.PlacementObject.Value != null)
+                    Content.Sort();
                 base.ChangeChildDepth(child, newDepth);
             }
         }


### PR DESCRIPTION
Completely random diff for no reason. If unacceptable feel free to just close without justification.

It's still horrible but the rest of the bad things in profiling are not easily resolved.

## [Fix O(n²) overhead from individual blueprint additions / removals by batching](https://github.com/ppy/osu/commit/a6913b229eaaff476b06626a24c0ad48454ce2b7)

`BlueprintContainer` enforces sorting, which means that adding hundreds of items to it one by one essentially incurs an insertion sort which is quadratic and a major, quickly avoidable, hotspot in profiling.

Resolved by adding items to temporary unsorted list and propagating insertions / removals once per frame.

| before | after |
| :-: | :-: |
| <img width="1002" height="411" alt="Screenshot 2026-07-29 at 11 33 51" src="https://github.com/user-attachments/assets/2ef81250-9e74-4782-bdef-1f8431327392" /> | <img width="1121" height="590" alt="Screenshot 2026-07-29 at 11 34 29" src="https://github.com/user-attachments/assets/afa0af79-2fc7-4b5d-ac5f-15c74fe4313c" /> |

## [Fix O(n²) overhead from timeline blueprints re-sorting on every depth change](https://github.com/ppy/osu/commit/f312006ef059a54be4f9a9e20f2d1029643db7c6)

Another very avoidable hotspot in profiling.

Selecting and deselecting items causes them to be either brought to front or sent to back via `ChangeChildDepth()`. To make matters worse, `ChangeChildDepth()` in the timeline specifically would incur a full sort of the list every time to cover off a bug scenario that could occur when a placement is in progress (as it is not ensured that the placement's location in the list of blueprints is correctly sorted as the placement's properties change; see https://github.com/ppy/osu/pull/30377).

In the case of a plain selection this is just pure overhead for nothing, so change the logic to only perform the sort when a placement is active.

| before | after |
| :-: | :-: |
| <img width="1396" height="546" alt="Screenshot 2026-07-29 at 11 45 04" src="https://github.com/user-attachments/assets/2e3e81e6-4e9b-4525-962e-7d897372cb1b" /> | <img width="1373" height="526" alt="Screenshot 2026-07-29 at 11 47 04" src="https://github.com/user-attachments/assets/6dfaf119-bc3e-4663-82e1-2b52291ce305" /> |
