### PR TITLE
Save last song select collection filter to local config

### DIFF
--- a/osu.Game/Configuration/OsuConfigManager.cs
+++ b/osu.Game/Configuration/OsuConfigManager.cs
@@ -51,6 +51,7 @@ namespace osu.Game.Configuration
 
             SetDefault(OsuSetting.SongSelectGroupMode, GroupMode.None);
             SetDefault(OsuSetting.SongSelectSortingMode, SortMode.Title);
+            SetDefault(OsuSetting.SongSelectCollectionFilter, string.Empty);
 
             SetDefault(OsuSetting.RandomSelectAlgorithm, RandomSelectAlgorithm.RandomPermutation);
             SetDefault(OsuSetting.ModSelectHotkeyStyle, ModSelectHotkeyStyle.Sequential);
@@ -385,6 +386,7 @@ namespace osu.Game.Configuration
         DisplayStarsMaximum,
         SongSelectGroupMode,
         SongSelectSortingMode,
+        SongSelectCollectionFilter,
         RandomSelectAlgorithm,
         ModSelectHotkeyStyle,
         ShowFpsDisplay,

--- a/osu.Game/Screens/Select/CollectionDropdown.cs
+++ b/osu.Game/Screens/Select/CollectionDropdown.cs
@@ -15,6 +15,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
+using osu.Game.Configuration;
 using osu.Game.Database;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
@@ -36,6 +37,7 @@ namespace osu.Game.Screens.Select
         protected virtual bool ShowManageCollectionsItem => true;
 
         private readonly BindableList<CollectionFilterMenuItem> filters = new BindableList<CollectionFilterMenuItem>();
+        private readonly Bindable<string> configCollectionFilter = new Bindable<string>();
 
         [Resolved]
         private ManageCollectionsDialog? manageCollectionsDialog { get; set; }
@@ -56,6 +58,12 @@ namespace osu.Game.Screens.Select
             AlwaysShowSearchBar = true;
         }
 
+        [BackgroundDependencyLoader]
+        private void load(OsuConfigManager configManager)
+        {
+            configManager.BindWith(OsuSetting.SongSelectCollectionFilter, configCollectionFilter);
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -74,6 +82,8 @@ namespace osu.Game.Screens.Select
                 filters.AddRange(collections.Select(c => new CollectionFilterMenuItem(c.ToLive(realm))));
                 if (ShowManageCollectionsItem)
                     filters.Add(new ManageCollectionsFilterMenuItem());
+
+                Current.Value = filters.SingleOrDefault(item => item.Collection?.PerformRead(c => c.ID.ToString()) == configCollectionFilter.Value) ?? allBeatmapsItem;
             }
             else
             {
@@ -121,12 +131,22 @@ namespace osu.Game.Screens.Select
             if (filter.NewValue.IsNull())
                 return;
 
-            // Never select the manage collection filter - rollback to the previous filter.
-            // This is done after the above since it is important that bindable is unbound from OldValue, which is lost after forcing it back to the old value.
-            if (filter.NewValue is ManageCollectionsFilterMenuItem)
+            switch (filter.NewValue)
             {
-                Current.Value = filter.OldValue;
-                manageCollectionsDialog?.Show();
+                case ManageCollectionsFilterMenuItem:
+                    // Never select the manage collection filter - rollback to the previous filter.
+                    // This is done after the above since it is important that bindable is unbound from OldValue, which is lost after forcing it back to the old value.
+                    Current.Value = filter.OldValue;
+                    manageCollectionsDialog?.Show();
+                    break;
+
+                case CollectionFilterMenuItem collectionMenuItem when collectionMenuItem.Collection != null:
+                    configCollectionFilter.Value = collectionMenuItem.Collection.PerformRead(c => c.ID.ToString());
+                    break;
+
+                case AllBeatmapsCollectionFilterMenuItem:
+                    configCollectionFilter.Value = string.Empty;
+                    break;
             }
         }
 

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -46,7 +47,7 @@ namespace osu.Game.Screens.Select
         private DifficultyRangeSlider difficultyRangeSlider = null!;
         private ShearedDropdown<SortMode> sortDropdown = null!;
         private ShearedDropdown<GroupModeDropdownItem> groupDropdown = null!;
-        private CollectionDropdown collectionDropdown = null!;
+        private readonly Bindable<string> configCollectionFilter = new Bindable<string>();
 
         /// <summary>
         /// An optional method which can force certain criteria adjustments.
@@ -196,7 +197,7 @@ namespace osu.Game.Screens.Select
                                                 RelativeSizeAxes = Axes.X,
                                             },
                                             Empty(),
-                                            collectionDropdown = new CollectionDropdown
+                                            new CollectionDropdown
                                             {
                                                 RelativeSizeAxes = Axes.X,
                                             },
@@ -225,6 +226,7 @@ namespace osu.Game.Screens.Select
             difficultyRangeSlider.UpperBound = config.GetBindable<double>(OsuSetting.DisplayStarsMaximum);
             config.BindWith(OsuSetting.ShowConvertedBeatmaps, showConvertedBeatmapsButton.Active);
             config.BindWith(OsuSetting.SongSelectSortingMode, sortDropdown.Current);
+            config.BindWith(OsuSetting.SongSelectCollectionFilter, configCollectionFilter);
 
             ruleset.BindValueChanged(_ => updateCriteria());
             mods.BindValueChanged(m =>
@@ -261,15 +263,7 @@ namespace osu.Game.Screens.Select
             showConvertedBeatmapsButton.Active.BindValueChanged(_ => updateCriteria());
             sortDropdown.Current.BindValueChanged(_ => updateCriteria());
             groupDropdown.Current.BindValueChanged(_ => updateCriteria());
-            collectionDropdown.Current.BindValueChanged(v =>
-            {
-                // The hope would be that this never arrives here, but due to bindings receiving changes before
-                // local ValueChanged events, that's not the case (see https://github.com/ppy/osu-framework/pull/1545).
-                if (v.NewValue is ManageCollectionsFilterMenuItem || v.OldValue is ManageCollectionsFilterMenuItem)
-                    return;
-
-                updateCriteria();
-            });
+            configCollectionFilter.BindValueChanged(_ => updateCriteria());
             collectionsSubscription = realm.RegisterForNotifications(r => r.All<BeatmapCollection>(), (_, changeSet) =>
             {
                 if (changeSet != null && groupDropdown.Current.Value.Value == GroupMode.Collections)
@@ -297,6 +291,11 @@ namespace osu.Game.Screens.Select
             string query = searchTextBox.Current.Value;
             bool isValidUser = localUser.Value.Id > 1;
 
+            IEnumerable<string>? collectionBeatmapMD5Hashes = null;
+
+            if (Guid.TryParse(configCollectionFilter.Value, out var collectionId))
+                collectionBeatmapMD5Hashes = realm.Run(r => r.Find<BeatmapCollection>(collectionId)?.BeatmapMD5Hashes.ToImmutableHashSet());
+
             var criteria = new FilterCriteria
             {
                 SelectedBeatmapSet = ScopedBeatmapSet.Value,
@@ -305,7 +304,7 @@ namespace osu.Game.Screens.Select
                 AllowConvertedBeatmaps = showConvertedBeatmapsButton.Active.Value,
                 Ruleset = ruleset.Value,
                 Mods = mods.Value,
-                Collection = collectionDropdown.Current.Value?.Collection,
+                CollectionBeatmapMD5Hashes = collectionBeatmapMD5Hashes,
                 LocalUserId = isValidUser ? localUser.Value.Id : null,
                 LocalUserUsername = isValidUser ? localUser.Value.Username : null,
             };

--- a/osu.Game/Screens/Select/FilterCriteria.cs
+++ b/osu.Game/Screens/Select/FilterCriteria.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using osu.Game.Beatmaps;
 using osu.Game.Collections;
-using osu.Game.Database;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Filter;
 using osu.Game.Rulesets.Mods;
@@ -113,24 +111,10 @@ namespace osu.Game.Screens.Select
             }
         }
 
-        private ImmutableHashSet<string>? collectionBeatmapMD5Hashes;
-        private Live<BeatmapCollection>? collection;
-
         /// <summary>
         /// Hashes from the <see cref="BeatmapCollection"/> to filter to.
         /// </summary>
-        public IEnumerable<string>? CollectionBeatmapMD5Hashes =>
-            collectionBeatmapMD5Hashes ??= Collection?.PerformRead(c => c.BeatmapMD5Hashes.ToImmutableHashSet());
-
-        public Live<BeatmapCollection>? Collection
-        {
-            get => collection;
-            set
-            {
-                collection = value;
-                collectionBeatmapMD5Hashes = null;
-            }
-        }
+        public IEnumerable<string>? CollectionBeatmapMD5Hashes { get; set; }
 
         public IRulesetFilterCriteria? RulesetCriteria { get; set; }
 


### PR DESCRIPTION
Implications of this change:

- The last used collection filter will be preserved across game restarts.
- The collection filter will be preserved across song selects in solo, multiplayer, and playlists.

https://github.com/user-attachments/assets/36bb2c7d-2751-4038-b81a-4f2b7a4f9b59

---

Written to address https://osu.ppy.sh/comments/4150059.

Aside from the obvious part of this, there's also https://github.com/ppy/osu/commit/ff1b3874534676d6e5075d6ab43ed44ce35867eb. I will restate the message of that commit for readers' convenience and so that it does not get lost to a squash:

> The previous flow was heavily relying on realm subscriptions. `FilterCriteria` expected to receive a direct `Live<BeatmapCollection>` from the dropdown. Because the realm subscription would only come alive after the initial load of the screen, the result would be that when restoring a collection filter from config, the carousel would filter once without the collection filter and then once again with it.
>
> This works around this issue by changing source of truth from the `Live<BeatmapCollection>` exposed by the dropdown to the stringified GUID in config, which is immediately available. This does however mean that the burden of retrieving the MD5 hashes of beatmaps in the selected collection is shifted from the lazy read in `BeatmapCarouselFilterMatching` via `FilterCriteria` (which runs on a TPL thread) onto the construction of the `FilterCriteria` (which runs on update thread), but *something* has to give here.