### PR TITLE
Fix crash when clicking on another object mid-placement of spinner

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuObjectPlacement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/Editor/TestSceneOsuObjectPlacement.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Testing;
+using osu.Game.Rulesets.Osu.Edit;
+using osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders;
+using osu.Game.Tests.Visual;
+using osuTK.Input;
+
+namespace osu.Game.Rulesets.Osu.Tests.Editor
+{
+    public partial class TestSceneOsuObjectPlacement : EditorTestScene
+    {
+        protected override Ruleset CreateEditorRuleset() => new OsuRuleset();
+
+        [Test]
+        public void TestCannotSelectObjectsMidSpinnerPlacement()
+        {
+            AddStep("seek to first object", () => EditorClock.Seek(EditorBeatmap.HitObjects.First().StartTime));
+            AddStep("select spinner placement tool", () => InputManager.Key(Key.Number4));
+            AddStep("move mouse to composer", () => InputManager.MoveMouseTo(this.ChildrenOfType<OsuHitObjectComposer>().Single()));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            AddStep("move mouse to slider", () => InputManager.MoveMouseTo(this.ChildrenOfType<SliderSelectionBlueprint>()
+                                                                               .Single(b => b.HitObject == EditorBeatmap.HitObjects[0])
+                                                                               .ScreenSpaceSelectionPoint));
+            AddStep("click left mouse", () => InputManager.Click(MouseButton.Left));
+            AddAssert("placement still ongoing", () => EditorBeatmap.PlacementObject, () => Is.Not.Null);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -44,8 +44,16 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
         {
             if (isPlacingEnd)
             {
+                // even if the mouse button isn't the correct button to terminate placement,
+                // clicks must not be allowed to fall through to underlying drawables.
+                // if they were allowed to fall through, they may trigger selection of some other object.
+                // selection of some other object will cause the tool to revert to "select",
+                // which will cause this placement to automatically commit,
+                // which *may* also cause the removal of the object whose selection was attempted
+                // (happens when the start time of this spinner is the same as the start time of clicked object),
+                // and that last possibility *will* result in a hard crash.
                 if (e.Button != MouseButton.Right)
-                    return false;
+                    return true;
 
                 updateEndTimeFromCurrent();
                 EndPlacement(true);


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38509.

You might be thinking: "@bdach is dumb and/or incompetent for not just directly reverting https://github.com/ppy/osu/pull/38464 and instead just reverting half of it in https://github.com/ppy/osu/pull/38506". That is certainly what *I* was thinking until I tried reverting and found that it actually doesn't help. This is actually a silent regression from https://github.com/ppy/osu/pull/37485!

The chain of failure goes something like this:

1. Start with editor seeked to a start time of one of the existing objects.
2. Begin placing a spinner.
3. Click the object that starts at the current time.
4. On master, `SpinnerPlacementBlueprint` does not consume the left click input when spinner placement has already started. This means that the left click input is allowed to fall through to the blueprint container.
5. When the left click input falls through to the blueprint container, it triggers selection logic to fire and the existing object to become selected.
6. Object selection changing also changes the currently used tool to the "select" tool:       https://github.com/ppy/osu/blob/cd27c935d6c15c3c6f2f5b561cc3340130f27407/osu.Game/Rulesets/Edit/HitObjectComposer.cs#L504-L511
7. Changing the currently used tool causes any pending placement to be committed if valid:
    https://github.com/ppy/osu/blob/abbf6e23492c471d722827c5b8baa935fad19419/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs#L437-L438
8. Committing the placement causes *the object whose attempt at selection triggered this entire chain of events to begin with* to be removed:
   https://github.com/ppy/osu/blob/cd27c935d6c15c3c6f2f5b561cc3340130f27407/osu.Game/Rulesets/Edit/HitObjectComposer.cs#L545-L550

   And therefore the failure is understandable, because at that point the placement blueprint of the now-removed object *really* does not reside in the container.

   Prior to https://github.com/ppy/osu/pull/37485 this would not cause an issue because the objects would both exist here.

To fix, prevent the issue at point (4) by making the placement blueprint consume left clicks and not allow fall-through to existing objects.