### PR TITLE
Revert "Fix O(n²) overhead from individual blueprint additions / removals by batching"

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -89,6 +89,35 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestSliderPlacementReplacesSliderAtSameStartTime()
+        {
+            Playfield playfield = null!;
+
+            AddStep("seek to 500", () => EditorClock.Seek(500));
+            AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
+            AddStep("grab playfield", () => playfield = this.ChildrenOfType<Playfield>().Single());
+
+            AddStep("start first slider", () =>
+            {
+                InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(0)));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("move", () => InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(100))));
+            AddStep("end first slider", () => InputManager.Click(MouseButton.Right));
+
+            AddStep("start second slider", () =>
+            {
+                InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(200)));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("move", () => InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(300))));
+            AddStep("end second slider", () => InputManager.Click(MouseButton.Right));
+
+            AddAssert("only one hit object", () => EditorBeatmap.HitObjects.Count, () => Is.EqualTo(1));
+            AddAssert("slider at correct position", () => Precision.AlmostEquals(EditorBeatmap.HitObjects.OfType<Slider>().Single().Position, new Vector2(200)));
+        }
+
+        [Test]
         public void TestPlacementOnSliderBodyDoesNotRemoveSlider()
         {
             Slider originalSlider = null!;

--- a/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Caching;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -243,17 +242,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 DragBox.HandleDrag(lastDragEvent);
                 UpdateSelectionFromDragBox(selectionBeforeDrag);
             }
-
-            if (!blueprintsPending.IsValid)
-            {
-                SelectionBlueprints.AddRange(blueprintsToAdd);
-                blueprintsToAdd.Clear();
-
-                SelectionBlueprints.RemoveRange(blueprintsToRemove, true);
-                blueprintsToRemove.Clear();
-
-                blueprintsPending.Validate();
-            }
         }
 
         /// <summary>
@@ -323,10 +311,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Blueprint Addition/Removal
 
-        private readonly Cached blueprintsPending = new Cached();
-        private readonly List<SelectionBlueprint<T>> blueprintsToAdd = new List<SelectionBlueprint<T>>();
-        private readonly List<SelectionBlueprint<T>> blueprintsToRemove = new List<SelectionBlueprint<T>>();
-
         protected virtual void AddBlueprintFor(T item)
         {
             if (blueprintMap.ContainsKey(item))
@@ -341,8 +325,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             blueprint.Selected += OnBlueprintSelected;
             blueprint.Deselected += OnBlueprintDeselected;
 
-            blueprintsToAdd.Add(blueprint);
-            blueprintsPending.Invalidate();
+            SelectionBlueprints.Add(blueprint);
 
             if (SelectionHandler.SelectedItems.Contains(item))
                 blueprint.Select();
@@ -359,8 +342,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             blueprintToRemove.Selected -= OnBlueprintSelected;
             blueprintToRemove.Deselected -= OnBlueprintDeselected;
 
-            blueprintsToRemove.Add(blueprintToRemove);
-            blueprintsPending.Invalidate();
+            SelectionBlueprints.Remove(blueprintToRemove, true);
 
             if (movementBlueprints?.Any(m => m.blueprint == blueprintToRemove) == true)
                 finishSelectionMovement();


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/38483.

See attached test case for reproduction.

The reason why this fixes things is that delaying the addition of the blueprint was causing its nested `DrawableHitObject` to not have `HitObject` applied to it correctly. One place that depends on that and crashes in its absence is object-to-object snapping.

Bad one to let through but short of manually fuzzing editor for however long I'm not sure how I could have seen this one coming. I was hoping tests would catch this sort of thing, which they clearly did not. I suppose this is still karma for attempting to paper over structural shortcomings instead of spending 2 weeks on refactoring everything.

I don't see any evidence on sentry that the other change ("Fix O(n²) overhead from timeline blueprints re-sorting on every depth change") needs reverting, but if it is felt like a safer option to do so I shall oblige. Not like there is any perceivable performance increase from it anyhow.

@peppy Probably worth a hotfix given count of duplicates (https://github.com/ppy/osu/issues/38488, https://github.com/ppy/osu/issues/38489, https://github.com/ppy/osu/issues/38502)