### PR TITLE
Fix indentation inspection

### DIFF
--- a/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
+++ b/osu.Game.Tests/Visual/Multiplayer/TestSceneRoomPanel.cs
@@ -208,23 +208,23 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Children = new[]
                 {
                     new MultiplayerRoomPanel(new Room
-                    {
-                        Name = "A host-only room",
-                        Description = "Host controls the queue.",
-                        QueueMode = QueueMode.HostOnly,
-                        Type = MatchType.HeadToHead,
-                        RoomID = 1337,
-                    })
-                    { ShowDescription = true },
+                        {
+                            Name = "A host-only room",
+                            Description = "Host controls the queue.",
+                            QueueMode = QueueMode.HostOnly,
+                            Type = MatchType.HeadToHead,
+                            RoomID = 1337,
+                        })
+                        { ShowDescription = true },
                     new MultiplayerRoomPanel(new Room
-                    {
-                        Name = "An all-players, team-versus room",
-                        Description = "Everyone can add maps. Team versus mode.",
-                        QueueMode = QueueMode.AllPlayers,
-                        Type = MatchType.TeamVersus,
-                        RoomID = 1338,
-                    })
-                    { ShowDescription = true },
+                        {
+                            Name = "An all-players, team-versus room",
+                            Description = "Everyone can add maps. Team versus mode.",
+                            QueueMode = QueueMode.AllPlayers,
+                            Type = MatchType.TeamVersus,
+                            RoomID = 1338,
+                        })
+                        { ShowDescription = true },
                     new MultiplayerRoomPanel(new Room
                     {
                         Name = "A round-robin room",
@@ -258,15 +258,15 @@ namespace osu.Game.Tests.Visual.Multiplayer
                 Children = new[]
                 {
                     new MultiplayerRoomPanel(new Room
-                    {
-                        Name =
-                            "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
-                        Description = "This room also has a very very long description sitting under that title to check that it also properly truncates when it reaches the right side of the panel, and if it doesn't, then hello again.",
-                        QueueMode = QueueMode.HostOnly,
-                        Type = MatchType.HeadToHead,
-                        RoomID = 1337,
-                    })
-                    { ShowDescription = true },
+                        {
+                            Name =
+                                "This room has a very very long title enough to make the external link button reach the participants list on the right side unless the test window is very wide, at which point I don't know, hi.",
+                            Description = "This room also has a very very long description sitting under that title to check that it also properly truncates when it reaches the right side of the panel, and if it doesn't, then hello again.",
+                            QueueMode = QueueMode.HostOnly,
+                            Type = MatchType.HeadToHead,
+                            RoomID = 1337,
+                        })
+                        { ShowDescription = true },
                 }
             });
         }


### PR DESCRIPTION
From https://github.com/ppy/osu/pull/38496, see https://github.com/ppy/osu/security/code-scanning/391 and others.

I'm PRing this rather than pushing to master in order to double check that CI is fine with this, because there are weird cases of crosstalk wherein fixing a resharper inspection will trigger a dotnet format inspection in return. I don't *think* that should happen with this from runs on my machine but who knows at this point.

I'm not sure why there was no feedback about this on the original PR itself. Weirdly it seems that sometimes these alerts just do not result in feedback from the actions bot and they only show up once code lands in master. No idea what that's about.