### PR TITLE
Fix legacy bar hit error meter origin resetting to center on every load

### DIFF
--- a/osu.Game/Screens/Play/HUD/HitErrorMeters/LegacyBarHitErrorMeter.cs
+++ b/osu.Game/Screens/Play/HUD/HitErrorMeters/LegacyBarHitErrorMeter.cs
@@ -37,7 +37,6 @@ namespace osu.Game.Screens.Play.HUD.HitErrorMeters
 
             AutoSizeAxes = Axes.X;
             Height = (bar_height * 4) * LegacySkin.STABLE_MAGIC_SCALE_FACTOR;
-            Origin = Anchor.Centre;
             InternalChildren = new Drawable[]
             {
                 new Box


### PR DESCRIPTION
My first contribution, hope I did nothing wrong.
Closes #38569
| master | This PR |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/604a6b9a-fa0d-44f4-a6f2-2d28cce9098e"/> | <video src="https://github.com/user-attachments/assets/45d26070-54ea-454a-a23c-16666cc04712"/> |