### PR TITLE
Fix song select not working if collections grouping active and a beatmap has null `MD5Hash`

### DIFF
--- a/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
+++ b/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs
@@ -436,6 +436,9 @@ namespace osu.Game.Screens.Select
             {
                 var beatmap = (BeatmapInfo)item.Model;
 
+                if (string.IsNullOrEmpty(beatmap.MD5Hash))
+                    continue;
+
                 // as a side note, even reading the `MD5Hash` off a realm model is slow if done enough times,
                 // so it definitely helps that thanks to the mapping it needs to only be retrieved once
                 if (md5ToCollectionsMap.TryGetValue(beatmap.MD5Hash, out var collections))


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38479, also reported in https://osu.ppy.sh/community/forums/topics/2230279?n=1.

The logs attached in the forum thread show

	2026-07-31 00:05:50 [error]: Unobserved exception occurred via FireAndForget call: Value cannot be null. (Parameter 'key')
	2026-07-31 00:05:50 [error]: System.ArgumentNullException: Value cannot be null. (Parameter 'key')
	2026-07-31 00:05:50 [error]: at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
	2026-07-31 00:05:50 [error]: at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
	2026-07-31 00:05:50 [error]: at osu.Game.Screens.Select.BeatmapCarouselFilterGrouping.defineGroupsByCollection(List`1 carouselItems, List`1 allCollections)
	2026-07-31 00:05:50 [error]: at osu.Game.Screens.Select.BeatmapCarouselFilterGrouping.getGroups(List`1 items, FilterCriteria criteria)
	2026-07-31 00:05:50 [error]: at osu.Game.Screens.Select.BeatmapCarouselFilterGrouping.<>c__DisplayClass33_0.<Run>b__0()

There are two `TryGetValue()` calls in the mentioned method:

https://github.com/ppy/osu/blob/6b2606c51b4334f36d9d09dc96dc5d6bafb468a1/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs#L425 https://github.com/ppy/osu/blob/6b2606c51b4334f36d9d09dc96dc5d6bafb468a1/osu.Game/Screens/Select/BeatmapCarouselFilterGrouping.cs#L441

Checking the realm database schema as presented by Realm Studio, `BeatmapCollection.BeatmapMD5Hashes` does not permit nulls, but `Beatmap.MD5Hash` *does* permit nulls. So in theory only the latter appears possible.

As to how `Beatmap.MD5Hash` *becomes* null? - no idea. The only thing I can think of is some external interference. I can't see any actual game code path that would write a null there. But given how crippling the result of that null is here (the carousel completely disappears), I think it's probably better to guard against it?