### PR TITLE
chore: Made collection sorting be case-insensitive

### DIFF
--- a/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
+++ b/osu.Game.Tests/Collections/IO/ImportCollectionsTest.cs
@@ -177,6 +177,7 @@ namespace osu.Game.Tests.Collections.IO
 
                         // Rename the second collecction.
                         collections[1].Name = "Another";
+                        collections[1].UpdateNameSortKey();
                     });
                 }
                 finally

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneCollectionDropdown.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneCollectionDropdown.cs
@@ -121,7 +121,12 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             addExpandHeaderStep();
 
-            AddStep("change name", () => writeAndRefresh(_ => getFirstCollection().Name = "First"));
+            AddStep("change name", () => writeAndRefresh(_ =>
+            {
+                var collection = getFirstCollection();
+                collection.Name = "First";
+                collection.UpdateNameSortKey();
+            }));
 
             assertCollectionDropdownContains("First");
             assertCollectionHeaderDisplays("First");

--- a/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneManageCollectionsDialog.cs
@@ -293,7 +293,11 @@ namespace osu.Game.Tests.Visual.SongSelect
             assertCollectionName(0, "1");
             assertCollectionName(1, "2");
 
-            AddStep("change first collection name", () => Realm.Write(_ => first.Name = "First"));
+            AddStep("change first collection name", () => Realm.Write(_ =>
+            {
+                first.Name = "First";
+                first.UpdateNameSortKey();
+            }));
 
             // Item will have moved due to alphabetical sorting.
             assertCollectionName(0, "2");
@@ -370,7 +374,11 @@ namespace osu.Game.Tests.Visual.SongSelect
 
             assertCollectionCount(1);
 
-            AddStep("change first collection name", () => Realm.Write(_ => first.Name = "First"));
+            AddStep("change first collection name", () => Realm.Write(_ =>
+            {
+                first.Name = "First";
+                first.UpdateNameSortKey();
+            }));
 
             assertCollectionCount(0);
 

--- a/osu.Game/Collections/BeatmapCollection.cs
+++ b/osu.Game/Collections/BeatmapCollection.cs
@@ -24,6 +24,18 @@ namespace osu.Game.Collections
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
+        /// A case-insensitive sort key derived from <see cref="Name"/>.
+        /// </summary>
+        [Indexed]
+        public string NameSortKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Recomputes <see cref="NameSortKey"/> from the current <see cref="Name"/>. Must be called after any
+        /// change to <see cref="Name"/> (inside the same write transaction).
+        /// </summary>
+        public void UpdateNameSortKey() => NameSortKey = Name.ToUpperInvariant();
+
+        /// <summary>
         /// The <see cref="BeatmapInfo.MD5Hash"/>es of beatmaps contained by the collection.
         /// </summary>
         /// <remarks>
@@ -44,6 +56,7 @@ namespace osu.Game.Collections
         {
             ID = Guid.NewGuid();
             Name = name ?? string.Empty;
+            UpdateNameSortKey();
             BeatmapMD5Hashes = beatmapMD5Hashes ?? new List<string>();
 
             LastModified = DateTimeOffset.UtcNow;

--- a/osu.Game/Collections/DrawableCollectionList.cs
+++ b/osu.Game/Collections/DrawableCollectionList.cs
@@ -54,7 +54,7 @@ namespace osu.Game.Collections
         {
             base.LoadComplete();
 
-            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.Name), collectionsChanged);
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.NameSortKey), collectionsChanged);
         }
 
         /// <summary>

--- a/osu.Game/Collections/DrawableCollectionListItem.cs
+++ b/osu.Game/Collections/DrawableCollectionListItem.cs
@@ -121,7 +121,11 @@ namespace osu.Game.Collections
             private void onCommit(TextBox sender, bool newText)
             {
                 if (collection.IsManaged && collection.Value.Name != TextBox.Current.Value)
-                    collection.PerformWrite(c => c.Name = TextBox.Current.Value);
+                    collection.PerformWrite(c =>
+                    {
+                        c.Name = TextBox.Current.Value;
+                        c.UpdateNameSortKey();
+                    });
             }
         }
 

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -21,6 +21,7 @@ using osu.Framework.Statistics;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
+using osu.Game.Collections;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
 using osu.Game.Input;
@@ -101,8 +102,9 @@ namespace osu.Game.Database
         /// 49   2025-06-10    Reset the LegacyOnlineID to -1 for all scores that have it set to 0 (which is semantically the same) for consistency of handling with OnlineID.
         /// 50   2025-07-11    Add UserTags to BeatmapMetadata.
         /// 51   2025-07-22    Add ScoreInfo.Pauses.
+        /// 52   2025-07-30    Add NameSortKey to BeatmapCollection for case-insensitive sorting.
         /// </summary>
-        private const int schema_version = 51;
+        private const int schema_version = 52;
 
         /// <summary>
         /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
@@ -1305,6 +1307,11 @@ namespace osu.Game.Database
                     foreach (var score in migration.NewRealm.All<ScoreInfo>().Where(s => s.LegacyOnlineID == 0))
                         score.LegacyOnlineID = -1;
 
+                    break;
+
+                case 52:
+                    foreach (var collection in migration.NewRealm.All<BeatmapCollection>())
+                        collection.UpdateNameSortKey();
                     break;
             }
 

--- a/osu.Game/Screens/Select/BeatmapCarousel.cs
+++ b/osu.Game/Screens/Select/BeatmapCarousel.cs
@@ -828,7 +828,7 @@ namespace osu.Game.Screens.Select
         /// because they use the sorting operation inside subscription queries for efficient drawable management,
         /// so this usage kind of has to follow suit.
         /// </remarks>
-        protected virtual List<BeatmapCollection> GetAllCollections() => realm.Run(r => r.All<BeatmapCollection>().OrderBy(c => c.Name).AsEnumerable().Detach());
+        protected virtual List<BeatmapCollection> GetAllCollections() => realm.Run(r => r.All<BeatmapCollection>().OrderBy(c => c.NameSortKey).AsEnumerable().Detach());
 
         protected virtual Dictionary<Guid, ScoreRank> GetBeatmapInfoGuidToTopRankMapping(FilterCriteria criteria) => realm.Run(r =>
         {

--- a/osu.Game/Screens/Select/CollectionDropdown.cs
+++ b/osu.Game/Screens/Select/CollectionDropdown.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Screens.Select
         {
             base.LoadComplete();
 
-            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.Name), collectionsChanged);
+            realmSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>().OrderBy(c => c.NameSortKey), collectionsChanged);
 
             Current.BindValueChanged(selectionChanged);
         }


### PR DESCRIPTION
This should resolve #38323 

<img width="709" height="412" alt="image" src="https://github.com/user-attachments/assets/f46c3179-4d2a-4199-9483-9863c413e750" />

Realm doesn't support case-insensitive string like ppy stated in the issue so sorting natively, and its weaver requires `Name` to stay a plain auto-property, so we can't wire this into the setter. Instead we store a separate indexed column and call `UpdateNameSortKey()` explicitly whenever Name changes.