### PR TITLE
Show room descriptions in multiplayer/playlists/daily challenge

### DIFF
--- a/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
+++ b/osu.Game.Tests/Visual/DailyChallenge/TestSceneDailyChallenge.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Tests.Visual.DailyChallenge
             var room = new Room
             {
                 Name = "Daily Challenge: June 4, 2024",
+                Description = "Highlights of May 2024",
                 Playlist =
                 [
                     new PlaylistItem(TestResources.CreateTestBeatmapSetInfo().Beatmaps.First())

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneMultiplayerMatchSubScreen.cs
@@ -79,7 +79,11 @@ namespace osu.Game.Tests.Visual.Multiplayer
 
             AddStep("load match", () =>
             {
-                room = new Room { Name = "Test Room" };
+                room = new Room
+                {
+                    Name = "Test Room",
+                    Description = "This multiplayer room has a short description!",
+                };
                 LoadScreen(screen = new TestMultiplayerMatchSubScreen(room));
             });
 

--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -8,6 +8,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Graphics.Sprites;
@@ -209,30 +210,44 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     new MultiplayerRoomPanel(new Room
                     {
                         Name = "A host-only room",
+                        Description = "Host controls the queue.",
                         QueueMode = QueueMode.HostOnly,
                         Type = MatchType.HeadToHead,
                         RoomID = 1337,
-                    }),
+                    })
+                    { ShowDescription = true },
                     new MultiplayerRoomPanel(new Room
                     {
                         Name = "An all-players, team-versus room",
+                        Description = "Everyone can add maps. Team versus mode.",
                         QueueMode = QueueMode.AllPlayers,
                         Type = MatchType.TeamVersus,
                         RoomID = 1338,
-                    }),
+                    })
+                    { ShowDescription = true },
                     new MultiplayerRoomPanel(new Room
                     {
                         Name = "A round-robin room",
+                        Description = "This description shouldn't be visible.",
                         QueueMode = QueueMode.AllPlayersRoundRobin,
                         Type = MatchType.HeadToHead,
                         RoomID = 1339,
-                    }),
+                    })
                 }
             });
+
+            AddUntilStep("wait for panels",
+                () => this.ChildrenOfType<MultiplayerRoomPanel>().Count(p => p.ChildrenOfType<DrawableRoomParticipantsList>().Any()),
+                () => Is.EqualTo(3));
+
+            AddAssert("description not displayed on third room", () =>
+                this.ChildrenOfType<MultiplayerRoomPanel>().ElementAt(2)
+                    .ChildrenOfType<SpriteText>()
+                    .All(t => t.Text.ToString() != "This description shouldn't be visible."));
         }
 
         [Test]
-        public void TestRoomWithLongTitle()
+        public void TestRoomWithLongTitleAndDescription()
         {
             AddStep("create rooms", () => Child = new FillFlowContainer
             {
@@ -246,10 +261,12 @@ namespace osu.Game.Tests.Visual.Multiplayer
                     {
                         Name =
                             "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
+                        Description = "This room also has a very very long description sitting under that title to check that it also properly truncates when it reaches the right side of the panel, and if it doesn't, then hello again.",
                         QueueMode = QueueMode.HostOnly,
                         Type = MatchType.HeadToHead,
                         RoomID = 1337,
-                    }),
+                    })
+                    { ShowDescription = true },
                 }
             });
         }

--- a/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
+++ b/osu.Game.Tests/Visual/Playlists/TestScenePlaylistsRoomSubScreen.cs
@@ -140,6 +140,8 @@ namespace osu.Game.Tests.Visual.Playlists
                 room = new Room
                 {
                     RoomID = 1,
+                    Name = "Test Playlist",
+                    Description = "This is a playlist with a short description, woo!",
                     MaxAttempts = 10,
                     Playlist =
                     [

--- a/osu.Game/Online/Rooms/Room.cs
+++ b/osu.Game/Online/Rooms/Room.cs
@@ -37,6 +37,15 @@ namespace osu.Game.Online.Rooms
         }
 
         /// <summary>
+        /// An optional description of the room.
+        /// </summary>
+        public string? Description
+        {
+            get => description;
+            set => SetField(ref description, value);
+        }
+
+        /// <summary>
         /// Sets the room password. Will be <c>null</c> after the room is created.
         /// </summary>
         /// <remarks>
@@ -275,6 +284,9 @@ namespace osu.Game.Online.Rooms
         [JsonProperty("name")]
         private string name = string.Empty;
 
+        [JsonProperty("description")]
+        private string? description;
+
         [JsonProperty("password")]
         private string? password;
 
@@ -381,6 +393,7 @@ namespace osu.Game.Online.Rooms
         {
             RoomID = other.RoomID;
             Name = other.Name;
+            Description = other.Description;
             Category = other.Category;
             Host = other.Host;
             ChannelId = other.ChannelId;

--- a/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
+++ b/osu.Game/Screens/OnlinePlay/DailyChallenge/DailyChallenge.cs
@@ -21,8 +21,10 @@ using osu.Framework.Screens;
 using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Cursor;
+using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Localisation;
 using osu.Game.Online.API;
@@ -136,7 +138,7 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                     {
                         RelativeSizeAxes = Axes.Both,
                     },
-                    new Header(ButtonSystemStrings.DailyChallenge.ToSentence(), null),
+                    createHeader(),
                     new PopoverContainer
                     {
                         RelativeSizeAxes = Axes.Both,
@@ -375,6 +377,68 @@ namespace osu.Game.Screens.OnlinePlay.DailyChallenge
                         Scheduler.AddOnce(() => leaderboard.RefetchScores());
                 });
             });
+        }
+
+        private Container createHeader()
+        {
+            var titleFlow = new FillFlowContainer
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal,
+                Spacing = new Vector2(6, 0),
+                Children = new Drawable[]
+                {
+                    new OsuHoverContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Action = () => game?.ShowWiki(@"Gameplay/Daily_challenge"),
+                        Child = new OsuSpriteText
+                        {
+                            Font = OsuFont.TorusAlternate.With(size: 24),
+                            Text = ButtonSystemStrings.DailyChallenge.ToSentence(),
+                        }
+                    }
+                }
+            };
+
+            if (!string.IsNullOrEmpty(room.Description))
+            {
+                var subtitleFont = OsuFont.TorusAlternate.With(size: 16);
+
+                titleFlow.AddRange(new Drawable[]
+                {
+                    new OsuSpriteText
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Font = subtitleFont,
+                        Text = "·",
+                        Colour = colourProvider.Content2,
+                        Margin = new MarginPadding { Bottom = 3 },
+                    },
+                    new TruncatingSpriteText
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Font = subtitleFont,
+                        Text = room.Description,
+                        Colour = colourProvider.Content2,
+                        Margin = new MarginPadding { Bottom = 3 },
+                    }
+                });
+            }
+
+            return new Container
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = Header.HEIGHT,
+                Padding = new MarginPadding { Left = WaveOverlayContainer.WIDTH_PADDING },
+                Child = titleFlow,
+            };
         }
 
         protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/Components/RoomPanel.cs
@@ -57,6 +57,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
 
         protected bool ShowExternalLink { get; init; } = true;
 
+        public bool ShowDescription { get; init; }
+
         private DrawableRoomParticipantsList? drawableRoomParticipantsList;
         private RoomSpecialCategoryPill? specialCategoryPill;
         private CornerIcon? passwordIcon;
@@ -99,6 +101,29 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                 Colour = colourProvider.Background6.Opacity(0.4f),
                 Radius = 4,
             };
+
+            IEnumerable<Drawable> createNameAndStatus()
+            {
+                yield return roomName = new RoomNameLine();
+
+                if (ShowDescription && !string.IsNullOrEmpty(Room.Description))
+                {
+                    Height = height + 16;
+
+                    yield return new TruncatingSpriteText
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Text = Room.Description,
+                        Font = OsuFont.Style.Caption2,
+                        Colour = colourProvider.Content2,
+                    };
+                }
+
+                yield return new RoomStatusText(Room)
+                {
+                    Beatmap = { BindTarget = currentBeatmap }
+                };
+            }
 
             InternalChildren = new Drawable[]
             {
@@ -207,14 +232,7 @@ namespace osu.Game.Screens.OnlinePlay.Lounge.Components
                                                                 AutoSizeAxes = Axes.Y,
                                                                 Padding = new MarginPadding { Top = 3 },
                                                                 Direction = FillDirection.Vertical,
-                                                                Children = new Drawable[]
-                                                                {
-                                                                    roomName = new RoomNameLine(),
-                                                                    new RoomStatusText(Room)
-                                                                    {
-                                                                        Beatmap = { BindTarget = currentBeatmap }
-                                                                    }
-                                                                }
+                                                                ChildrenEnumerable = createNameAndStatus()
                                                             }
                                                         },
                                                     },

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerMatchSubScreen.cs
@@ -206,7 +206,8 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
                                         {
                                             new MultiplayerRoomPanel(room)
                                             {
-                                                OnEdit = () => settingsOverlay.Show()
+                                                OnEdit = () => settingsOverlay.Show(),
+                                                ShowDescription = true,
                                             }
                                         },
                                         null,

--- a/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Multiplayer/MultiplayerRoomPanel.cs
@@ -3,13 +3,14 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Game.Beatmaps.Drawables;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
 using osu.Game.Screens.OnlinePlay.Lounge.Components;
-using osu.Game.Screens.OnlinePlay.Match.Components;
 using osuTK;
 
 namespace osu.Game.Screens.OnlinePlay.Multiplayer
@@ -34,12 +35,14 @@ namespace osu.Game.Screens.OnlinePlay.Multiplayer
         [BackgroundDependencyLoader]
         private void load()
         {
-            ButtonsContainer.Add(ChangeSettingsButton = new PurpleRoundedButton
+            ButtonsContainer.Add(ChangeSettingsButton = new ShearedButton
             {
                 RelativeSizeAxes = Axes.Y,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(120, 0.7f),
+                Size = new Vector2(130, 1),
+                DarkerColour = Color4Extensions.FromHex(@"593790"),
+                LighterColour = Color4Extensions.FromHex(@"593790").Lighten(0.5f),
                 Text = "Change settings",
                 Action = () => OnEdit?.Invoke()
             });

--- a/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Playlists/PlaylistsRoomSubScreen.cs
@@ -199,7 +199,8 @@ namespace osu.Game.Screens.OnlinePlay.Playlists
                                         {
                                             new PlaylistsRoomPanel(room)
                                             {
-                                                SelectedItem = SelectedItem
+                                                SelectedItem = SelectedItem,
+                                                ShowDescription = true,
                                             }
                                         },
                                         null,


### PR DESCRIPTION
Apparently this field has existed for a good while (https://github.com/ppy/osu-web/pull/12362) but went unused, so this PR should fix that.

Right now it can't be set directly, but we can reconsider that in the future if there's demand, given the only area it's really needed right now is daily challenge rooms to display themed week info.

Will need an ASS update to the related command from @peppy.

<table>
<tr>
 <td>Daily Challenge
 <td> <img width="1323" height="165" alt="image" src="https://github.com/user-attachments/assets/03847b5c-3b11-4ffe-b673-bac270b21374" />
<tr>
 <td>Multiplayer
 <td> <img width="1205" height="147" alt="image" src="https://github.com/user-attachments/assets/d36ec59a-55fa-47b8-b434-5d02bc1b179b" />
 <tr>
 <td>Playlist
 <td> <img width="1201" height="147" alt="image" src="https://github.com/user-attachments/assets/04fc2e56-f2f5-4a2f-9a3f-7800355b4aa1" />
</table>
