### PR TITLE
Throw when attempting to create ZIP archive with duplicated filenames in entries

### DIFF
--- a/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
+++ b/osu.Game.Tests/Beatmaps/IO/LegacyBeatmapExporterTest.cs
@@ -12,7 +12,9 @@ using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
+using osu.Game.Extensions;
 using osu.Game.IO.Archives;
+using osu.Game.Models;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Tests.Resources;
 using osu.Game.Tests.Visual;
@@ -226,6 +228,43 @@ namespace osu.Game.Tests.Beatmaps.IO
 
                 return false;
             }
+        }
+
+        [Test]
+        public void TestExportFailsOnDuplicateEntry()
+        {
+            IWorkingBeatmap beatmap = null!;
+            BeatmapSetInfo beatmapSetInfo = null!;
+            Exception exception = null!;
+
+            AddStep("import beatmap", () => beatmap = importBeatmapFromArchives(@"241526 Soleily - Renatus.osz"));
+            AddStep("add bogus duplicated file", () =>
+            {
+                Realm.Write(r =>
+                {
+                    var refetchedSet = r.Find<BeatmapSetInfo>(((BeatmapSetInfo)beatmap.BeatmapInfo.BeatmapSet!).ID);
+                    var fileToDuplicate = refetchedSet!.Files.First();
+                    var duplicate = new RealmNamedFileUsage(fileToDuplicate.File, fileToDuplicate.Filename);
+                    refetchedSet.Files.Add(duplicate);
+                    beatmapSetInfo = refetchedSet.Detach();
+                    beatmapSetInfo.Files.AddRange(refetchedSet.Files.Detach());
+                });
+            });
+            AddStep("attempt export", () =>
+            {
+                var outStream = new MemoryStream();
+
+                try
+                {
+                    new LegacyBeatmapExporter(LocalStorage)
+                        .ExportToStream(beatmapSetInfo, outStream, null);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+            });
+            AddUntilStep("exception thrown", () => exception, () => Is.Not.Null);
         }
 
         private IWorkingBeatmap importBeatmapFromStream(Stream stream)

--- a/osu.Game/Database/LegacyArchiveExporter.cs
+++ b/osu.Game/Database/LegacyArchiveExporter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -46,10 +48,14 @@ namespace osu.Game.Database
                 int i = 0;
                 int fileCount = model.Files.Count();
                 bool anyFileMissing = false;
+                HashSet<string> filesWritten = [];
 
                 foreach (var file in model.Files)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
+
+                    if (filesWritten.Contains(file.Filename))
+                        throw new InvalidOperationException($"Error when exporting {model.GetDisplayString()}: Multiple files specify filename of {file.Filename}");
 
                     using (var stream = GetFileContents(model, file))
                     {
@@ -61,6 +67,7 @@ namespace osu.Game.Database
                         }
 
                         writer.Write(file.Filename, stream);
+                        filesWritten.Add(file.Filename);
                     }
 
                     i++;


### PR DESCRIPTION
This came up [in a `osu-server-beatmap-submission` sentry alert](https://sentry.ppy.sh/organizations/ppy/issues/146593).

In this case the server is correct to reject the submission, and there's not really anything the server should be doing, but that begs the question how this happened in the first place. I have no answer to that, as `RealmFileStore.AddFile()` appears to be correctly compensating for the same with the same name already existing.

So for now this is intended to stop the chain of failure one level earlier, which at least probably provides slightly better messaging, and maybe someone will bother to report this better with reproduction steps, at which point maybe the actual primary bug can get fixed too.