### PR TITLE
Add gameplay setting to toggle slider tick/end miss markers

### DIFF
--- a/osu.Game.Rulesets.Osu.Tests/TestSceneSliderEndMissJudgement.cs
+++ b/osu.Game.Rulesets.Osu.Tests/TestSceneSliderEndMissJudgement.cs
@@ -1,0 +1,139 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Game.Beatmaps;
+using osu.Game.Configuration;
+using osu.Game.Replays;
+using osu.Game.Rulesets.Judgements;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Objects.Drawables;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Replays;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+using osu.Game.Screens.Play;
+using osu.Game.Tests.Visual;
+using osuTK;
+
+namespace osu.Game.Rulesets.Osu.Tests
+{
+    public partial class TestSceneSliderEndMissJudgement : RateAdjustedBeatmapTestScene
+    {
+        private const double time_slider_start = 1000;
+        private const float slider_path_length = 200;
+
+        private static readonly Vector2 slider_start_position = new Vector2(256 - slider_path_length / 2, 192);
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
+
+        private ScoreAccessibleReplayPlayer currentPlayer = null!;
+        private readonly List<JudgementResult> judgementResults = new List<JudgementResult>();
+
+        [Test]
+        public void TestMissMarkersHidden()
+        {
+            AddStep("disable slider end miss", () => config.SetValue(OsuSetting.ShowSliderEndMiss, false));
+
+            performMiss();
+
+            AddUntilStep("wait for tick miss", () => judgementResults.Any(r => r.Type == HitResult.LargeTickMiss));
+            AddAssert("no slider miss markers shown", () => !currentPlayer.ChildrenOfType<DrawableOsuJudgement>()
+                                                                         .Any(j => j.Result?.Type is HitResult.LargeTickMiss or HitResult.IgnoreMiss));
+        }
+
+        [Test]
+        public void TestMissMarkersShown()
+        {
+            AddStep("enable slider end miss", () => config.SetValue(OsuSetting.ShowSliderEndMiss, true));
+
+            performMiss();
+
+            AddUntilStep("slider miss markers shown", () => currentPlayer.ChildrenOfType<DrawableOsuJudgement>()
+                                                                        .Any(j => j.Result?.Type is HitResult.LargeTickMiss or HitResult.IgnoreMiss));
+        }
+
+        private void performMiss()
+        {
+            performTest(new List<ReplayFrame>
+            {
+                new OsuReplayFrame(time_slider_start - 150, slider_start_position, OsuAction.LeftButton),
+                new OsuReplayFrame(time_slider_start - 50, slider_start_position),
+            });
+        }
+
+        private void performTest(List<ReplayFrame> frames)
+        {
+            AddStep("load player", () =>
+            {
+                Beatmap.Value = CreateWorkingBeatmap(new Beatmap<OsuHitObject>
+                {
+                    HitObjects =
+                    {
+                        new Slider
+                        {
+                            StartTime = time_slider_start,
+                            Position = slider_start_position,
+                            TickDistanceMultiplier = 3,
+                            Path = new SliderPath(PathType.LINEAR, new[]
+                            {
+                                Vector2.Zero,
+                                new Vector2(slider_path_length, 0),
+                            }, slider_path_length),
+                        }
+                    },
+                    BeatmapInfo =
+                    {
+                        Difficulty = new BeatmapDifficulty
+                        {
+                            SliderMultiplier = 1,
+                            SliderTickRate = 3,
+                            OverallDifficulty = 0
+                        },
+                        Ruleset = new OsuRuleset().RulesetInfo,
+                    }
+                });
+
+                var p = new ScoreAccessibleReplayPlayer(new Score { Replay = new Replay { Frames = frames } });
+
+                p.OnLoadComplete += _ =>
+                {
+                    p.ScoreProcessor.NewJudgement += result =>
+                    {
+                        if (currentPlayer == p) judgementResults.Add(result);
+                    };
+                };
+
+                LoadScreen(currentPlayer = p);
+                judgementResults.Clear();
+            });
+
+            AddUntilStep("Beatmap at 0", () => Beatmap.Value.Track.CurrentTime == 0);
+            AddUntilStep("Wait until player is loaded", () => currentPlayer.IsCurrentScreen());
+        }
+
+        private partial class ScoreAccessibleReplayPlayer : ReplayPlayer
+        {
+            public new ScoreProcessor ScoreProcessor => base.ScoreProcessor;
+
+            protected override bool PauseOnFocusLost => false;
+
+            public ScoreAccessibleReplayPlayer(Score score)
+                : base(score, new PlayerConfiguration
+                {
+                    AllowPause = false,
+                    ShowResults = false,
+                })
+            {
+            }
+        }
+    }
+}

--- a/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuPlayfield.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Game.Beatmaps;
+using osu.Game.Configuration;
 using osu.Game.Rulesets.Judgements;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
@@ -51,6 +52,9 @@ namespace osu.Game.Rulesets.Osu.UI
         public override Quad SkinnableComponentScreenSpaceDrawQuad => playfieldBorder.ScreenSpaceDrawQuad;
 
         private readonly Container judgementAboveHitObjectLayer;
+
+        [Resolved]
+        private OsuConfigManager config { get; set; } = null!;
 
         public OsuPlayfield()
         {
@@ -193,6 +197,13 @@ namespace osu.Game.Rulesets.Osu.UI
 
             if (!judgedObject.DisplayResult || !DisplayJudgements.Value)
                 return;
+
+            // LargeTickMiss = slider ticks / ends / repeats; IgnoreMiss = slider tails.
+            if (!config.Get<bool>(OsuSetting.ShowSliderEndMiss)
+                && result.Type is HitResult.LargeTickMiss or HitResult.IgnoreMiss)
+            {
+                return;
+            }
 
             var explosion = judgementPooler.Get(result.Type, doj => doj.Apply(result, judgedObject));
 

--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -148,6 +148,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.HitLighting, true);
             SetDefault(OsuSetting.StarFountains, true);
+            SetDefault(OsuSetting.ShowSliderEndMiss, true);
 
             SetDefault(OsuSetting.HUDVisibilityMode, HUDVisibilityMode.Always);
             SetDefault(OsuSetting.ShowHealthDisplayWhenCantFail, true);
@@ -419,6 +420,7 @@ namespace osu.Game.Configuration
         UIHoldActivationDelay,
         HitLighting,
         StarFountains,
+        ShowSliderEndMiss,
         MenuBackgroundSource,
         GameplayDisableWinKey,
         SeasonalBackgroundMode,

--- a/osu.Game/Localisation/GameplaySettingsStrings.cs
+++ b/osu.Game/Localisation/GameplaySettingsStrings.cs
@@ -80,6 +80,11 @@ namespace osu.Game.Localisation
         public static LocalisableString StarFountains => new TranslatableString(getKey(@"star_fountains"), @"Star fountains");
 
         /// <summary>
+        /// "Show sliderend miss"
+        /// </summary>
+        public static LocalisableString ShowSliderEndMiss => new TranslatableString(getKey(@"show_sliderend_miss"), @"Show sliderend miss");
+
+        /// <summary>
         /// "Always show key overlay"
         /// </summary>
         public static LocalisableString AlwaysShowKeyOverlay => new TranslatableString(getKey(@"key_overlay"), @"Always show key overlay");

--- a/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Gameplay/GeneralSettings.cs
@@ -40,6 +40,11 @@ namespace osu.Game.Overlays.Settings.Sections.Gameplay
                     Caption = GameplaySettingsStrings.StarFountains,
                     Current = config.GetBindable<bool>(OsuSetting.StarFountains)
                 }),
+                new SettingsItemV2(new FormCheckBox
+                {
+                    Caption = GameplaySettingsStrings.ShowSliderEndMiss,
+                    Current = config.GetBindable<bool>(OsuSetting.ShowSliderEndMiss)
+                }),
             };
         }
     }


### PR DESCRIPTION
Adds a "Show sliderend miss" option under Gameplay settings that controls whether LargeTickMiss and IgnoreMiss judgement visuals are displayed during play.

I myself have only just began to switch from stable, and this was always one of the problems I had with the gameplay.

<img width="598" height="329" alt="image" src="https://github.com/user-attachments/assets/c9111ffc-2918-4e5c-8f97-95127a16f745" />

Extremely simple addition to the code, avoiding the need for users to use the `sliderendmiss.png` workaround in this [forum post](https://osu.ppy.sh/community/forums/topics/1890272?n=2) for every skin individually - especially considering the way "edit externally" works.

I have just placed the option in **Gameplay** under the **General** tab for now, but please move if you feel there is a better place/name for it.

I have read some discussions from the past, [here](https://github.com/ppy/osu/discussions/26653), and I have seen that you have changed the animation, but I think that allowing a toggle for users to remove it entirely would be a better idea, unless you are afraid of too many settings etc.

I am unsure if tests are required, so if not, you can remove them.

