### PR TITLE
Fix storyboard decode hanging on self-referential variable definitions

### DIFF
--- a/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
+++ b/osu.Game.Tests/Beatmaps/Formats/LegacyStoryboardDecoderTest.cs
@@ -210,6 +210,23 @@ namespace osu.Game.Tests.Beatmaps.Formats
         }
 
         [Test]
+        public void TestDecodeSelfReferencingVariableDoesNotHang()
+        {
+            var decoder = new LegacyStoryboardDecoder();
+
+            using (var resStream = TestResources.OpenResource("variable-with-self-reference.osb"))
+            using (var stream = new LineBufferedReader(resStream))
+            {
+                // a self-referential variable definition (e.g. $self=x$self) must not cause the decode to loop indefinitely.
+                var storyboard = decoder.Decode(stream);
+
+                // the remaining (well-formed) sprite is still decoded correctly.
+                StoryboardLayer background = storyboard.Layers.Single(l => l.Depth == 3);
+                ClassicAssert.AreEqual(320, ((StoryboardSprite)background.Elements.Single()).InitialPosition.X);
+            }
+        }
+
+        [Test]
         public void TestDecodeVideoWithLowercaseExtension()
         {
             var decoder = new LegacyStoryboardDecoder();

--- a/osu.Game.Tests/Resources/variable-with-self-reference.osb
+++ b/osu.Game.Tests/Resources/variable-with-self-reference.osb
@@ -1,0 +1,6 @@
+[Variables]
+$self=x$self
+
+[Events]
+Sprite,Foreground,TopCentre,"selfref.jpg",$self,240
+Sprite,Background,TopCentre,"normal.jpg",320,240

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -402,6 +402,7 @@ namespace osu.Game.Beatmaps.Formats
         /// every well-formed reference. This intentionally avoids repeatedly re-scanning the line,
         /// which would otherwise never terminate for a self-referential definition (e.g. <c>$a=x$a</c>).
         /// </remarks>
+        /// <seealso href="https://github.com/peppy/osu-stable-reference/blob/c34a74fb61c17c5667486a12548485d1f03baa2e/osu!/GameplayElements/HitObjectManager_LoadSave.cs#L1105-L1110"/>
         /// <param name="line">The line which may contains variables.</param>
         private void decodeVariables(ref string line)
         {

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -406,6 +406,9 @@ namespace osu.Game.Beatmaps.Formats
         /// <param name="line">The line which may contains variables.</param>
         private void decodeVariables(ref string line)
         {
+            if (!line.Contains('$'))
+                return;
+
             foreach (var v in variables)
                 line = line.Replace(v.Key, v.Value);
         }

--- a/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
+++ b/osu.Game/Beatmaps/Formats/LegacyStoryboardDecoder.cs
@@ -396,19 +396,17 @@ namespace osu.Game.Beatmaps.Formats
         /// <summary>
         /// Decodes any beatmap variables present in a line into their real values.
         /// </summary>
+        /// <remarks>
+        /// Each defined variable is substituted a single time. Storyboard variables are plain text
+        /// substitutions and are not expected to reference other variables, so a single pass resolves
+        /// every well-formed reference. This intentionally avoids repeatedly re-scanning the line,
+        /// which would otherwise never terminate for a self-referential definition (e.g. <c>$a=x$a</c>).
+        /// </remarks>
         /// <param name="line">The line which may contains variables.</param>
         private void decodeVariables(ref string line)
         {
-            while (line.Contains('$'))
-            {
-                string origLine = line;
-
-                foreach (var v in variables)
-                    line = line.Replace(v.Key, v.Value);
-
-                if (line == origLine)
-                    break;
-            }
+            foreach (var v in variables)
+                line = line.Replace(v.Key, v.Value);
         }
     }
 }


### PR DESCRIPTION
A storyboard `[Variables]` entry whose value re-introduces its own key causes `LegacyStoryboardDecoder.decodeVariables()` to loop forever, hanging the game.

### Details

`decodeVariables()` substitutes every variable into a line, repeating until a full pass makes no change:

```csharp
while (line.Contains('$'))
{
    string origLine = line;

    foreach (var v in variables)
        line = line.Replace(v.Key, v.Value);

    if (line == origLine)
        break;
}
```

If a variable's value contains its own key (e.g. `$a=x$a`), each pass replaces `$a` with `x$a`, so the line grows by one character every iteration, always still contains `$`, and never equals `origLine` — the loop never terminates. (A doubling form such as `$a=$a$a` instead grows the line exponentially until it throws `OutOfMemoryException`.)

The storyboard is decoded lazily when a beatmap is played, so a beatmap containing such a storyboard imports normally and then hangs the client the moment the map is started. The `try`/`catch` in `WorkingBeatmapCache.GetStoryboard()` cannot catch a non-terminating loop and there is no watchdog, so recovery requires force-killing the process.

Minimal reproducer (as a `.osb`, or the `[Variables]`/`[Events]` sections of a `.osu`):

```
[Variables]
$a=x$a

[Events]
$a
```

### Fix

Substitute each defined variable a single time instead of repeatedly re-scanning the line. Storyboard variables are plain text substitutions and are not expected to reference other variables, so a single pass resolves every well-formed reference (including the existing `variable-with-suffix` case) while removing the re-scan that never terminates for a self-referential definition.

Added a regression test that decodes a self-referential definition and asserts the surrounding well-formed sprite still decodes correctly.
