### PR TITLE
Fix text clipping on form controls

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -219,7 +219,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Height = 16;
                 TextContainer.Height = 1;
                 BackgroundUnfocused = BackgroundFocused = BackgroundCommit = Colour4.Transparent;
-                Masking = false;
+                CornerRadius = 0;
             }
 
             protected override SpriteText CreatePlaceholder() => base.CreatePlaceholder().With(t => t.Margin = default);

--- a/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormTextBox.cs
@@ -219,6 +219,7 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 Height = 16;
                 TextContainer.Height = 1;
                 BackgroundUnfocused = BackgroundFocused = BackgroundCommit = Colour4.Transparent;
+                Masking = false;
             }
 
             protected override SpriteText CreatePlaceholder() => base.CreatePlaceholder().With(t => t.Margin = default);


### PR DESCRIPTION
| before | after | 
| :-: | :-: |
| <img width="428" height="68" alt="Screenshot 2026-08-10 at 08 35 11" src="https://github.com/user-attachments/assets/382fd113-5b8f-428d-a394-bbed48cda151" /> | <img width="428" height="68" alt="Screenshot 2026-08-10 at 08 35 34" src="https://github.com/user-attachments/assets/dacf9bac-eafb-4b25-8ba3-a7be9101724e" /> |

---

Closes https://github.com/ppy/osu/issues/38558.