### PR TITLE
Inherit previous object's sample settings in polygon tool

### DIFF
--- a/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
@@ -9,7 +9,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Game.Beatmaps.ControlPoints;
-using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
@@ -25,6 +24,8 @@ namespace osu.Game.Rulesets.Osu.Edit
 {
     public partial class PolygonGenerationPopover : OsuPopover
     {
+        private DependencyContainer dependencies = null!;
+
         private FormSliderBar<double> distanceSnapInput { get; set; } = null!;
         private FormSliderBar<int> offsetAngleInput { get; set; } = null!;
         private FormSliderBar<int> repeatCountInput { get; set; } = null!;
@@ -50,14 +51,16 @@ namespace osu.Game.Rulesets.Osu.Edit
         [Resolved]
         private HitObjectComposer composer { get; set; } = null!;
 
-        private Bindable<TernaryState> newComboState = null!;
+        private PlacementStateManager? placementStateManager;
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            return dependencies = new DependencyContainer(parent);
+        }
 
         [BackgroundDependencyLoader]
         private void load()
         {
-            var selectionHandler = (EditorSelectionHandler)composer.BlueprintContainer.SelectionHandler;
-            newComboState = selectionHandler.SelectionNewComboState.GetBoundCopy();
-
             AllowableAnchors = new[] { Anchor.CentreLeft, Anchor.CentreRight };
 
             Child = new FillFlowContainer
@@ -120,6 +123,8 @@ namespace osu.Game.Rulesets.Osu.Edit
                     }
                 }
             };
+
+            dependencies.CacheAs(composer.BlueprintContainer.SelectionHandler);
         }
 
         protected override void LoadComplete()
@@ -133,7 +138,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             offsetAngleInput.Current.BindValueChanged(_ => Scheduler.AddOnce(tryCreatePolygon));
             repeatCountInput.Current.BindValueChanged(_ => Scheduler.AddOnce(tryCreatePolygon));
             pointInput.Current.BindValueChanged(_ => Scheduler.AddOnce(tryCreatePolygon));
-            newComboState.BindValueChanged(_ => Scheduler.AddOnce(tryCreatePolygon));
             tryCreatePolygon();
         }
 
@@ -162,7 +166,6 @@ namespace osu.Game.Rulesets.Osu.Edit
             {
                 float angle = float.DegreesToRadians(offsetAngleInput.Current.Value) + (i + 1) * (2 * float.Pi / pointInput.Current.Value);
                 var position = OsuPlayfield.BASE_SIZE / 2 + new Vector2(polygonRadius * float.Cos(angle), polygonRadius * float.Sin(angle));
-                bool newCombo = i == 0 && newComboState.Value == TernaryState.True;
 
                 HitCircle circle;
 
@@ -172,9 +175,6 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                     circle.Position = position;
                     circle.StartTime = startTime;
-                    circle.NewCombo = newCombo;
-
-                    editorBeatmap.Update(circle);
                 }
                 else
                 {
@@ -182,12 +182,10 @@ namespace osu.Game.Rulesets.Osu.Edit
                     {
                         Position = position,
                         StartTime = startTime,
-                        NewCombo = newCombo,
                     };
 
                     newlyAdded.Add(circle);
 
-                    // TODO: probably ensure samples also follow current ternary status (not trivial)
                     circle.Samples.Add(circle.CreateHitSampleInfo());
                 }
 
@@ -202,14 +200,14 @@ namespace osu.Game.Rulesets.Osu.Edit
                 startTime = beatSnapProvider.SnapTime(startTime + timeSpacing);
             }
 
-            var previousNewComboState = newComboState.Value;
-
             insertedCircles.AddRange(newlyAdded);
             editorBeatmap.AddRange(newlyAdded);
 
-            // When adding new hitObjects, newCombo state will get reset to false when no objects are selected.
-            // Since this is the case when this popover is showing, we need to restore the previous newCombo state
-            newComboState.Value = previousNewComboState;
+            placementStateManager?.RemoveAndDisposeImmediately();
+            Content.Add(placementStateManager = new PlacementStateManager(insertedCircles.Cast<HitObject>().ToArray())
+            {
+                PerformBeatmapUpdates = true,
+            });
 
             commitButton.Enabled.Value = true;
         }

--- a/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
+++ b/osu.Game.Rulesets.Osu/Edit/PolygonGenerationPopover.cs
@@ -124,6 +124,8 @@ namespace osu.Game.Rulesets.Osu.Edit
                 }
             };
 
+            // TODO: This is a pretty ugly dependency chain.
+            // We should look to rearrange things to avoid this altogether.
             dependencies.CacheAs(composer.BlueprintContainer.SelectionHandler);
         }
 

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -1212,6 +1212,89 @@ namespace osu.Game.Tests.Visual.Editing
             hitObjectHasAutoAdditionBankFlag(0, true);
         }
 
+        [Test]
+        public void TestPolygonGenerationInheritsSettings()
+        {
+            AddStep("seek to 1000", () => EditorClock.Seek(1000));
+            AddStep("open polygon tool", () =>
+            {
+                InputManager.PressKey(Key.LShift);
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.D);
+                InputManager.ReleaseKey(Key.LControl);
+                InputManager.ReleaseKey(Key.LShift);
+            });
+
+            for (int i = 2; i <= 4; ++i)
+            {
+                hitObjectHasSamples(i, HitSampleInfo.HIT_NORMAL);
+                hitObjectHasSampleBank(i, HitSampleInfo.BANK_SOFT);
+                hitObjectHasAutoNormalBankFlag(i, true);
+                hitObjectHasSampleVolume(i, 60);
+            }
+
+            AddStep("add finish sound", () => InputManager.Key(Key.E));
+
+            for (int i = 2; i <= 4; ++i)
+            {
+                hitObjectHasSamples(i, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
+                hitObjectHasSampleBank(i, HitSampleInfo.BANK_SOFT);
+                hitObjectHasAutoNormalBankFlag(i, true);
+                hitObjectHasAutoAdditionBankFlag(i, true);
+                hitObjectHasSampleVolume(i, 60);
+            }
+
+            AddStep("set addition bank to drum", () =>
+            {
+                InputManager.PressKey(Key.LAlt);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.LAlt);
+            });
+
+            for (int i = 2; i <= 4; ++i)
+            {
+                hitObjectHasSamples(i, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
+                hitObjectHasSampleNormalBank(i, HitSampleInfo.BANK_SOFT);
+                hitObjectHasAutoNormalBankFlag(i, true);
+                hitObjectHasSampleAdditionBank(i, HitSampleInfo.BANK_DRUM);
+                hitObjectHasAutoAdditionBankFlag(i, false);
+                hitObjectHasSampleVolume(i, 60);
+            }
+
+            AddStep("set normal bank to normal", () =>
+            {
+                InputManager.PressKey(Key.LShift);
+                InputManager.Key(Key.W);
+                InputManager.ReleaseKey(Key.LShift);
+            });
+
+            for (int i = 2; i <= 4; ++i)
+            {
+                hitObjectHasSamples(i, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
+                hitObjectHasSampleNormalBank(i, HitSampleInfo.BANK_NORMAL);
+                hitObjectHasAutoNormalBankFlag(i, false);
+                hitObjectHasSampleAdditionBank(i, HitSampleInfo.BANK_DRUM);
+                hitObjectHasAutoAdditionBankFlag(i, false);
+                hitObjectHasSampleVolume(i, 60);
+            }
+
+            AddStep("set addition bank to auto", () =>
+            {
+                InputManager.PressKey(Key.LAlt);
+                InputManager.Key(Key.Q);
+                InputManager.ReleaseKey(Key.LAlt);
+            });
+
+            for (int i = 2; i <= 4; ++i)
+            {
+                hitObjectHasSamples(i, HitSampleInfo.HIT_NORMAL, HitSampleInfo.HIT_FINISH);
+                hitObjectHasSampleBank(i, HitSampleInfo.BANK_NORMAL);
+                hitObjectHasAutoNormalBankFlag(i, false);
+                hitObjectHasAutoAdditionBankFlag(i, true);
+                hitObjectHasSampleVolume(i, 60);
+            }
+        }
+
         private void clickSamplePiece(int objectIndex)
         {
             AddStep("switch tool to select", () => InputManager.Key(Key.Number1));

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -1212,13 +1212,17 @@ namespace osu.Game.Tests.Visual.Editing
             hitObjectHasAutoAdditionBankFlag(0, true);
         }
 
-        private void clickSamplePiece(int objectIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} sample piece", () =>
+        private void clickSamplePiece(int objectIndex)
         {
-            var samplePiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece is not NodeSamplePointPiece && piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
+            AddStep("switch tool to select", () => InputManager.Key(Key.Number1));
+            AddStep($"click {objectIndex.ToOrdinalWords()} sample piece", () =>
+            {
+                var samplePiece = this.ChildrenOfType<SamplePointPiece>().Single(piece => piece is not NodeSamplePointPiece && piece.HitObject == EditorBeatmap.HitObjects.ElementAt(objectIndex));
 
-            InputManager.MoveMouseTo(samplePiece);
-            InputManager.Click(MouseButton.Left);
-        });
+                InputManager.MoveMouseTo(samplePiece);
+                InputManager.Click(MouseButton.Left);
+            });
+        }
 
         private void clickNodeSamplePiece(int objectIndex, int nodeIndex) => AddStep($"click {objectIndex.ToOrdinalWords()} object {nodeIndex.ToOrdinalWords()} node sample piece", () =>
         {

--- a/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
@@ -12,9 +12,9 @@ using osu.Game.Audio;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose;
+using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
 namespace osu.Game.Rulesets.Edit
@@ -47,12 +47,12 @@ namespace osu.Game.Rulesets.Edit
 
         private Bindable<double> startTimeBindable = null!;
 
-        private HitObject? getPreviousHitObject() => beatmap.HitObjects.TakeWhile(h => h.StartTime <= startTimeBindable.Value).LastOrDefault();
-
         protected override bool IsValidForPlacement => HitObject.StartTime >= beatmap.ControlPointInfo.TimingPoints.FirstOrDefault()?.Time;
 
         [Resolved]
         private IPlacementHandler placementHandler { get; set; } = null!;
+
+        private PlacementStateManager placementStateManager = null!;
 
         /// <summary>
         /// Acceptable leniency to account for rounding errors and minor unsnaps that we generally
@@ -80,6 +80,8 @@ namespace osu.Game.Rulesets.Edit
         [BackgroundDependencyLoader]
         private void load()
         {
+            AddInternal(placementStateManager = new PlacementStateManager(HitObject));
+
             startTimeBindable = HitObject.StartTimeBindable.GetBoundCopy();
             startTimeBindable.BindValueChanged(_ => ApplyDefaultsToHitObject(), true);
         }
@@ -119,45 +121,9 @@ namespace osu.Game.Rulesets.Edit
         public override SnapResult UpdateTimeAndPosition(Vector2 screenSpacePosition, double time)
         {
             if (PlacementActive == PlacementState.Waiting)
-            {
                 HitObject.StartTime = time;
 
-                if (HitObject is IHasComboInformation comboInformation)
-                    comboInformation.UpdateComboInformation(getPreviousHitObject() as IHasComboInformation);
-            }
-
-            var lastHitObject = getPreviousHitObject();
-            var lastHitNormal = lastHitObject?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
-
-            if (lastHitNormal != null && AutomaticBankAssignment)
-                // Inherit the bank from the previous hit object
-                HitObject.Samples = HitObject.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL ? s.With(newBank: lastHitNormal.Bank, newEditorAutoBank: true) : s).ToList();
-            else
-                HitObject.Samples = HitObject.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL ? s.With(newEditorAutoBank: false) : s).ToList();
-
-            if (lastHitNormal != null)
-            {
-                // Inherit the volume and sample set info from the previous hit object
-                HitObject.Samples = HitObject.Samples.Select(s => s.With(
-                    newVolume: lastHitNormal.Volume,
-                    newSuffix: lastHitNormal.Suffix,
-                    newUseBeatmapSamples: lastHitNormal.UseBeatmapSamples)).ToList();
-            }
-
-            if (AutomaticAdditionBankAssignment)
-            {
-                string bank = HitObject.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank ?? HitSampleInfo.BANK_SOFT;
-                HitObject.Samples = HitObject.Samples.Select(s => s.Name != HitSampleInfo.HIT_NORMAL ? s.With(newBank: bank, newEditorAutoBank: true) : s).ToList();
-            }
-            else
-                HitObject.Samples = HitObject.Samples.Select(s => s.Name != HitSampleInfo.HIT_NORMAL ? s.With(newEditorAutoBank: false) : s).ToList();
-
-            if (HitObject is IHasRepeats hasRepeats)
-            {
-                // Make sure all the node samples are identical to the hit object's samples
-                for (int i = 0; i < hasRepeats.NodeSamples.Count; i++)
-                    hasRepeats.NodeSamples[i] = HitObject.Samples.Select(o => o.With()).ToList();
-            }
+            placementStateManager.CopyStateFromPreviousObject();
 
             return new SnapResult(screenSpacePosition, time);
         }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -22,7 +22,6 @@ using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
-using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
@@ -34,9 +33,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
     /// </summary>
     public abstract partial class ComposeBlueprintContainer : EditorBlueprintContainer
     {
+        private DependencyContainer dependencies = null!;
+
         private readonly Container<PlacementBlueprint> placementBlueprintContainer;
 
-        protected new EditorSelectionHandler SelectionHandler => (EditorSelectionHandler)base.SelectionHandler;
+        public new EditorSelectionHandler SelectionHandler => (EditorSelectionHandler)base.SelectionHandler;
 
         public PlacementBlueprint CurrentPlacement { get; private set; }
 
@@ -64,6 +65,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
             };
         }
 
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            return dependencies = new DependencyContainer(parent);
+        }
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -74,6 +80,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             {
                 Child = placementBlueprintContainer
             });
+
+            dependencies.CacheAs(SelectionHandler);
         }
 
         protected override void LoadComplete()
@@ -85,19 +93,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             // updates to selected are handled for us by SelectionHandler.
             NewCombo.BindTo(SelectionHandler.SelectionNewComboState);
 
-            // we are responsible for current placement blueprint updated based on state changes.
-            NewCombo.ValueChanged += _ => updatePlacementNewCombo();
-
-            // we own SelectionHandler so don't need to worry about making bindable copies (for simplicity)
-            foreach (var kvp in SelectionHandler.SelectionSampleStates)
-                kvp.Value.BindValueChanged(_ => updatePlacementSamples());
-
-            foreach (var kvp in SelectionHandler.SelectionBankStates)
-                kvp.Value.BindValueChanged(_ => updatePlacementSamples());
-
-            foreach (var kvp in SelectionHandler.SelectionAdditionBankStates)
-                kvp.Value.BindValueChanged(_ => updatePlacementSamples());
-
             SelectionHandler.AutoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip(), true);
         }
 
@@ -107,68 +102,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             var blueprint = (HitObjectSelectionBlueprint)GetBlueprintFor(hitObject);
             blueprint.DrawableObject = drawableObject;
-        }
-
-        private void updatePlacementNewCombo()
-        {
-            if (CurrentHitObjectPlacement?.HitObject is IHasComboInformation c)
-                c.NewCombo = NewCombo.Value == TernaryState.True;
-        }
-
-        private void updatePlacementSamples()
-        {
-            if (CurrentHitObjectPlacement == null) return;
-
-            foreach (var kvp in SelectionHandler.SelectionSampleStates)
-                sampleChanged(kvp.Key, kvp.Value.Value);
-
-            foreach (var kvp in SelectionHandler.SelectionBankStates)
-                bankChanged(kvp.Key, kvp.Value.Value);
-
-            foreach (var kvp in SelectionHandler.SelectionAdditionBankStates)
-                additionBankChanged(kvp.Key, kvp.Value.Value);
-        }
-
-        private void sampleChanged(string sampleName, TernaryState state)
-        {
-            if (CurrentHitObjectPlacement == null) return;
-
-            var samples = CurrentHitObjectPlacement.HitObject.Samples;
-
-            var existingSample = samples.FirstOrDefault(s => s.Name == sampleName);
-
-            switch (state)
-            {
-                case TernaryState.False:
-                    if (existingSample != null)
-                        samples.Remove(existingSample);
-                    break;
-
-                case TernaryState.True:
-                    if (existingSample == null)
-                        samples.Add(CurrentHitObjectPlacement.HitObject.CreateHitSampleInfo(sampleName));
-                    break;
-            }
-        }
-
-        private void bankChanged(string bankName, TernaryState state)
-        {
-            if (CurrentHitObjectPlacement == null) return;
-
-            if (bankName == EditorSelectionHandler.HIT_BANK_AUTO)
-                CurrentHitObjectPlacement.AutomaticBankAssignment = state == TernaryState.True;
-            else if (state == TernaryState.True)
-                CurrentHitObjectPlacement.HitObject.Samples = CurrentHitObjectPlacement.HitObject.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL ? s.With(newBank: bankName) : s).ToList();
-        }
-
-        private void additionBankChanged(string bankName, TernaryState state)
-        {
-            if (CurrentHitObjectPlacement == null) return;
-
-            if (bankName == EditorSelectionHandler.HIT_BANK_AUTO)
-                CurrentHitObjectPlacement.AutomaticAdditionBankAssignment = state == TernaryState.True;
-            else if (state == TernaryState.True)
-                CurrentHitObjectPlacement.HitObject.Samples = CurrentHitObjectPlacement.HitObject.Samples.Select(s => s.Name != HitSampleInfo.HIT_NORMAL ? s.With(newBank: bankName) : s).ToList();
         }
 
         public readonly Bindable<TernaryState> NewCombo = new Bindable<TernaryState> { Description = "New Combo" };
@@ -403,10 +336,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 // Fixes a 1-frame position discrepancy due to the first mouse move event happening in the next frame
                 updatePlacementTimeAndPosition();
-
-                updatePlacementSamples();
-
-                updatePlacementNewCombo();
             }
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -61,6 +61,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         #region Selection State
 
+        public event Action? SelectionStateChanged;
+
         /// <summary>
         /// The state of "new combo" for all selected hitobjects.
         /// </summary>
@@ -150,6 +152,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                             break;
                     }
+
+                    SelectionStateChanged?.Invoke();
                 };
 
                 SelectionBankStates[bankName] = bindable;
@@ -213,6 +217,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                             break;
                     }
+
+                    SelectionStateChanged?.Invoke();
                 };
 
                 SelectionAdditionBankStates[bankName] = bindable;
@@ -239,6 +245,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                             AddHitSample(sampleName);
                             break;
                     }
+
+                    SelectionStateChanged?.Invoke();
                 };
 
                 SelectionSampleStates[sampleName] = bindable;
@@ -257,6 +265,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
                         SetNewCombo(true);
                         break;
                 }
+
+                SelectionStateChanged?.Invoke();
             };
         }
 

--- a/osu.Game/Screens/Edit/Compose/Components/PlacementStateManager.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/PlacementStateManager.cs
@@ -1,0 +1,219 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Game.Audio;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+
+namespace osu.Game.Screens.Edit.Compose.Components
+{
+    public partial class PlacementStateManager : Component
+    {
+        public bool PerformBeatmapUpdates { get; init; }
+
+        private readonly HitObject[] hitObjects;
+
+        private bool automaticBankAssignment;
+        private bool automaticAdditionBankAssignment;
+
+        public PlacementStateManager(params HitObject[] hitObjects)
+        {
+            this.hitObjects = hitObjects;
+        }
+
+        [Resolved]
+        private EditorSelectionHandler? selectionHandler { get; set; }
+
+        [Resolved]
+        private EditorBeatmap editorBeatmap { get; set; } = null!;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            if (selectionHandler != null)
+                selectionHandler.SelectionStateChanged += updatePlacementFromSelectionStateChange;
+
+            updatePlacementFromSelectionStateChange();
+            CopyStateFromPreviousObject();
+        }
+
+        private void updatePlacementFromSelectionStateChange()
+        {
+            updatePlacementNewCombo();
+            updatePlacementSamples();
+        }
+
+        private void updatePlacementNewCombo()
+        {
+            if (selectionHandler == null)
+                return;
+
+            IHasComboInformation? comboStarter = null;
+
+            for (int i = 0; i < hitObjects.Length; ++i)
+            {
+                var hitObject = hitObjects[i];
+
+                if (hitObject is not IHasComboInformation withCombo)
+                    continue;
+
+                if (comboStarter == null)
+                {
+                    withCombo.NewCombo = selectionHandler.SelectionNewComboState.Value == TernaryState.True;
+                    comboStarter = withCombo;
+                }
+                else
+                    withCombo.NewCombo = false;
+
+                if (PerformBeatmapUpdates)
+                    editorBeatmap.Update(hitObject);
+            }
+        }
+
+        private void updatePlacementSamples()
+        {
+            if (selectionHandler == null)
+                return;
+
+            foreach (var hitObject in hitObjects)
+            {
+                foreach (var kvp in selectionHandler.SelectionSampleStates)
+                    sampleChanged(hitObject, kvp.Key, kvp.Value.Value);
+
+                foreach (var kvp in selectionHandler.SelectionBankStates)
+                    bankChanged(hitObject, kvp.Key, kvp.Value.Value);
+
+                foreach (var kvp in selectionHandler.SelectionAdditionBankStates)
+                    additionBankChanged(hitObject, kvp.Key, kvp.Value.Value);
+            }
+        }
+
+        private void sampleChanged(HitObject hitObject, string sampleName, TernaryState state)
+        {
+            var samples = hitObject.Samples;
+
+            var existingSample = samples.FirstOrDefault(s => s.Name == sampleName);
+
+            switch (state)
+            {
+                case TernaryState.False:
+                    if (existingSample != null)
+                        samples.Remove(existingSample);
+                    break;
+
+                case TernaryState.True:
+                    if (existingSample == null)
+                        samples.Add(hitObject.CreateHitSampleInfo(sampleName));
+                    break;
+            }
+
+            if (PerformBeatmapUpdates)
+                editorBeatmap.Update(hitObject);
+        }
+
+        private void bankChanged(HitObject hitObject, string bankName, TernaryState state)
+        {
+            if (bankName == EditorSelectionHandler.HIT_BANK_AUTO)
+            {
+                automaticBankAssignment = state == TernaryState.True;
+                if (automaticBankAssignment)
+                    CopyStateFromPreviousObject();
+            }
+            else if (state == TernaryState.True)
+            {
+                hitObject.Samples = hitObject.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL ? s.With(newBank: bankName, newEditorAutoBank: false) : s).ToList();
+
+                if (PerformBeatmapUpdates)
+                    editorBeatmap.Update(hitObject);
+            }
+        }
+
+        private void additionBankChanged(HitObject hitObject, string bankName, TernaryState state)
+        {
+            if (bankName == EditorSelectionHandler.HIT_BANK_AUTO)
+            {
+                automaticAdditionBankAssignment = state == TernaryState.True;
+                if (automaticAdditionBankAssignment)
+                    CopyStateFromPreviousObject();
+            }
+            else if (state == TernaryState.True)
+            {
+                hitObject.Samples = hitObject.Samples.Select(s => s.Name != HitSampleInfo.HIT_NORMAL ? s.With(newBank: bankName, newEditorAutoBank: false) : s).ToList();
+
+                if (PerformBeatmapUpdates)
+                    editorBeatmap.Update(hitObject);
+            }
+        }
+
+        private HitObject? getPreviousHitObject()
+        {
+            if (hitObjects.Length == 0)
+                return null;
+
+            return editorBeatmap.HitObjects.TakeWhile(h => h.StartTime < hitObjects.First().GetEndTime()).LastOrDefault();
+        }
+
+        /// <summary>
+        /// Updates the state of combo and sample information to inherit the required pieces from the previous object.
+        /// Should be manually called by the consumer whenever a placement-in-progress changes its temporal placement
+        /// (as it can change which previous object the information should be inherited from).
+        /// </summary>
+        public void CopyStateFromPreviousObject()
+        {
+            var lastHitObject = getPreviousHitObject();
+            var lastHitNormal = lastHitObject?.Samples?.FirstOrDefault(o => o.Name == HitSampleInfo.HIT_NORMAL);
+
+            foreach (var hitObject in hitObjects)
+            {
+                if (hitObject is IHasComboInformation comboInformation)
+                    comboInformation.UpdateComboInformation(lastHitObject as IHasComboInformation);
+
+                if (automaticBankAssignment && lastHitNormal != null)
+                    // Inherit the bank from the previous hit object
+                    hitObject.Samples = hitObject.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL ? s.With(newBank: lastHitNormal.Bank, newEditorAutoBank: true) : s).ToList();
+                else
+                    // There is no previous object to derive from, so ensure that `EditorAutoBank` flag is definitively turned off for the normal samples
+                    hitObject.Samples = hitObject.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL ? s.With(newEditorAutoBank: false) : s).ToList();
+
+                if (lastHitNormal != null)
+                {
+                    // Inherit the volume and sample set info from the previous hit object
+                    hitObject.Samples = hitObject.Samples.Select(s => s.With(
+                        newVolume: lastHitNormal.Volume,
+                        newSuffix: lastHitNormal.Suffix,
+                        newUseBeatmapSamples: lastHitNormal.UseBeatmapSamples)).ToList();
+                }
+
+                if (automaticAdditionBankAssignment)
+                {
+                    string bank = hitObject.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank ?? HitSampleInfo.BANK_SOFT;
+                    hitObject.Samples = hitObject.Samples.Select(s => s.Name != HitSampleInfo.HIT_NORMAL ? s.With(newBank: bank, newEditorAutoBank: true) : s).ToList();
+                }
+
+                if (hitObject is IHasRepeats hasRepeats)
+                {
+                    // Make sure all the node samples are identical to the hit object's samples
+                    for (int i = 0; i < hasRepeats.NodeSamples.Count; i++)
+                        hasRepeats.NodeSamples[i] = hitObject.Samples.Select(o => o.With()).ToList();
+                }
+
+                if (PerformBeatmapUpdates)
+                    editorBeatmap.Update(hitObject);
+
+                lastHitObject = hitObject;
+            }
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (selectionHandler != null)
+                selectionHandler.SelectionStateChanged -= updatePlacementFromSelectionStateChange;
+
+            base.Dispose(isDisposing);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/30589.

To achieve this sample assignment logic is moved out from `ComposeBlueprintContainer` and `HitObjectPlacementBlueprint` into a unified `PlacementStateManager` (willing to negotiate naming) component.