### PR TITLE
Adjust flashlight scale animation to match stable closer in osu!, osu!taiko, and osu!catch

### DIFF
--- a/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
+++ b/osu.Game.Rulesets.Catch/Mods/CatchModFlashlight.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Game.Rulesets.Catch.Objects;
@@ -47,12 +48,18 @@ namespace osu.Game.Rulesets.Catch.Mods
                 FlashlightSmoothness = 1.4f;
             }
 
+            // all sizings here match stable as per
+            // https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Fruits/RulesetFruits.cs#L645-L655
+            // all "scale" quantities below are relative to the `targetScale` of the flashlight effect at 0 combo
+
+            protected override float BreakTimeScale => 1.538f; // ≈ 8.0 / 5.2
+
             protected override float GetComboScaleFor(int combo)
             {
                 if (combo >= 200)
-                    return 0.770f;
+                    return 0.770f; // ≈ 4.0 / 5.2
                 if (combo >= 100)
-                    return 0.885f;
+                    return 0.885f; // ≈ 4.6 / 5.2
 
                 return 1.0f;
             }
@@ -64,9 +71,17 @@ namespace osu.Game.Rulesets.Catch.Mods
                 FlashlightPosition = playfield.CatcherArea.ToSpaceOfOtherDrawable(playfield.Catcher.DrawPosition, this);
             }
 
+            // as per https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Fruits/RulesetFruits.cs#L657-L660,
+            // stable's animation speed is 0.1 "units" per 1 frame at 60 fps
+            // converting to local units here, this is:
+            // (0.1 / 5.2) * (1 / 60 [s]) = 1.154 [1 / s] = (1.154 / 1000) [1 / ms]
+            private const double scale_animation_speed = 1.154 / 1000;
+
             protected override void UpdateFlashlightSize(float size)
             {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), FLASHLIGHT_FADE_DURATION);
+                double relativeDelta = Math.Abs(FlashlightSize.Y - size) / DefaultFlashlightSize;
+                double duration = relativeDelta / scale_animation_speed;
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), duration);
             }
 
             protected override string FragmentShader => "CircularFlashlight";

--- a/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
+++ b/osu.Game.Rulesets.Osu/Mods/OsuModFlashlight.cs
@@ -82,9 +82,17 @@ namespace osu.Game.Rulesets.Osu.Mods
                 return base.OnMouseMove(e);
             }
 
+            // as per https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Ruleset.cs#L532-L535,
+            // stable's animation speed is 0.1 "units" per 1 frame at 60 fps
+            // converting to local units here, this is:
+            // (0.1 / 3.2) * (1 / 60 [s]) = 1.875 [1 / s] = (1.875 / 1000) [1 / ms]
+            private const double scale_animation_speed = 1.875 / 1000;
+
             protected override void UpdateFlashlightSize(float size)
             {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), FLASHLIGHT_FADE_DURATION);
+                double relativeDelta = Math.Abs(FlashlightSize.Y - size) / DefaultFlashlightSize;
+                double duration = relativeDelta / scale_animation_speed;
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), duration);
             }
 
             protected override string FragmentShader => "CircularFlashlight";

--- a/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
+++ b/osu.Game.Rulesets.Taiko/Mods/TaikoModFlashlight.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Layout;
@@ -51,9 +52,17 @@ namespace osu.Game.Rulesets.Taiko.Mods
                 AddLayout(flashlightProperties);
             }
 
+            // as per https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Ruleset.cs#L532-L535,
+            // stable's animation speed is 0.1 "units" per 1 frame at 60 fps
+            // converting to local units here, this is:
+            // (0.1 / 3.2) * (1 / 60 [s]) = 1.875 [1 / s] = (1.875 / 1000) [1 / ms]
+            private const double scale_animation_speed = 1.875 / 1000;
+
             protected override void UpdateFlashlightSize(float size)
             {
-                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), FLASHLIGHT_FADE_DURATION);
+                double relativeDelta = Math.Abs(FlashlightSize.Y - size) / DefaultFlashlightSize;
+                double duration = relativeDelta / scale_animation_speed;
+                this.TransformTo(nameof(FlashlightSize), new Vector2(0, size), duration);
             }
 
             protected override string FragmentShader => "CircularFlashlight";

--- a/osu.Game/Rulesets/Mods/ModFlashlight.cs
+++ b/osu.Game/Rulesets/Mods/ModFlashlight.cs
@@ -118,13 +118,14 @@ namespace osu.Game.Rulesets.Mods
 
             private DrawInfo playfieldDrawInfo => PlayfieldDrawInfoTracker.DrawInfo;
 
-            private readonly float defaultFlashlightSize;
+            protected readonly float DefaultFlashlightSize;
+
             private readonly float sizeMultiplier;
             private readonly bool comboBasedSize;
 
             protected Flashlight(ModFlashlight modFlashlight)
             {
-                defaultFlashlightSize = modFlashlight.DefaultFlashlightSize;
+                DefaultFlashlightSize = modFlashlight.DefaultFlashlightSize;
                 sizeMultiplier = modFlashlight.SizeMultiplier.Value;
                 comboBasedSize = modFlashlight.ComboBasedSize.Value;
             }
@@ -149,8 +150,17 @@ namespace osu.Game.Rulesets.Mods
                 if (player != null)
                 {
                     isBreakTime.BindTo(player.IsBreakTime);
-                    isBreakTime.BindValueChanged(_ => UpdateFlashlightSize(GetSize()), true);
+                    isBreakTime.BindValueChanged(val =>
+                    {
+                        // `player.IsBreakTime` will exit out of break *before* the actual specified time instant in the .osu
+                        // see `BreakTracker.Breaks_set`
+                        // to match stable, delay the animation in case of exiting break to the exact time specified in the .osu
+                        double delay = val.NewValue ? 0 : BreakOverlay.BREAK_FADE_DURATION;
+                        Scheduler.AddDelayed(() => UpdateFlashlightSize(GetSize()), delay);
+                    });
                 }
+
+                UpdateFlashlightSize(GetSize());
 
                 PlayfieldDrawInfoTracker.OnDrawInfoInvalidate += () => Invalidate(Invalidation.DrawNode);
             }
@@ -161,22 +171,28 @@ namespace osu.Game.Rulesets.Mods
 
             public float GetSize()
             {
-                float size = defaultFlashlightSize * sizeMultiplier;
+                float size = DefaultFlashlightSize * sizeMultiplier;
 
                 if (isBreakTime.Value)
-                    size *= 2.5f;
+                    size *= BreakTimeScale;
                 else if (comboBasedSize)
                     size *= GetComboScaleFor(Combo.Value);
 
                 return size;
             }
 
+            // all sizings here match stable as per
+            // https://github.com/peppy/osu-stable-reference/blob/baa8705f782c0de2b10a7387d78014c61c8b17fb/osu!/GameModes/Play/Rulesets/Ruleset.cs#L520-L530
+            // all "scale" quantities below are relative to the `targetScale` of the flashlight effect at 0 combo
+
+            protected virtual float BreakTimeScale => 2.5f; // = 8.0 / 3.2
+
             protected virtual float GetComboScaleFor(int combo)
             {
                 if (combo >= 200)
-                    return 0.625f;
+                    return 0.625f; // = 2.0 / 3.2
                 if (combo >= 100)
-                    return 0.8125f;
+                    return 0.8125f; // = 2.6 / 3.2
 
                 return 1.0f;
             }


### PR DESCRIPTION
Continuation of (and probably conclusion to) https://github.com/ppy/osu/discussions/36329.

Changes made:

- In osu!, osu!taiko, and osu!catch, the flashlight scale animation was incorrectly specified to have a constant duration of 800ms. This number was only correct when the following simultaneous criteria were met:

  - The current combo is between 0 and 100
  - A break is starting or ending
  - The ruleset is osu! or osu!taiko

  In comparison, stable enforces a constant *speed* of the animation rather than a given duration of it, and this change mirrors that.

- In osu!, osu!taiko, and osu!catch, the animation of the flashlight when exiting a break would play 325ms too early.

- In osu!catch, the radius of the flaslight during a break would be too large.

See comparison video: https://drive.google.com/file/d/16qHKYGHxy1vDiaAHgnEXrWziHBOI6_Xa/view?usp=share_link

Test map used: [Agressor Bunx - Free Machine (spaceman_atlas).zip](https://github.com/user-attachments/files/30543804/Agressor.Bunx.-.Free.Machine.spaceman_atlas.zip)
