### PR TITLE
RankedPlay / Quickplay queue NullReferenceException 

### DIFF
--- a/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingQueueScreen.cs
+++ b/osu.Game.Tests/Visual/Matchmaking/TestSceneMatchmakingQueueScreen.cs
@@ -83,6 +83,18 @@ namespace osu.Game.Tests.Visual.Matchmaking
             AddWaitStep("wait a little bit", 10);
         }
 
+        [Test]
+        public void TestRoomScreenPushNullHandling()
+        {
+            AddStep("leave room", () => MultiplayerClient.LeaveRoom());
+
+            AddWaitStep("wait for room leave", 5);
+
+            AddStep("change state to in room", () => queueScreen!.SetState(ScreenQueue.MatchmakingScreenState.InRoom));
+
+            AddWaitStep("wait a little bit", 10);
+        }
+
         private static double generateCount(double x, double mean, double stdDev, double amplitude)
         {
             return amplitude * Math.Exp(-Math.Pow(x - mean, 2) / (2 * Math.Pow(stdDev, 2))) + Random.Shared.Next(300);

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/Queue/ScreenQueue.cs
@@ -21,6 +21,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Logging;
 using osu.Framework.Screens;
 using osu.Framework.Threading;
 using osu.Game.Database;
@@ -728,14 +729,21 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.Queue
                     {
                         pushScreenDelegate = Schedule(() =>
                         {
+                            if (client.Room == null)
+                            {
+                                Logger.Log("Room became null, returning to idle");
+                                SetState(MatchmakingScreenState.Idle);
+                                return;
+                            }
+
                             switch (poolType)
                             {
                                 case MatchmakingPoolType.QuickPlay:
-                                    this.Push(new ScreenMatchmaking(client.Room!));
+                                    this.Push(new ScreenMatchmaking(client.Room));
                                     break;
 
                                 case MatchmakingPoolType.RankedPlay:
-                                    this.Push(new RankedPlayScreen(client.Room!));
+                                    this.Push(new RankedPlayScreen(client.Room));
                                     break;
                             }
                         });


### PR DESCRIPTION
Resolves #38482

The original error in the logs refers to a NullReferenceException in ```UserActivity.cs::InLobby```, but that is just the first place the null room is accessed when the ```ScreenQueue.cs``` moves the user to the  ```RankedPlayScreen```.

I initially assumed it was from the user getting disconnected and the room set to null during the BeginDelayedSequence(2000) in ```ScreenQueue.cs```, but I couldn't replicate that regardless of what I tried (and there is a similar test case in ```TestSceneMatchmakingQueueScreen``` with a comment about this). What did end up recreating this was leaving the room first, then changing to an in room state after.

I added a new visual test which replicates the issue, and added a room null check to ```ScreenQueue.cs``` to prevent it. When it occurs the matchmaking screen will return to an idle state. My main question would be: what indication should be shown to the user that the queue failed and reset?

Any feedback is appreciated!