### PR TITLE
Fix incorrect parallax config migration

### DIFF
--- a/osu.Game/OsuGame.cs
+++ b/osu.Game/OsuGame.cs
@@ -1380,7 +1380,7 @@ namespace osu.Game
             if (combined < 20260728)
             {
 #pragma warning disable CS0612 // Type or member is obsolete (MenuParallax exists solely to make this migration work, it should not be used anywhere else)
-                LocalConfig.SetValue(OsuSetting.MenuParallaxScale, LocalConfig.Get<bool>(OsuSetting.MenuParallax) ? 1 : 0);
+                LocalConfig.SetValue<float>(OsuSetting.MenuParallaxScale, LocalConfig.Get<bool>(OsuSetting.MenuParallax) ? 1 : 0);
 #pragma warning restore CS0612 // Type or member is obsolete
             }
         }


### PR DESCRIPTION
See https://sentry.ppy.sh/organizations/ppy/issues/146906 (would show up as an ugly generic "error occurred" notification on every start-up).

Magic bindable config API strikes once more. `1` and `0` literals are inferred to be `int` in generic contexts, which then fails at trying to get the target bindable as `Bindable<int>` instead of `Bindable<float>`.

This is invisible in debug because config migrations do not run in debug.