### PR TITLE
Fix Keybindings not shown on mania scroll speed change

### DIFF
--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaScrollSpeedToast.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaScrollSpeedToast.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Testing;
+using osu.Game.Overlays;
+using osu.Game.Overlays.OSD;
+using osu.Game.Rulesets.Mania.Configuration;
+using osu.Game.Tests.Visual;
+
+namespace osu.Game.Rulesets.Mania.Tests
+{
+    [TestFixture]
+    public partial class TestSceneManiaScrollSpeedToast : OsuTestScene
+    {
+        private ManiaRulesetConfigManager config = null!;
+        private TestOnScreenDisplay osd = null!;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("set up OSD", () =>
+            {
+                config = (ManiaRulesetConfigManager)RulesetConfigs.GetConfigFor(new ManiaRuleset())!;
+                config.LookupKeyBindings = action => action.ToString();
+
+                Child = osd = new TestOnScreenDisplay();
+                osd.BeginTracking(this, config);
+            });
+        }
+
+        [Test]
+        public void TestScrollSpeedToastShowsShortcut()
+        {
+            AddStep("increase scroll speed", () => config.SetValue(ManiaRulesetSetting.ScrollSpeed, config.Get<double>(ManiaRulesetSetting.ScrollSpeed) + 1));
+            AddUntilStep("wait for toast", () => osd.ChildrenOfType<TrackedSettingToast>().Any());
+            AddAssert("toast shortcut is not empty", () => osd.ChildrenOfType<TrackedSettingToast>().Single().ExtraText != default);
+        }
+
+        private partial class TestOnScreenDisplay : OnScreenDisplay
+        {
+            protected override void DisplayTemporarily(Drawable toDisplay) => toDisplay.FadeIn().ResizeHeightTo(110);
+        }
+    }
+}

--- a/osu.Game.Rulesets.Mania.Tests/TestSceneManiaScrollSpeedToast.cs
+++ b/osu.Game.Rulesets.Mania.Tests/TestSceneManiaScrollSpeedToast.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Testing;
+using osu.Game.Input.Bindings;
 using osu.Game.Overlays;
 using osu.Game.Overlays.OSD;
 using osu.Game.Rulesets.Mania.Configuration;
@@ -34,9 +36,20 @@ namespace osu.Game.Rulesets.Mania.Tests
         [Test]
         public void TestScrollSpeedToastShowsShortcut()
         {
+            var lookedUpActions = new List<GlobalAction>();
+
+            AddStep("set lookup spy", () =>
+                config.LookupKeyBindings = action =>
+                {
+                    lookedUpActions.Add(action);
+                    return action.ToString();
+                });
+
             AddStep("increase scroll speed", () => config.SetValue(ManiaRulesetSetting.ScrollSpeed, config.Get<double>(ManiaRulesetSetting.ScrollSpeed) + 1));
             AddUntilStep("wait for toast", () => osd.ChildrenOfType<TrackedSettingToast>().Any());
-            AddAssert("toast shortcut is not empty", () => osd.ChildrenOfType<TrackedSettingToast>().Single().ExtraText != default);
+            AddAssert("shortcut uses increase and decrease actions", () =>
+                lookedUpActions.Contains(GlobalAction.IncreaseScrollSpeed) &&
+                lookedUpActions.Contains(GlobalAction.DecreaseScrollSpeed));
         }
 
         private partial class TestOnScreenDisplay : OnScreenDisplay

--- a/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
+++ b/osu.Game.Rulesets.Mania/Configuration/ManiaRulesetConfigManager.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Configuration.Tracking;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Mania.UI;
@@ -47,10 +50,15 @@ namespace osu.Game.Rulesets.Mania.Configuration
                 speed => new SettingDescription(
                     rawValue: speed,
                     name: RulesetSettingsStrings.ScrollSpeed,
-                    value: RulesetSettingsStrings.ScrollSpeedTooltip((int)DrawableManiaRuleset.ComputeScrollTime(speed), speed)
+                    value: RulesetSettingsStrings.ScrollSpeedTooltip((int)DrawableManiaRuleset.ComputeScrollTime(speed), speed),
+                    shortcut: new TranslatableString(@"_", @"{0} / {1}",
+                        LookupKeyBindings(GlobalAction.IncreaseScrollSpeed),
+                        LookupKeyBindings(GlobalAction.DecreaseScrollSpeed))
                 )
             )
         };
+
+        public Func<GlobalAction, LocalisableString> LookupKeyBindings { get; set; } = _ => string.Empty;
     }
 
     public enum ManiaRulesetSetting

--- a/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/UI/DrawableManiaRuleset.cs
@@ -12,6 +12,7 @@ using osu.Framework.Input;
 using osu.Framework.Threading;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Input;
 using osu.Game.Input.Handlers;
 using osu.Game.Replays;
 using osu.Game.Rulesets.Mania.Beatmaps;
@@ -76,8 +77,9 @@ namespace osu.Game.Rulesets.Mania.UI
         }
 
         [BackgroundDependencyLoader]
-        private void load(ISkinSource source)
+        private void load(ISkinSource source, RealmKeyBindingStore keyBindingStore)
         {
+            Config.LookupKeyBindings = keyBindingStore.GetBindingsStringFor;
             currentSkin = source;
             currentSkin.SourceChanged += onSkinChange;
             skinChanged();


### PR DESCRIPTION
closes #15211

This is my first contribution to osu!, so I searched for a ticket that had a simple MVP solution to get some practice contributing.

The issue also mentions a possible refactor/cleanup, I considered something like injecting `RealmKeyBindingStore` in `RulesetConfigManager` or expanding `IRulesetConfigManager` to have a method that can look up the keybind, but figured that those are slightly bigger architectural changes, and didn't want to overstep my first contribution as I am still learning the codebase.

for this change, I decided to use a similar implementation as OsuGameBase as an MVP fix. and lifted LookupKeyBindings from [`OsuConfigManager`](https://github.com/ppy/osu/blob/4f649c51b1b911361244e253e3469b2fb456f00e/osu.Game/Configuration/OsuConfigManager.cs#L265)

Here is in `OsuConfigManager` that I based my implementation on
https://github.com/ppy/osu/blob/4f649c51b1b911361244e253e3469b2fb456f00e/osu.Game/Configuration/OsuConfigManager.cs#L283-L287

and in `DrawableManiaRuleset.cs` I used the following from `OsuGameBase.cs`
https://github.com/ppy/osu/blob/4f649c51b1b911361244e253e3469b2fb456f00e/osu.Game/OsuGameBase.cs#L440

First image is showing the change running in debug, and the second is a visual test confirming behavior.

<img width="469" height="222" alt="image" src="https://github.com/user-attachments/assets/186902fd-a09b-476e-90cd-e0c14311a1f4" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d6d337be-a4b4-49da-8a4c-1076bf6c3dc5" />
