### PR TITLE
Minimize crash/freezes on multiple "block all realm operations"

### DIFF
--- a/osu.Game/Database/RealmDetachedBeatmapStore.cs
+++ b/osu.Game/Database/RealmDetachedBeatmapStore.cs
@@ -62,16 +62,16 @@ namespace osu.Game.Database
                 {
                     try
                     {
-                        realm.Run(_ =>
-                        {
-                            var detached = frozenSets.Detach();
+                        // operations purposefully not wrapped in `Realm.Run()`.
+                        // `frozenSets` is, as the name suggests, frozen, and thus documented as safe to access from any thread for reading.
+                        // using `Realm.Run()` would only be misdirection here as it would take out a *second, non-frozen* realm instance.
+                        var detached = frozenSets.Detach();
 
-                            lock (detachedBeatmapSets)
-                            {
-                                detachedBeatmapSets.Clear();
-                                detachedBeatmapSets.AddRange(detached);
-                            }
-                        });
+                        lock (detachedBeatmapSets)
+                        {
+                            detachedBeatmapSets.Clear();
+                            detachedBeatmapSets.AddRange(detached);
+                        }
                     }
                     finally
                     {

--- a/osu.Game/Database/RealmDetachedBeatmapStore.cs
+++ b/osu.Game/Database/RealmDetachedBeatmapStore.cs
@@ -76,6 +76,7 @@ namespace osu.Game.Database
                     finally
                     {
                         loaded.Set();
+                        frozenSets.Realm.Dispose();
                     }
                 }, TaskCreationOptions.LongRunning).FireAndForget();
 

--- a/osu.Game/Database/RealmDetachedBeatmapStore.cs
+++ b/osu.Game/Database/RealmDetachedBeatmapStore.cs
@@ -76,6 +76,22 @@ namespace osu.Game.Database
                     finally
                     {
                         loaded.Set();
+
+                        // Freezing a collection incurs a full freeze of the realm too,
+                        // which wraps a separate new `SharedRealmHandle` representing the frozen realm:
+                        // https://github.com/realm/realm-dotnet/blob/113c01264fc00f6cedf3c829caa9cfb30b963914/Realm/Realm/DatabaseTypes/RealmCollectionBase.cs#L180-L191
+                        // (note suppressed CA2000 inspection above!)
+                        // https://github.com/realm/realm-dotnet/blob/113c01264fc00f6cedf3c829caa9cfb30b963914/Realm/Realm/Handles/SharedRealmHandle.cs#L650-L655
+                        // https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/impl/realm_coordinator.cpp#L296-L313
+                        //
+                        // The freezing API on the .NET side does not expose a direct way to eagerly clean up that frozen handle.
+                        // It appears that handle is simply allowed to fall out of scope and eventually get picked up by GC.
+                        // This is a problem when considering interactions with the `BlockAllOperations()` API,
+                        // which is designed to support moving the realm to custom locations.
+                        // Not eagerly disposing the realm associated with the frozen collection as below can cause `BlockAllOperations()` to time out and crash.
+                        //
+                        // If freezing objects and/or collections is going to be more widely used in the repository,
+                        // this should be extracted to an extension method and the direct usage of the freezing APIs banned in kind via `BannedSymbols.txt`.
                         frozenSets.Realm.Dispose();
                     }
                 }, TaskCreationOptions.LongRunning).FireAndForget();

--- a/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/DebugSettings/MemorySettings.cs
@@ -71,9 +71,16 @@ namespace osu.Game.Overlays.Settings.Sections.DebugSettings
                         Text = @"Compact realm",
                         Action = () =>
                         {
-                            // Blocking operations implicitly causes a Compact().
-                            using (realm.BlockAllOperations(@"compact"))
+                            try
                             {
+                                // Blocking operations implicitly causes a Compact().
+                                using (realm.BlockAllOperations(@"compact"))
+                                {
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Logger.Error(e, @"Compacting realm failed");
                             }
                         }
                     },


### PR DESCRIPTION
Using the compact or block realm buttons semi quickly in succession would lead to a crash in the former and the long freeze and unblock in the latter case. This is also technically reachable from folder migration path, but way less easy to do.

(Error: `System.TimeoutException: Realm compact failed after 26 attempts over 5 seconds`)

Turns out `RealmDetachedBeatmapStore` holds its frozen realm reader open for quite some time longer than it needs to (until GC), so dispose it manually as soon as the work is done to avoid unnecessarily blocking the next operations that needs to block realm operations. Also wrap compacting in `try/catch` to align with the block all operations button and avoid the crash if the background work still takes "too long".

The test for multiple migrations in succession
`CustomDataDirectoryTest.TestMigrationBetweenTwoTargets` did not catch it, because `RealmDetachedBeatmapStore` is not used in `OsuGameBase`.

Before:

https://github.com/user-attachments/assets/a020255d-4c93-45d9-870a-74fe15512022

After:

https://github.com/user-attachments/assets/8347f14a-7bbf-4a09-919f-08effdc06621