### PR TITLE
Fix/beatmap listing backspace scroll

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -135,6 +135,26 @@ namespace osu.Game.Tests.Visual.Online
         }
 
         [Test]
+        public void TestBackspaceWhileScrolledScrollsBackToTop()
+        {
+            AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
+
+            AddStep("show many results", () => fetchFor(getManyBeatmaps(100).ToArray()));
+
+            AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
+
+            AddStep("type in search box", () => overlay.ChildrenOfType<SearchTextBox>().First().Text = "test");
+
+            AddStep("scroll to bottom", () => overlay.ChildrenOfType<OverlayScrollContainer>().First().ScrollToEnd());
+
+            AddUntilStep("scrolled to bottom", () => overlay.ChildrenOfType<OverlayScrollContainer>().First().IsScrolledToEnd());
+
+            AddStep("press backspace", () => InputManager.Key(Key.BackSpace));
+
+            AddUntilStep("is scrolled to top", () => overlay.ChildrenOfType<OverlayScrollContainer>().First().Current == 0);
+        }
+
+        [Test]
         public void TestCorrectOldContentExpiration()
         {
             AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);

--- a/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneBeatmapListingOverlay.cs
@@ -138,19 +138,15 @@ namespace osu.Game.Tests.Visual.Online
         public void TestBackspaceWhileScrolledScrollsBackToTop()
         {
             AddAssert("is visible", () => overlay.State.Value == Visibility.Visible);
-
             AddStep("show many results", () => fetchFor(getManyBeatmaps(100).ToArray()));
 
             AddUntilStep("placeholder hidden", () => !overlay.ChildrenOfType<BeatmapListingOverlay.NotFoundDrawable>().Any(d => d.IsPresent));
-
             AddStep("type in search box", () => overlay.ChildrenOfType<SearchTextBox>().First().Text = "test");
 
             AddStep("scroll to bottom", () => overlay.ChildrenOfType<OverlayScrollContainer>().First().ScrollToEnd());
-
             AddUntilStep("scrolled to bottom", () => overlay.ChildrenOfType<OverlayScrollContainer>().First().IsScrolledToEnd());
 
             AddStep("press backspace", () => InputManager.Key(Key.BackSpace));
-
             AddUntilStep("is scrolled to top", () => overlay.ChildrenOfType<OverlayScrollContainer>().First().Current == 0);
         }
 

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -112,10 +112,12 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             bool typingStarted = false;
 
-            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
+            AddStep("set callback and populate search box", () =>
+            {
+                control.TypingStarted = () => typingStarted = true;
+                control.Query.Value = "test";
+            });
             AddStep("focus search box", () => control.TakeFocus());
-            AddStep("type a character", () => InputManager.Key(Key.A));
-            AddStep("reset flag", () => typingStarted = false);
             AddStep("press backspace", () => InputManager.Key(Key.BackSpace));
             AddAssert("typing started was called", () => typingStarted);
         }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -41,7 +42,6 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
-            ManualTextInputContainer textInputContainer;
             OsuSpriteText query;
             OsuSpriteText general;
             OsuSpriteText ruleset;
@@ -53,15 +53,18 @@ namespace osu.Game.Tests.Visual.UserInterface
             OsuSpriteText played;
             OsuSpriteText explicitMap;
 
+            ManualTextInputContainer textInputContainer;
+
             Children = new Drawable[]
             {
                 textInputContainer = new ManualTextInputContainer
                 {
+                    RelativeSizeAxes = Axes.Both,
                     Child = control = new BeatmapListingSearchControl
                     {
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                    }
+                    },
                 },
                 new FillFlowContainer
                 {
@@ -84,8 +87,6 @@ namespace osu.Game.Tests.Visual.UserInterface
                 }
             };
 
-            textInput = textInputContainer.TextInput;
-
             control.Query.BindValueChanged(q => query.Text = $"Query: {q.NewValue}", true);
             control.General.BindCollectionChanged((_, _) => general.Text = $"General: {(control.General.Any() ? string.Join('.', control.General.Select(i => i.ToString().ToSnakeCase())) : "")}", true);
             control.Ruleset.BindValueChanged(r => ruleset.Text = $"Ruleset: {r.NewValue}", true);
@@ -96,6 +97,7 @@ namespace osu.Game.Tests.Visual.UserInterface
             control.Ranks.BindCollectionChanged((_, _) => ranks.Text = $"Ranks: {(control.Ranks.Any() ? string.Join('.', control.Ranks.Select(i => i.ToString())) : "")}", true);
             control.Played.BindValueChanged(p => played.Text = $"Played: {p.NewValue}", true);
             control.ExplicitContent.BindValueChanged(e => explicitMap.Text = $"Explicit Maps: {e.NewValue}", true);
+            textInput = textInputContainer.TextInput;
         });
 
         [Test]
@@ -117,96 +119,77 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestTypingStartedFiredOnTextAdded()
+        public void TestTypingStartedFiredOnTextMutatingInteractions()
         {
+            var cases = new (string Name, Action Perform)[]
+            {
+                ("type a character",            () => textInput.Text("a")),
+                ("backspace (DeleteBackwardChar)",  () => InputManager.Key(Key.BackSpace)),
+                ("Ctrl+Backspace (DeleteBackwardWord)", () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.BackSpace); InputManager.ReleaseKey(Key.LControl); }),
+                ("Shift+Left (SelectBackwardChar)", () => { InputManager.PressKey(Key.LShift); InputManager.Key(Key.Left); InputManager.ReleaseKey(Key.LShift); }),
+                ("Ctrl+C (Copy)",                  () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.C); InputManager.ReleaseKey(Key.LControl); }),
+                ("Ctrl+X (Cut)",                   () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.X); InputManager.ReleaseKey(Key.LControl); }),
+                ("Ctrl+V (Paste)",                 () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.V); InputManager.ReleaseKey(Key.LControl); }),
+                ("Ctrl+A (SelectAll)",             () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.A); InputManager.ReleaseKey(Key.LControl); }),
+                ("escape with text (GlobalAction.Back)", () => InputManager.Key(Key.Escape)),
+            };
+
             bool typingStarted = false;
 
-            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
-            AddStep("focus search box", () => control.TakeFocus());
-            AddStep("type a character", () => textInput.Text("a"));
-            AddAssert("typing started was called", () => typingStarted);
+            foreach (var (name, perform) in cases)
+            {
+                AddStep($"setup for: {name}", () =>
+                {
+                    typingStarted = false;
+                    control.Query.Value = "test";
+                    control.TypingStarted = () => typingStarted = true;
+                    control.TakeFocus();
+                });
+                AddStep(name, perform);
+                AddAssert("typing started was called", () => typingStarted);
+            }
         }
 
         [Test]
-        public void TestTypingStartedFiredOnBackspace()
+        public void TestTypingStartedNotFiredOnNonMutatingInteractions()
         {
+            var cases = new (string Name, Action Perform)[]
+            {
+                ("F5 (no PlatformAction)",          () => InputManager.Key(Key.F5)),
+                ("F12 (no PlatformAction)",         () => InputManager.Key(Key.F12)),
+                ("Delete (blocked by SearchTextBox)",   () => InputManager.Key(Key.Delete)),
+                ("Ctrl+S (PlatformAction.Save)",    () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.S); InputManager.ReleaseKey(Key.LControl); }),
+                ("Ctrl+= (PlatformAction.ZoomIn)",  () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.Plus); InputManager.ReleaseKey(Key.LControl); }),
+            };
+
             bool typingStarted = false;
 
-            AddStep("set callback and populate search box", () =>
+            foreach (var (name, perform) in cases)
             {
-                control.TypingStarted = () => typingStarted = true;
-                control.Query.Value = "test";
-            });
-            AddStep("focus search box", () => control.TakeFocus());
-            AddStep("press backspace", () => InputManager.Key(Key.BackSpace));
-            AddAssert("typing started was called", () => typingStarted);
+                AddStep($"setup for: {name}", () =>
+                {
+                    typingStarted = false;
+                    control.TypingStarted = () => typingStarted = true;
+                    control.TakeFocus();
+                });
+                AddStep(name, perform);
+                AddAssert("typing started was not called", () => !typingStarted);
+            }
         }
 
         [Test]
-        public void TestTypingStartedFiredOnEscapeClear()
+        public void TestEscapeClearsSearchBox()
         {
-            bool typingStarted = false;
-
-            AddStep("set callback and populate search box", () =>
-            {
-                control.TypingStarted = () => typingStarted = true;
-                control.Query.Value = "test";
-            });
+            AddStep("populate search box", () => control.Query.Value = "test");
             AddStep("focus search box", () => control.TakeFocus());
             AddStep("press escape", () => InputManager.Key(Key.Escape));
-            AddAssert("typing started was called", () => typingStarted);
             AddAssert("search box is empty", () => string.IsNullOrEmpty(control.Query.Value));
-        }
-
-        [Test]
-        public void TestTypingStartedNotFiredOnCopy()
-        {
-            bool typingStarted = false;
-
-            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
-            AddStep("focus search box", () => control.TakeFocus());
-            AddStep("type a character", () => textInput.Text("a"));
-            AddStep("reset flag", () => typingStarted = false);
-            AddStep("copy text", () =>
-            {
-                InputManager.PressKey(Key.LControl);
-                InputManager.Key(Key.C);
-                InputManager.ReleaseKey(Key.LControl);
-            });
-            AddAssert("typing started was not called", () => !typingStarted);
-        }
-
-        [Test]
-        public void TestTypingStartedNotFiredOnSelectAll()
-        {
-            bool typingStarted = false;
-
-            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
-            AddStep("focus search box", () => control.TakeFocus());
-            AddStep("select all", () =>
-            {
-                InputManager.PressKey(Key.LControl);
-                InputManager.Key(Key.A);
-                InputManager.ReleaseKey(Key.LControl);
-            });
-            AddAssert("typing started was not called", () => !typingStarted);
         }
 
         protected override void Dispose(bool isDisposing)
         {
             localConfig?.Dispose();
             base.Dispose(isDisposing);
-        }
-
-        private partial class ManualTextInputContainer : Container
-        {
-            [Cached(typeof(TextInputSource))]
-            public readonly ManualTextInputSource TextInput = new ManualTextInputSource();
-
-            public ManualTextInputContainer()
-            {
-                RelativeSizeAxes = Axes.Both;
-            }
         }
 
         private static readonly APIBeatmapSet beatmap_set = new APIBeatmapSet
@@ -224,5 +207,11 @@ namespace osu.Game.Tests.Visual.UserInterface
                 Cover = string.Empty
             }
         };
+
+        private partial class ManualTextInputContainer : Container
+        {
+            [Cached(typeof(TextInputSource))]
+            public readonly ManualTextInputSource TextInput = new ManualTextInputSource();
+        }
     }
 }

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 #nullable disable
@@ -8,6 +8,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using osu.Framework.Testing.Input;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
@@ -26,6 +28,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
 
         private BeatmapListingSearchControl control;
+        private ManualTextInputSource textInput;
 
         private OsuConfigManager localConfig;
 
@@ -38,6 +41,7 @@ namespace osu.Game.Tests.Visual.UserInterface
         [SetUp]
         public void SetUp() => Schedule(() =>
         {
+            ManualTextInputContainer textInputContainer;
             OsuSpriteText query;
             OsuSpriteText general;
             OsuSpriteText ruleset;
@@ -51,10 +55,13 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             Children = new Drawable[]
             {
-                control = new BeatmapListingSearchControl
+                textInputContainer = new ManualTextInputContainer
                 {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
+                    Child = control = new BeatmapListingSearchControl
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    }
                 },
                 new FillFlowContainer
                 {
@@ -76,6 +83,8 @@ namespace osu.Game.Tests.Visual.UserInterface
                     }
                 }
             };
+
+            textInput = textInputContainer.TextInput;
 
             control.Query.BindValueChanged(q => query.Text = $"Query: {q.NewValue}", true);
             control.General.BindCollectionChanged((_, _) => general.Text = $"General: {(control.General.Any() ? string.Join('.', control.General.Select(i => i.ToString().ToSnakeCase())) : "")}", true);
@@ -108,6 +117,17 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestTypingStartedFiredOnTextAdded()
+        {
+            bool typingStarted = false;
+
+            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
+            AddStep("focus search box", () => control.TakeFocus());
+            AddStep("type a character", () => textInput.Text("a"));
+            AddAssert("typing started was called", () => typingStarted);
+        }
+
+        [Test]
         public void TestTypingStartedFiredOnBackspace()
         {
             bool typingStarted = false;
@@ -123,16 +143,29 @@ namespace osu.Game.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestTypingStartedFiredOnEscapeClear()
+        {
+            bool typingStarted = false;
+
+            AddStep("set callback and populate search box", () =>
+            {
+                control.TypingStarted = () => typingStarted = true;
+                control.Query.Value = "test";
+            });
+            AddStep("focus search box", () => control.TakeFocus());
+            AddStep("press escape", () => InputManager.Key(Key.Escape));
+            AddAssert("typing started was called", () => typingStarted);
+            AddAssert("search box is empty", () => string.IsNullOrEmpty(control.Query.Value));
+        }
+
+        [Test]
         public void TestTypingStartedNotFiredOnCopy()
         {
             bool typingStarted = false;
 
-            AddStep("set callback and type text", () =>
-            {
-                control.TypingStarted = () => typingStarted = true;
-            });
+            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
             AddStep("focus search box", () => control.TakeFocus());
-            AddStep("type a character", () => InputManager.Key(Key.A));
+            AddStep("type a character", () => textInput.Text("a"));
             AddStep("reset flag", () => typingStarted = false);
             AddStep("copy text", () =>
             {
@@ -163,6 +196,17 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             localConfig?.Dispose();
             base.Dispose(isDisposing);
+        }
+
+        private partial class ManualTextInputContainer : Container
+        {
+            [Cached(typeof(TextInputSource))]
+            public readonly ManualTextInputSource TextInput = new ManualTextInputSource();
+
+            public ManualTextInputContainer()
+            {
+                RelativeSizeAxes = Axes.Both;
+            }
         }
 
         private static readonly APIBeatmapSet beatmap_set = new APIBeatmapSet

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -123,14 +123,44 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             var cases = new (string Name, Action Perform)[]
             {
-                ("type a character",            () => textInput.Text("a")),
-                ("backspace (DeleteBackwardChar)",  () => InputManager.Key(Key.BackSpace)),
-                ("Ctrl+Backspace (DeleteBackwardWord)", () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.BackSpace); InputManager.ReleaseKey(Key.LControl); }),
-                ("Shift+Left (SelectBackwardChar)", () => { InputManager.PressKey(Key.LShift); InputManager.Key(Key.Left); InputManager.ReleaseKey(Key.LShift); }),
-                ("Ctrl+C (Copy)",                  () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.C); InputManager.ReleaseKey(Key.LControl); }),
-                ("Ctrl+X (Cut)",                   () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.X); InputManager.ReleaseKey(Key.LControl); }),
-                ("Ctrl+V (Paste)",                 () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.V); InputManager.ReleaseKey(Key.LControl); }),
-                ("Ctrl+A (SelectAll)",             () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.A); InputManager.ReleaseKey(Key.LControl); }),
+                ("type a character", () => textInput.Text("a")),
+                ("backspace (DeleteBackwardChar)", () => InputManager.Key(Key.BackSpace)),
+                ("Ctrl+Backspace (DeleteBackwardWord)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.BackSpace);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
+                ("Shift+Left (SelectBackwardChar)", () =>
+                {
+                    InputManager.PressKey(Key.LShift);
+                    InputManager.Key(Key.Left);
+                    InputManager.ReleaseKey(Key.LShift);
+                }),
+                ("Ctrl+C (Copy)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.C);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
+                ("Ctrl+X (Cut)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.X);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
+                ("Ctrl+V (Paste)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.V);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
+                ("Ctrl+A (SelectAll)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.A);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
                 ("escape with text (GlobalAction.Back)", () => InputManager.Key(Key.Escape)),
             };
 
@@ -155,11 +185,21 @@ namespace osu.Game.Tests.Visual.UserInterface
         {
             var cases = new (string Name, Action Perform)[]
             {
-                ("F5 (no PlatformAction)",          () => InputManager.Key(Key.F5)),
-                ("F12 (no PlatformAction)",         () => InputManager.Key(Key.F12)),
-                ("Delete (blocked by SearchTextBox)",   () => InputManager.Key(Key.Delete)),
-                ("Ctrl+S (PlatformAction.Save)",    () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.S); InputManager.ReleaseKey(Key.LControl); }),
-                ("Ctrl+= (PlatformAction.ZoomIn)",  () => { InputManager.PressKey(Key.LControl); InputManager.Key(Key.Plus); InputManager.ReleaseKey(Key.LControl); }),
+                ("F5 (no PlatformAction)", () => InputManager.Key(Key.F5)),
+                ("F12 (no PlatformAction)", () => InputManager.Key(Key.F12)),
+                ("Delete (blocked by SearchTextBox)", () => InputManager.Key(Key.Delete)),
+                ("Ctrl+S (PlatformAction.Save)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.S);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
+                ("Ctrl+= (PlatformAction.ZoomIn)", () =>
+                {
+                    InputManager.PressKey(Key.LControl);
+                    InputManager.Key(Key.Plus);
+                    InputManager.ReleaseKey(Key.LControl);
+                }),
             };
 
             bool typingStarted = false;

--- a/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
+++ b/osu.Game.Tests/Visual/UserInterface/TestSceneBeatmapListingSearchControl.cs
@@ -16,10 +16,11 @@ using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
 using osu.Game.Overlays.BeatmapListing;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.UserInterface
 {
-    public partial class TestSceneBeatmapListingSearchControl : OsuTestScene
+    public partial class TestSceneBeatmapListingSearchControl : OsuManualInputManagerTestScene
     {
         [Cached]
         private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
@@ -104,6 +105,56 @@ namespace osu.Game.Tests.Visual.UserInterface
 
             AddStep("configure explicit content to disallowed", () => localConfig.SetValue(OsuSetting.ShowOnlineExplicitContent, false));
             AddAssert("explicit control set to hide", () => control.ExplicitContent.Value == SearchExplicit.Hide);
+        }
+
+        [Test]
+        public void TestTypingStartedFiredOnBackspace()
+        {
+            bool typingStarted = false;
+
+            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
+            AddStep("focus search box", () => control.TakeFocus());
+            AddStep("type a character", () => InputManager.Key(Key.A));
+            AddStep("reset flag", () => typingStarted = false);
+            AddStep("press backspace", () => InputManager.Key(Key.BackSpace));
+            AddAssert("typing started was called", () => typingStarted);
+        }
+
+        [Test]
+        public void TestTypingStartedNotFiredOnCopy()
+        {
+            bool typingStarted = false;
+
+            AddStep("set callback and type text", () =>
+            {
+                control.TypingStarted = () => typingStarted = true;
+            });
+            AddStep("focus search box", () => control.TakeFocus());
+            AddStep("type a character", () => InputManager.Key(Key.A));
+            AddStep("reset flag", () => typingStarted = false);
+            AddStep("copy text", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.C);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+            AddAssert("typing started was not called", () => !typingStarted);
+        }
+
+        [Test]
+        public void TestTypingStartedNotFiredOnSelectAll()
+        {
+            bool typingStarted = false;
+
+            AddStep("set callback", () => control.TypingStarted = () => typingStarted = true);
+            AddStep("focus search box", () => control.TakeFocus());
+            AddStep("select all", () =>
+            {
+                InputManager.PressKey(Key.LControl);
+                InputManager.Key(Key.A);
+                InputManager.ReleaseKey(Key.LControl);
+            });
+            AddAssert("typing started was not called", () => !typingStarted);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -7,7 +7,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Configuration;
@@ -187,22 +186,16 @@ namespace osu.Game.Overlays.BeatmapListing
                 PlaceholderText = BeatmapsStrings.ListingSearchPrompt;
             }
 
-            protected override bool OnKeyDown(KeyDownEvent e)
+            protected override void OnUserTextAdded(string added)
             {
-                if (!base.OnKeyDown(e))
-                    return false;
-
+                base.OnUserTextAdded(added);
                 TextChanged?.Invoke();
-                return true;
             }
 
-            public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+            protected override void OnUserTextRemoved(string removed)
             {
-                if (!base.OnPressed(e))
-                    return false;
-
+                base.OnUserTextRemoved(removed);
                 TextChanged?.Invoke();
-                return true;
             }
 
             public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Overlays.BeatmapListing
     public partial class BeatmapListingSearchControl : CompositeDrawable
     {
         /// <summary>
-        /// Any time the text box receives key events (even while masked).
+        /// Invoked any time text is added to or removed from the search box.
         /// </summary>
         public Action? TypingStarted;
 
@@ -175,7 +175,7 @@ namespace osu.Game.Overlays.BeatmapListing
         private partial class BeatmapSearchTextBox : BasicSearchTextBox
         {
             /// <summary>
-            /// Any time the text box receives key events (even while masked).
+            /// Invoked any time text is added to or removed from the text box.
             /// </summary>
             public Action? TextChanged;
 

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Configuration;
@@ -25,7 +26,7 @@ namespace osu.Game.Overlays.BeatmapListing
     public partial class BeatmapListingSearchControl : CompositeDrawable
     {
         /// <summary>
-        /// Invoked any time text is added to or removed from the search box.
+        /// Invoked when the user interacts with the search box in a way that aims to mutate its state.
         /// </summary>
         public Action? TypingStarted;
 
@@ -175,7 +176,7 @@ namespace osu.Game.Overlays.BeatmapListing
         private partial class BeatmapSearchTextBox : BasicSearchTextBox
         {
             /// <summary>
-            /// Invoked any time text is added to or removed from the text box.
+            /// Invoked when the user interacts with this text box in a way that aims to mutate its state.
             /// </summary>
             public Action? TextChanged;
 
@@ -192,10 +193,13 @@ namespace osu.Game.Overlays.BeatmapListing
                 TextChanged?.Invoke();
             }
 
-            protected override void OnUserTextRemoved(string removed)
+            public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
             {
-                base.OnUserTextRemoved(removed);
+                if (!base.OnPressed(e))
+                    return false;
+
                 TextChanged?.Invoke();
+                return true;
             }
 
             public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)

--- a/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
+++ b/osu.Game/Overlays/BeatmapListing/BeatmapListingSearchControl.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps.Drawables;
 using osu.Game.Configuration;
@@ -189,6 +190,15 @@ namespace osu.Game.Overlays.BeatmapListing
             protected override bool OnKeyDown(KeyDownEvent e)
             {
                 if (!base.OnKeyDown(e))
+                    return false;
+
+                TextChanged?.Invoke();
+                return true;
+            }
+
+            public override bool OnPressed(KeyBindingPressEvent<PlatformAction> e)
+            {
+                if (!base.OnPressed(e))
                     return false;
 
                 TextChanged?.Invoke();


### PR DESCRIPTION
partially fixes https://github.com/ppy/osu/issues/38539
The issue described two other scenarios that I believe are out of scope for the bug, but shouldn't be dismissed entirely.
1. the loading spinner blocks mouse input
2. when typing while the text box is not visible, the cursor is inserted into the wrong spot

Keeping this as a draft for now until my other PR gets feedback/merged, since it is my first contribution, I don't want to open multiple PRs in the case that I am doing something wrong.

<hr>

This fix refactors `BeatmapListingSearchControl.cs` to replace `OnKeyDown` in favor of `OnUserTextAdded` and `OnUserTextRemoved` 

The reasoning/justification for this is that those handlers more appropriately handle text input in the searchTextBox, eliminating edge cases like backspace not being detected, which was dispatched through `PlatformAction` rather than `GlobalAction`.

My initial solution was to add an additional `OnPressed` handler for `PlatformAction` to handle the backspace event but I found that that had minor side-effects such as being triggered from copy/paste. 

This solution does turn one handler (`OnKeyDown`) into two, for added/removed, I think it is a cleaner solution, because these handlers more accurately reflect the action being taken as well as help decouple text inputs from 'key presses'. I am not sure if it was an issue before, but it should help with things like msoft IME devices (https://support.microsoft.com/en-us/windows/hardware/input-devices/microsoft-japanese-ime) or onscreen keyboards.


Additionally I added visual tests to test that backspace scenario properly, as well as some additional tests to ensure that the `OnUserTextAdded/Removed` functions properly, independent of the bug regression test and I added a test case for 'escape' and some other regression cases. 

I also updated the tests to use ManualTextInputContainer to inject the character through the real text input process to ensure that OnUserTextAdded is happening from a keypress. I figured this keeps the testing scenario similar to 'OnKeyDown' while actually ensuring text pipeline is correct.