### PR TITLE
Move up selection state bindables to `HitObjectComposer` level

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchHitObjectComposer.cs
@@ -31,6 +31,8 @@ namespace osu.Game.Rulesets.Catch.Edit
     {
         public const float DISTANCE_SNAP_RADIUS = 50;
 
+        public override Bindable<TernaryState>? SelectionNewComboState { get; } = new Bindable<TernaryState>();
+
         private CatchDistanceSnapGrid distanceSnapGrid = null!;
 
         private readonly BindableDouble timeRangeMultiplier = new BindableDouble(1)

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaBeatSnapGrid.cs
@@ -5,11 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps.ControlPoints;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Beatmaps;
 using osu.Game.Rulesets.Mania.Edit;
@@ -88,6 +90,11 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         public override ComposeBlueprintContainer BlueprintContainer => throw new NotImplementedException();
         public override IEnumerable<DrawableHitObject> HitObjects => Enumerable.Empty<DrawableHitObject>();
         public override bool CursorInPlacementArea => false;
+        public override Bindable<TernaryState>? SelectionNewComboState => throw new NotImplementedException();
+        public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionSampleStates => throw new NotImplementedException();
+        public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionBankStates => throw new NotImplementedException();
+        public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionAdditionBankStates => throw new NotImplementedException();
+        public override Bindable<bool> AutoSelectionBankEnabled => throw new NotImplementedException();
 
         public TestHitObjectComposer(Playfield playfield)
             : base(new ManiaRuleset())

--- a/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaBeatSnapGrid.cs
+++ b/osu.Game.Rulesets.Mania.Tests/Editor/TestSceneManiaBeatSnapGrid.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Mania.Tests.Editor
         public override ComposeBlueprintContainer BlueprintContainer => throw new NotImplementedException();
         public override IEnumerable<DrawableHitObject> HitObjects => Enumerable.Empty<DrawableHitObject>();
         public override bool CursorInPlacementArea => false;
-        public override Bindable<TernaryState>? SelectionNewComboState => throw new NotImplementedException();
+        public override Bindable<TernaryState> SelectionNewComboState => throw new NotImplementedException();
         public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionSampleStates => throw new NotImplementedException();
         public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionBankStates => throw new NotImplementedException();
         public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionAdditionBankStates => throw new NotImplementedException();

--- a/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaHitObjectComposer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mania.Objects;
@@ -26,6 +27,8 @@ namespace osu.Game.Rulesets.Mania.Edit
     [Cached]
     public partial class ManiaHitObjectComposer : ScrollingHitObjectComposer<ManiaHitObject>
     {
+        public override Bindable<TernaryState>? SelectionNewComboState => null;
+
         private DrawableManiaEditorRuleset drawableRuleset = null!;
 
         [Resolved]

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -44,6 +44,8 @@ namespace osu.Game.Rulesets.Osu.Edit
         {
         }
 
+        public override Bindable<TernaryState> SelectionNewComboState { get; } = new Bindable<TernaryState>();
+
         protected override DrawableRuleset<OsuHitObject> CreateDrawableRuleset(Ruleset ruleset, IBeatmap beatmap, IReadOnlyList<Mod> mods)
             => new DrawableOsuEditorRuleset(ruleset, beatmap, mods);
 
@@ -388,8 +390,7 @@ namespace osu.Game.Rulesets.Osu.Edit
 
                 if (!osuSelectionHandler.SelectedItems.Any())
                 {
-                    osuSelectionHandler.SelectionNewComboState.Value =
-                        osuSelectionHandler.SelectionNewComboState.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
+                    SelectionNewComboState!.Value = SelectionNewComboState.Value == TernaryState.False ? TernaryState.True : TernaryState.False;
                     return true;
                 }
             }

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoHitObjectComposer.cs
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Mods;
@@ -13,6 +15,7 @@ using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
 using osu.Game.Screens.Edit.Compose.Components;
+using osu.Game.Utils;
 using osuTK;
 
 namespace osu.Game.Rulesets.Taiko.Edit
@@ -20,6 +23,14 @@ namespace osu.Game.Rulesets.Taiko.Edit
     [Cached]
     public partial class TaikoHitObjectComposer : ScrollingHitObjectComposer<TaikoHitObject>
     {
+        public override Bindable<TernaryState>? SelectionNewComboState => null;
+
+        public IBindable<TernaryState> SelectionRimState => selectionRimState;
+        private readonly Bindable<TernaryState> selectionRimState = new Bindable<TernaryState>();
+
+        public IBindable<TernaryState> SelectionStrongState => selectionStrongState;
+        private readonly Bindable<TernaryState> selectionStrongState = new Bindable<TernaryState>();
+
         protected override bool ApplyHorizontalCentering => false;
 
         private Bindable<bool> limitPlacementToCurrentTime = null!;
@@ -33,6 +44,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
         private void load(OsuConfigManager config)
         {
             limitPlacementToCurrentTime = config.GetBindable<bool>(OsuSetting.EditorLimitedDistanceSnap);
+            setUpStateBindables();
         }
 
         public override SnapResult FindSnappedPositionAndTime(Vector2 screenSpacePosition)
@@ -62,5 +74,74 @@ namespace osu.Game.Rulesets.Taiko.Edit
             => new TaikoBlueprintContainer(this);
 
         protected override BeatSnapGrid CreateBeatSnapGrid() => new TaikoBeatSnapGrid();
+
+        #region Selection handling
+
+        protected override void UpdateTernaryStates()
+        {
+            base.UpdateTernaryStates();
+
+            selectionRimState.Value = EditorBeatmap.SelectedHitObjects.OfType<Hit>().GetTernaryState(h => h.Type == HitType.Rim);
+            selectionStrongState.Value = EditorBeatmap.SelectedHitObjects.OfType<TaikoStrongableHitObject>().GetTernaryState(h => h.IsStrong);
+        }
+
+        private void setUpStateBindables()
+        {
+            selectionStrongState.ValueChanged += state =>
+            {
+                switch (state.NewValue)
+                {
+                    case TernaryState.False:
+                        SetStrongState(false);
+                        break;
+
+                    case TernaryState.True:
+                        SetStrongState(true);
+                        break;
+                }
+            };
+
+            selectionRimState.ValueChanged += state =>
+            {
+                switch (state.NewValue)
+                {
+                    case TernaryState.False:
+                        SetRimState(false);
+                        break;
+
+                    case TernaryState.True:
+                        SetRimState(true);
+                        break;
+                }
+            };
+        }
+
+        public void SetStrongState(bool state)
+        {
+            if (EditorBeatmap.SelectedHitObjects.OfType<TaikoStrongableHitObject>().All(h => h.IsStrong == state))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (h is not TaikoStrongableHitObject strongable) return;
+
+                if (strongable.IsStrong != state)
+                    strongable.IsStrong = state;
+            });
+        }
+
+        public void SetRimState(bool state)
+        {
+            if (EditorBeatmap.SelectedHitObjects.OfType<Hit>().All(h => h.Type == (state ? HitType.Rim : HitType.Centre)))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (h is Hit taikoHit)
+                    taikoHit.Type = state ? HitType.Rim : HitType.Centre;
+            });
+        }
+
+        #endregion
     }
 }

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoSelectionHandler.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Game.Graphics.UserInterface;
@@ -17,66 +16,8 @@ namespace osu.Game.Rulesets.Taiko.Edit
 {
     public partial class TaikoSelectionHandler : EditorSelectionHandler
     {
-        private readonly Bindable<TernaryState> selectionRimState = new Bindable<TernaryState>();
-        private readonly Bindable<TernaryState> selectionStrongState = new Bindable<TernaryState>();
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            selectionStrongState.ValueChanged += state =>
-            {
-                switch (state.NewValue)
-                {
-                    case TernaryState.False:
-                        SetStrongState(false);
-                        break;
-
-                    case TernaryState.True:
-                        SetStrongState(true);
-                        break;
-                }
-            };
-
-            selectionRimState.ValueChanged += state =>
-            {
-                switch (state.NewValue)
-                {
-                    case TernaryState.False:
-                        SetRimState(false);
-                        break;
-
-                    case TernaryState.True:
-                        SetRimState(true);
-                        break;
-                }
-            };
-        }
-
-        public void SetStrongState(bool state)
-        {
-            if (SelectedItems.OfType<TaikoStrongableHitObject>().All(h => h.IsStrong == state))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                if (h is not TaikoStrongableHitObject strongable) return;
-
-                if (strongable.IsStrong != state)
-                    strongable.IsStrong = state;
-            });
-        }
-
-        public void SetRimState(bool state)
-        {
-            if (SelectedItems.OfType<Hit>().All(h => h.Type == (state ? HitType.Rim : HitType.Centre)))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                if (h is Hit taikoHit)
-                    taikoHit.Type = state ? HitType.Rim : HitType.Centre;
-            });
-        }
+        [Resolved]
+        private TaikoHitObjectComposer composer { get; set; } = null!;
 
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
         {
@@ -84,7 +25,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
             {
                 yield return new TernaryStateToggleMenuItem("Rim")
                 {
-                    State = { BindTarget = selectionRimState },
+                    State = { BindTarget = composer.SelectionRimState },
                     Hotkey = new Hotkey(new KeyCombination(InputKey.W), new KeyCombination(InputKey.R)),
                 };
             }
@@ -93,7 +34,7 @@ namespace osu.Game.Rulesets.Taiko.Edit
             {
                 yield return new TernaryStateToggleMenuItem("Strong")
                 {
-                    State = { BindTarget = selectionStrongState },
+                    State = { BindTarget = composer.SelectionStrongState },
                     Hotkey = new Hotkey(new KeyCombination(InputKey.E)),
                 };
             }
@@ -103,13 +44,5 @@ namespace osu.Game.Rulesets.Taiko.Edit
         }
 
         public override bool HandleMovement(MoveSelectionEvent<HitObject> moveEvent) => true;
-
-        protected override void UpdateTernaryStates()
-        {
-            base.UpdateTernaryStates();
-
-            selectionRimState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<Hit>(), h => h.Type == HitType.Rim);
-            selectionStrongState.Value = GetStateFromSelection(EditorBeatmap.SelectedHitObjects.OfType<TaikoStrongableHitObject>(), h => h.IsStrong);
-        }
     }
 }

--- a/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneHitObjectSampleAdjustments.cs
@@ -18,7 +18,6 @@ using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
-using osu.Game.Screens.Edit.Compose.Components;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Tests.Beatmaps;
 using osuTK;
@@ -131,7 +130,7 @@ namespace osu.Game.Tests.Visual.Editing
             hitObjectHasSampleNormalBank(0, HitSampleInfo.BANK_DRUM);
             hitObjectHasSampleAdditionBank(0, HitSampleInfo.BANK_NORMAL);
 
-            setAdditionBankViaPopover(EditorSelectionHandler.HIT_BANK_AUTO);
+            setAdditionBankViaPopover(HitObjectComposer.HIT_BANK_AUTO);
             hitObjectHasSampleNormalBank(0, HitSampleInfo.BANK_DRUM);
             hitObjectHasSampleAdditionBank(0, HitSampleInfo.BANK_DRUM);
         }
@@ -691,7 +690,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             clickSamplePiece(0);
             samplePopoverIsOpen();
-            samplePopoverHasSingleAdditionBank(EditorSelectionHandler.HIT_BANK_AUTO);
+            samplePopoverHasSingleAdditionBank(HitObjectComposer.HIT_BANK_AUTO);
         }
 
         [Test]
@@ -739,7 +738,7 @@ namespace osu.Game.Tests.Visual.Editing
             clickSamplePiece(0);
             samplePopoverIsOpen();
             samplePopoverHasSingleBank(HitSampleInfo.BANK_NORMAL);
-            samplePopoverHasSingleAdditionBank(EditorSelectionHandler.HIT_BANK_AUTO);
+            samplePopoverHasSingleAdditionBank(HitObjectComposer.HIT_BANK_AUTO);
             dismissPopover();
 
             AddStep("Move to 5000", () => EditorClock.Seek(5000));
@@ -756,7 +755,7 @@ namespace osu.Game.Tests.Visual.Editing
             clickSamplePiece(1);
             samplePopoverIsOpen();
             samplePopoverHasSingleBank(HitSampleInfo.BANK_NORMAL);
-            samplePopoverHasSingleAdditionBank(EditorSelectionHandler.HIT_BANK_AUTO);
+            samplePopoverHasSingleAdditionBank(HitObjectComposer.HIT_BANK_AUTO);
         }
 
         [Test]

--- a/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
+++ b/osu.Game.Tests/Visual/Editing/TimelineTestScene.cs
@@ -48,6 +48,7 @@ namespace osu.Game.Tests.Visual.Editing
 
             Composer = playable.BeatmapInfo.Ruleset.CreateInstance().CreateHitObjectComposer();
             Debug.Assert(Composer != null);
+            Dependencies.CacheAs(Composer);
 
             Composer.Alpha = 0;
 

--- a/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
+++ b/osu.Game/Overlays/SkinEditor/SkinSelectionHandler.cs
@@ -58,7 +58,7 @@ namespace osu.Game.Overlays.SkinEditor
 
         private void updateTernaryStates()
         {
-            var usingClosestAnchor = GetStateFromSelection(SelectedBlueprints, c => !c.Item.UsesFixedAnchor);
+            var usingClosestAnchor = SelectedBlueprints.GetTernaryState(c => !c.Item.UsesFixedAnchor);
 
             if (closestAnchor != null)
                 closestAnchor.State.Value = usingClosestAnchor;
@@ -66,14 +66,14 @@ namespace osu.Game.Overlays.SkinEditor
             if (fixedAnchors != null)
             {
                 foreach (var fixedAnchor in fixedAnchors)
-                    fixedAnchor.State.Value = GetStateFromSelection(SelectedBlueprints, c => c.Item.UsesFixedAnchor && ((Drawable)c.Item).Anchor == fixedAnchor.Anchor);
+                    fixedAnchor.State.Value = SelectedBlueprints.GetTernaryState(c => c.Item.UsesFixedAnchor && ((Drawable)c.Item).Anchor == fixedAnchor.Anchor);
             }
 
             if (originMenu != null)
             {
                 foreach (var origin in originMenu.Items.OfType<AnchorMenuItem>())
                 {
-                    origin.State.Value = GetStateFromSelection(SelectedBlueprints, c => ((Drawable)c.Item).Origin == origin.Anchor);
+                    origin.State.Value = SelectedBlueprints.GetTernaryState(c => ((Drawable)c.Item).Origin == origin.Anchor);
                     origin.Action.Disabled = usingClosestAnchor == TernaryState.True;
                 }
             }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.SelectionState.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.SelectionState.cs
@@ -1,0 +1,518 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Humanizer;
+using osu.Framework.Bindables;
+using osu.Game.Audio;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Objects;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Screens.Edit.Compose.Components.Timeline;
+using osu.Game.Utils;
+
+namespace osu.Game.Rulesets.Edit
+{
+    public partial class HitObjectComposer<TObject>
+    {
+        #region Selection State
+
+        public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionSampleStates => selectionSampleStates;
+        private readonly Dictionary<string, Bindable<TernaryState>> selectionSampleStates = new Dictionary<string, Bindable<TernaryState>>();
+
+        public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionBankStates => selectionBankStates;
+        private readonly Dictionary<string, Bindable<TernaryState>> selectionBankStates = new Dictionary<string, Bindable<TernaryState>>();
+
+        public override IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionAdditionBankStates => selectionAdditionBankStates;
+        private readonly Dictionary<string, Bindable<TernaryState>> selectionAdditionBankStates = new Dictionary<string, Bindable<TernaryState>>();
+
+        public override Bindable<bool> AutoSelectionBankEnabled { get; } = new Bindable<bool>();
+
+        /// <summary>
+        /// Set up ternary state bindables and bind them to selection/hitobject changes (in both directions)
+        /// </summary>
+        private void createSelectionStateBindables()
+        {
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
+            {
+                var bindable = new Bindable<TernaryState>
+                {
+                    Description = bankName.Titleize()
+                };
+
+                bindable.ValueChanged += state =>
+                {
+                    switch (state.NewValue)
+                    {
+                        case TernaryState.False:
+                            if (EditorBeatmap.SelectedHitObjects.Count == 0)
+                            {
+                                // Ensure that if this is the last selected bank, it should remain selected.
+                                if (selectionBankStates.Values.All(b => b.Value == TernaryState.False))
+                                    bindable.Value = TernaryState.True;
+                            }
+                            else
+                            {
+                                // Auto should never apply when there is a selection made.
+                                // This is also required to stop a bindable feedback loop when a HitObject has zero samples (and LINQ `All` below becomes true).
+                                if (bankName == HIT_BANK_AUTO)
+                                    break;
+
+                                // Never remove a sample bank.
+                                // These are basically radio buttons, not toggles.
+                                if (EditorBeatmap.SelectedHitObjects.All(h => h.Samples.Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName)))
+                                    bindable.Value = TernaryState.True;
+                            }
+
+                            break;
+
+                        case TernaryState.True:
+                            if (EditorBeatmap.SelectedHitObjects.Count == 0)
+                            {
+                                // Ensure the user can't stack multiple bank selections when there's no hitobject selection.
+                                // Note that in normal scenarios this is sorted out by the feedback from applying the bank to the selected objects.
+                                foreach (var other in selectionBankStates.Values)
+                                {
+                                    if (other != bindable)
+                                        other.Value = TernaryState.False;
+                                }
+                            }
+                            else
+                            {
+                                // Auto should just not apply if there's a selection already made.
+                                // Maybe we could make it a disabled button in the future, but right now the editor buttons don't support disabled state.
+                                if (bankName == HIT_BANK_AUTO)
+                                {
+                                    bindable.Value = TernaryState.False;
+                                    break;
+                                }
+
+                                SetSampleBank(bankName);
+                            }
+
+                            break;
+                    }
+
+                    InvokeSelectionStateChanged();
+                };
+
+                selectionBankStates[bankName] = bindable;
+            }
+
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
+            {
+                var bindable = new Bindable<TernaryState>
+                {
+                    Description = bankName.Titleize()
+                };
+
+                bindable.ValueChanged += state =>
+                {
+                    switch (state.NewValue)
+                    {
+                        case TernaryState.False:
+                            if (EditorBeatmap.SelectedHitObjects.Count == 0)
+                            {
+                                // Ensure that if this is the last selected bank, it should remain selected.
+                                if (selectionAdditionBankStates.Values.All(b => b.Value == TernaryState.False))
+                                    bindable.Value = TernaryState.True;
+                            }
+                            else
+                            {
+                                // Completely empty selections should be allowed in the case that none of the selected objects have any addition samples.
+                                // This is also required to stop a bindable feedback loop when a HitObject has zero addition samples (and LINQ `All` below becomes true).
+                                if (EditorBeatmap.SelectedHitObjects.SelectMany(enumerateAllSamples).All(h => h.All(o => o.Name == HitSampleInfo.HIT_NORMAL)))
+                                    break;
+
+                                // Never remove a sample bank.
+                                // These are basically radio buttons, not toggles.
+                                if (bankName == HIT_BANK_AUTO)
+                                {
+                                    if (EditorBeatmap.SelectedHitObjects.SelectMany(enumerateAllSamples).All(h => h.Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.EditorAutoBank)))
+                                        bindable.Value = TernaryState.True;
+                                }
+                                else
+                                {
+                                    if (EditorBeatmap.SelectedHitObjects.SelectMany(enumerateAllSamples).All(h => h.Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName && !s.EditorAutoBank)))
+                                        bindable.Value = TernaryState.True;
+                                }
+                            }
+
+                            break;
+
+                        case TernaryState.True:
+                            // If any of the selected objects have any addition samples, we should apply the addition bank.
+                            if (EditorBeatmap.SelectedHitObjects.SelectMany(enumerateAllSamples).Any(h => h.Any(o => o.Name != HitSampleInfo.HIT_NORMAL)))
+                                SetSampleAdditionBank(bankName);
+
+                            // There are either no selected items, or none of the selected items have addition sounds.
+                            // This state is basically the user pre-selecting an addition bank before actually adding an addition.
+                            // Ensure the user can't stack multiple bank selections in this state.
+                            // Note that in normal scenarios this is sorted out by the feedback from applying the bank to the selected objects.
+                            foreach (var other in selectionAdditionBankStates.Values)
+                            {
+                                if (other != bindable)
+                                    other.Value = TernaryState.False;
+                            }
+
+                            break;
+                    }
+
+                    InvokeSelectionStateChanged();
+                };
+
+                selectionAdditionBankStates[bankName] = bindable;
+            }
+
+            resetTernaryStates();
+
+            foreach (string sampleName in HitSampleInfo.ALL_ADDITIONS)
+            {
+                var bindable = new Bindable<TernaryState>
+                {
+                    Description = sampleName.Replace("hit", string.Empty).Titleize()
+                };
+
+                bindable.ValueChanged += state =>
+                {
+                    switch (state.NewValue)
+                    {
+                        case TernaryState.False:
+                            RemoveHitSample(sampleName);
+                            break;
+
+                        case TernaryState.True:
+                            AddHitSample(sampleName);
+                            break;
+                    }
+
+                    InvokeSelectionStateChanged();
+                };
+
+                selectionSampleStates[sampleName] = bindable;
+            }
+
+            // new combo
+            if (SelectionNewComboState != null)
+            {
+                SelectionNewComboState.ValueChanged += state =>
+                {
+                    switch (state.NewValue)
+                    {
+                        case TernaryState.False:
+                            SetNewCombo(false);
+                            break;
+
+                        case TernaryState.True:
+                            SetNewCombo(true);
+                            break;
+                    }
+
+                    InvokeSelectionStateChanged();
+                };
+            }
+        }
+
+        private void resetTernaryStates()
+        {
+            if (EditorBeatmap.SelectedHitObjects.Count > 0)
+                return;
+
+            if (SelectionNewComboState != null)
+                SelectionNewComboState.Value = TernaryState.False;
+            AutoSelectionBankEnabled.Value = true;
+            selectionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;
+            selectionAdditionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;
+            foreach (var (_, sampleState) in selectionSampleStates)
+                sampleState.Value = TernaryState.False;
+        }
+
+        /// <summary>
+        /// Called when context menu ternary states may need to be recalculated (selection changed or hitobject updated).
+        /// </summary>
+        protected virtual void UpdateTernaryStates()
+        {
+            if (EditorBeatmap.SelectedHitObjects.Any() && SelectionNewComboState != null)
+                SelectionNewComboState.Value = EditorBeatmap.SelectedHitObjects.OfType<IHasComboInformation>().GetTernaryState(h => h.NewCombo);
+            AutoSelectionBankEnabled.Value = EditorBeatmap.SelectedHitObjects.Count == 0;
+
+            var samplesInSelection = EditorBeatmap.SelectedHitObjects.SelectMany(enumerateAllSamples).ToArray();
+
+            if (samplesInSelection.Length > 0)
+            {
+                foreach ((string sampleName, var bindable) in selectionSampleStates)
+                {
+                    bindable.Value = samplesInSelection.GetTernaryState(h => h.Any(s => s.Name == sampleName));
+                }
+
+                foreach ((string bankName, var bindable) in selectionBankStates)
+                {
+                    bindable.Value = samplesInSelection.SelectMany(s => s).Where(o => o.Name == HitSampleInfo.HIT_NORMAL).GetTernaryState(h => h.Bank == bankName);
+                }
+
+                // if there are no addition samples in the selection, do not touch the state of addition bank bindables.
+                // this is to reduce annoyance from the bank resetting if the user wants to e.g. remove the only addition sound on an object, but then add another addition sound
+                // while keeping the bank the same.
+                // note that deselecting all objects will still reset the addition bank selection to auto via `ResetTernaryStates()`. this may need to be reconsidered later.
+                if (samplesInSelection.SelectMany(s => s).Any(o => o.Name != HitSampleInfo.HIT_NORMAL))
+                {
+                    foreach ((string bankName, var bindable) in selectionAdditionBankStates)
+                    {
+                        bindable.Value = samplesInSelection.SelectMany(s => s).Where(o => o.Name != HitSampleInfo.HIT_NORMAL)
+                                                           .GetTernaryState(h => (bankName != HIT_BANK_AUTO && h.Bank == bankName && !h.EditorAutoBank) || (bankName == HIT_BANK_AUTO && h.EditorAutoBank));
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<IList<HitSampleInfo>> enumerateAllSamples(HitObject hitObject)
+        {
+            yield return hitObject.Samples;
+
+            if (hitObject is IHasRepeats withRepeats)
+            {
+                foreach (var node in withRepeats.NodeSamples)
+                    yield return node;
+            }
+        }
+
+        #endregion
+
+        #region Ternary state changes
+
+        /// <summary>
+        /// Sets the sample bank for all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <remarks>
+        /// Should be kept in sync with <see cref="SamplePointPiece.SampleEditPopover.setBank"/>.
+        /// </remarks>
+        /// <param name="bankName">The name of the sample bank.</param>
+        public void SetSampleBank(string bankName)
+        {
+            bool hasRelevantBank(HitObject hitObject)
+            {
+                bool result = hitObject.Samples.Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName);
+
+                if (hitObject is IHasRepeats hasRepeats)
+                {
+                    foreach (var node in hasRepeats.NodeSamples)
+                        result &= node.Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName);
+                }
+
+                return result;
+            }
+
+            if (EditorBeatmap.SelectedHitObjects.All(hasRelevantBank))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (hasRelevantBank(h))
+                    return;
+
+                h.Samples = h.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL || s.EditorAutoBank ? s.With(newBank: bankName) : s).ToList();
+
+                if (h is IHasRepeats hasRepeats)
+                {
+                    for (int i = 0; i < hasRepeats.NodeSamples.Count; ++i)
+                        hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Select(s => s.Name == HitSampleInfo.HIT_NORMAL || s.EditorAutoBank ? s.With(newBank: bankName) : s).ToList();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Sets the sample addition bank for all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <remarks>
+        /// Should be kept in sync with <see cref="SamplePointPiece.SampleEditPopover.setAdditionBank"/>.
+        /// </remarks>
+        /// <param name="bankName">The name of the sample bank.</param>
+        public void SetSampleAdditionBank(string bankName)
+        {
+            bool hasRelevantBank(HitObject hitObject) =>
+                bankName == HIT_BANK_AUTO
+                    ? enumerateAllSamples(hitObject).SelectMany(o => o).Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.EditorAutoBank)
+                    : enumerateAllSamples(hitObject).SelectMany(o => o).Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName && !s.EditorAutoBank);
+
+            if (EditorBeatmap.SelectedHitObjects.All(hasRelevantBank))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                if (hasRelevantBank(h))
+                    return;
+
+                string normalBank = h.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank ?? HitSampleInfo.BANK_SOFT;
+                h.Samples = h.Samples.Select(s =>
+                                 s.Name != HitSampleInfo.HIT_NORMAL
+                                     ? bankName == HIT_BANK_AUTO ? s.With(newBank: normalBank, newEditorAutoBank: true) : s.With(newBank: bankName, newEditorAutoBank: false)
+                                     : s)
+                             .ToList();
+
+                if (h is IHasRepeats hasRepeats)
+                {
+                    for (int i = 0; i < hasRepeats.NodeSamples.Count; ++i)
+                    {
+                        normalBank = hasRepeats.NodeSamples[i].FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank ?? HitSampleInfo.BANK_SOFT;
+                        hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Select(s =>
+                            s.Name != HitSampleInfo.HIT_NORMAL
+                                ? bankName == HIT_BANK_AUTO ? s.With(newBank: normalBank, newEditorAutoBank: true) : s.With(newBank: bankName, newEditorAutoBank: false)
+                                : s).ToList();
+                    }
+                }
+            });
+        }
+
+        private bool hasRelevantSample(HitObject hitObject, string sampleName)
+        {
+            bool result = hitObject.Samples.Any(s => s.Name == sampleName);
+
+            if (hitObject is IHasRepeats hasRepeats)
+            {
+                foreach (var node in hasRepeats.NodeSamples)
+                    result &= node.Any(s => s.Name == sampleName);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Adds a hit sample to all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <remarks>
+        /// Should be kept in sync with <see cref="SamplePointPiece.SampleEditPopover.addHitSample"/>.
+        /// </remarks>
+        /// <param name="sampleName">The name of the hit sample.</param>
+        public void AddHitSample(string sampleName)
+        {
+            if (EditorBeatmap.SelectedHitObjects.All(h => hasRelevantSample(h, sampleName)))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                string? forcedBank = null;
+                // if the selected object(s) only have normal samples, check whether the user has preselected a singular non-auto bank using `SelectionAdditionBankStates`.
+                // other scenarios are already handled by `CreateHitSampleInfo()`:
+                // - if the selected object(s) already have addition samples, `CreateHitSampleInfo()` will copy the bank from said addition samples.
+                // - if the selected object(s) do not have addition samples but the user has preselected auto bank, `CreateHitSampleInfo()` will use the auto bank anyway.
+                if (h.Samples.All(s => s.Name == HitSampleInfo.HIT_NORMAL))
+                    forcedBank = selectionAdditionBankStates.SingleOrDefault(kv => kv.Value.Value == TernaryState.True).Key;
+
+                // Make sure there isn't already an existing sample
+                if (h.Samples.All(s => s.Name != sampleName))
+                {
+                    var hitSample = h.CreateHitSampleInfo(sampleName);
+
+                    if (forcedBank != null && forcedBank != HIT_BANK_AUTO)
+                        hitSample = hitSample.With(newBank: forcedBank, newEditorAutoBank: false);
+
+                    h.Samples.Add(hitSample);
+                }
+
+                if (h is IHasRepeats hasRepeats)
+                {
+                    foreach (var node in hasRepeats.NodeSamples)
+                    {
+                        if (node.Any(s => s.Name == sampleName))
+                            continue;
+
+                        var hitSample = h.CreateHitSampleInfo(sampleName);
+
+                        HitSampleInfo? existingAddition = node.FirstOrDefault(s => s.Name != HitSampleInfo.HIT_NORMAL);
+                        if (existingAddition != null)
+                            hitSample = hitSample.With(newBank: existingAddition.Bank, newEditorAutoBank: existingAddition.EditorAutoBank);
+
+                        node.Add(hitSample);
+                    }
+                }
+            });
+        }
+
+        /// <summary>
+        /// Removes a hit sample from all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="sampleName">The name of the hit sample.</param>
+        public void RemoveHitSample(string sampleName)
+        {
+            if (EditorBeatmap.SelectedHitObjects.All(h => !hasRelevantSample(h, sampleName)))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                h.SamplesBindable.RemoveAll(s => s.Name == sampleName);
+
+                if (h is IHasRepeats hasRepeats)
+                {
+                    for (int i = 0; i < hasRepeats.NodeSamples.Count; ++i)
+                        hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Where(s => s.Name != sampleName).ToList();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Set the new combo state of all selected <see cref="HitObject"/>s.
+        /// </summary>
+        /// <param name="state">Whether to set or unset.</param>
+        /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
+        public void SetNewCombo(bool state)
+        {
+            if (EditorBeatmap.SelectedHitObjects.OfType<IHasComboInformation>().All(h => h.NewCombo == state))
+                return;
+
+            EditorBeatmap.PerformOnSelection(h =>
+            {
+                var comboInfo = h as IHasComboInformation;
+
+                if (comboInfo == null || comboInfo.NewCombo == state) return;
+
+                comboInfo.NewCombo = state;
+            });
+        }
+
+        #endregion
+    }
+
+    public abstract partial class HitObjectComposer
+    {
+        #region Selection State
+
+        /// <summary>
+        /// A special bank name that is only used in the editor UI.
+        /// When selected and in placement mode, the bank of the last hit object will always be used.
+        /// </summary>
+        public const string HIT_BANK_AUTO = @"auto";
+
+        public event Action? SelectionStateChanged;
+
+        public void InvokeSelectionStateChanged() => SelectionStateChanged?.Invoke();
+
+        /// <summary>
+        /// The state of "new combo" for all selected hitobjects.
+        /// </summary>
+        public abstract Bindable<TernaryState>? SelectionNewComboState { get; }
+
+        /// <summary>
+        /// The state of each sample type for all selected hitobjects. Keys match with <see cref="HitSampleInfo"/> constant specifications.
+        /// </summary>
+        public abstract IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionSampleStates { get; }
+
+        /// <summary>
+        /// The state of each sample bank type for all selected hitobjects.
+        /// </summary>
+        public abstract IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionBankStates { get; }
+
+        /// <summary>
+        /// The state of each sample addition bank type for all selected hitobjects.
+        /// </summary>
+        public abstract IReadOnlyDictionary<string, Bindable<TernaryState>> SelectionAdditionBankStates { get; }
+
+        /// <summary>
+        /// Whether there is no selection and the auto <see cref="SelectionBankStates"/> can be used.
+        /// </summary>
+        public abstract Bindable<bool> AutoSelectionBankEnabled { get; }
+
+        #endregion
+    }
+}

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -135,6 +136,8 @@ namespace osu.Game.Rulesets.Edit
 
             string shiftDisplay = keyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Shift));
             string altDisplay = keyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Alt));
+
+            createSelectionStateBindables();
 
             InternalChildren = new[]
             {
@@ -269,6 +272,9 @@ namespace osu.Game.Rulesets.Edit
             SetSelectTool();
 
             EditorBeatmap.SelectedHitObjects.CollectionChanged += selectionChanged;
+
+            // bring in updates from selection changes
+            EditorBeatmap.HitObjectUpdated += hitObjectUpdated;
         }
 
         /// <summary>
@@ -503,7 +509,17 @@ namespace osu.Game.Rulesets.Edit
             {
                 // ensure in selection mode if a selection is made.
                 SetSelectTool();
+                Scheduler.AddOnce(UpdateTernaryStates);
             }
+            else
+                // Reset the ternary states when the selection is cleared.
+                Scheduler.AddOnce(resetTernaryStates);
+        }
+
+        private void hitObjectUpdated(HitObject _)
+        {
+            // bring in updates from selection changes
+            Scheduler.AddOnce(UpdateTernaryStates);
         }
 
         public void SetSelectTool() => toolboxCollection.Items.First().Select();
@@ -565,6 +581,17 @@ namespace osu.Game.Rulesets.Edit
         protected virtual Playfield PlayfieldAtScreenSpacePosition(Vector2 screenSpacePosition) => drawableRulesetWrapper.Playfield;
 
         #endregion
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (EditorBeatmap.IsNotNull())
+            {
+                EditorBeatmap.HitObjectUpdated -= hitObjectUpdated;
+                EditorBeatmap.SelectedHitObjects.CollectionChanged -= selectionChanged;
+            }
+
+            base.Dispose(isDisposing);
+        }
     }
 
     /// <summary>

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -1,15 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -52,51 +50,50 @@ namespace osu.Game.Rulesets.Edit
         /// </summary>
         protected virtual bool ApplyHorizontalCentering => true;
 
-        protected IRulesetConfigManager Config { get; private set; }
+        protected IRulesetConfigManager? Config { get; private set; }
 
         // Provides `Playfield`
-        private DependencyContainer dependencies;
+        private DependencyContainer dependencies = null!;
 
         [Resolved]
-        protected EditorClock EditorClock { get; private set; }
+        protected EditorClock EditorClock { get; private set; } = null!;
 
         [Resolved]
-        protected EditorBeatmap EditorBeatmap { get; private set; }
+        protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
 
         [Resolved]
-        protected IBeatSnapProvider BeatSnapProvider { get; private set; }
+        protected IBeatSnapProvider BeatSnapProvider { get; private set; } = null!;
 
         [Resolved]
-        private OverlayColourProvider colourProvider { get; set; }
+        private OverlayColourProvider colourProvider { get; set; } = null!;
 
         public override ComposeBlueprintContainer BlueprintContainer => blueprintContainer;
-        private ComposeBlueprintContainer blueprintContainer;
+        private ComposeBlueprintContainer blueprintContainer = null!;
 
-        protected ExpandingToolboxContainer LeftToolbox { get; private set; }
+        protected ExpandingToolboxContainer LeftToolbox { get; private set; } = null!;
 
-        protected ExpandingToolboxContainer RightToolbox { get; private set; }
+        protected ExpandingToolboxContainer RightToolbox { get; private set; } = null!;
 
-        private DrawableEditorRulesetWrapper<TObject> drawableRulesetWrapper;
+        private DrawableEditorRulesetWrapper<TObject> drawableRulesetWrapper = null!;
 
         protected readonly Container LayerBelowRuleset = new Container { RelativeSizeAxes = Axes.Both };
 
-        protected InputManager InputManager { get; private set; }
+        protected InputManager InputManager { get; private set; } = null!;
 
-        private Box leftToolboxBackground;
-        private Box rightToolboxBackground;
+        private Box leftToolboxBackground = null!;
+        private Box rightToolboxBackground = null!;
 
-        private EditorRadioButtonCollection toolboxCollection;
-        private FillFlowContainer togglesCollection;
-        private FillFlowContainer sampleBankTogglesCollection;
+        private EditorRadioButtonCollection toolboxCollection = null!;
+        private FillFlowContainer togglesCollection = null!;
+        private FillFlowContainer sampleBankTogglesCollection = null!;
 
-        private IBindable<bool> hasTiming;
-        private Bindable<bool> autoSeekOnPlacement;
+        private IBindable<bool> hasTiming = null!;
+        private Bindable<bool> autoSeekOnPlacement = null!;
         private readonly Bindable<bool> composerFocusMode = new Bindable<bool>();
 
-        [CanBeNull]
-        private EditorRadioButton lastTool;
+        private EditorRadioButton? lastTool;
 
-        protected DrawableRuleset<TObject> DrawableRuleset { get; private set; }
+        protected DrawableRuleset<TObject> DrawableRuleset { get; private set; } = null!;
 
         protected HitObjectComposer(Ruleset ruleset)
             : base(ruleset)
@@ -107,7 +104,7 @@ namespace osu.Game.Rulesets.Edit
             dependencies = new DependencyContainer(base.CreateChildDependencies(parent));
 
         [BackgroundDependencyLoader(true)]
-        private void load(OsuConfigManager config, [CanBeNull] Editor editor, ReadableKeyCombinationProvider keyCombinationProvider)
+        private void load(OsuConfigManager config, Editor? editor, ReadableKeyCombinationProvider keyCombinationProvider)
         {
             autoSeekOnPlacement = config.GetBindable<bool>(OsuSetting.EditorAutoSeekOnPlacement);
 
@@ -118,7 +115,7 @@ namespace osu.Game.Rulesets.Edit
 
             try
             {
-                DrawableRuleset = CreateDrawableRuleset(Ruleset, EditorBeatmap.PlayableBeatmap, new[] { Ruleset.GetAutoplayMod() });
+                DrawableRuleset = CreateDrawableRuleset(Ruleset, EditorBeatmap.PlayableBeatmap, Ruleset.GetAutoplayMod()?.Yield().ToArray() ?? []);
                 drawableRulesetWrapper = new DrawableEditorRulesetWrapper<TObject>(DrawableRuleset)
                 {
                     Clock = EditorClock,
@@ -281,13 +278,13 @@ namespace osu.Game.Rulesets.Edit
         /// Generally implementations should not be adding to this directly.
         /// Use <see cref="LayerBelowRuleset"/> or <see cref="BlueprintContainer"/> instead.
         /// </remarks>
-        protected Container PlayfieldContentContainer { get; private set; }
+        protected Container PlayfieldContentContainer { get; private set; } = null!;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            InputManager = GetContainingInputManager();
+            InputManager = GetContainingInputManager()!;
 
             hasTiming = EditorBeatmap.HasTiming.GetBoundCopy();
             hasTiming.BindValueChanged(timing =>
@@ -500,7 +497,7 @@ namespace osu.Game.Rulesets.Edit
             return index >= 0;
         }
 
-        private void selectionChanged(object sender, NotifyCollectionChangedEventArgs changedArgs)
+        private void selectionChanged(object? sender, NotifyCollectionChangedEventArgs changedArgs)
         {
             if (EditorBeatmap.SelectedHitObjects.Any())
             {

--- a/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
@@ -25,16 +25,6 @@ namespace osu.Game.Rulesets.Edit
     public abstract partial class HitObjectPlacementBlueprint : PlacementBlueprint
     {
         /// <summary>
-        /// Whether the sample bank should be taken from the previous hit object.
-        /// </summary>
-        public bool AutomaticBankAssignment { get; set; }
-
-        /// <summary>
-        /// Whether the sample addition bank should be taken from the previous hit objects.
-        /// </summary>
-        public bool AutomaticAdditionBankAssignment { get; set; }
-
-        /// <summary>
         /// The <see cref="HitObject"/> that is being placed.
         /// </summary>
         public readonly HitObject HitObject;

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -91,9 +91,10 @@ namespace osu.Game.Screens.Edit.Compose.Components
             Beatmap.HitObjectAdded += hitObjectAdded;
 
             // updates to selected are handled for us by SelectionHandler.
-            NewCombo.BindTo(SelectionHandler.SelectionNewComboState);
+            if (Composer.SelectionNewComboState != null)
+                NewCombo.BindTo(Composer.SelectionNewComboState);
 
-            SelectionHandler.AutoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip(), true);
+            Composer.AutoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip(), true);
         }
 
         protected override void TransferBlueprintFor(HitObject hitObject, DrawableHitObject drawableObject)
@@ -158,7 +159,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
             if (newComboButton != null)
                 yield return newComboButton;
 
-            foreach (var kvp in SelectionHandler.SelectionSampleStates)
+            foreach (var kvp in Composer.SelectionSampleStates)
             {
                 yield return new DrawableTernaryButton
                 {
@@ -171,12 +172,12 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private IEnumerable<SampleBankTernaryButton> createSampleBankTernaryButtons()
         {
-            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(EditorSelectionHandler.HIT_BANK_AUTO))
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HitObjectComposer.HIT_BANK_AUTO))
             {
                 yield return new SampleBankTernaryButton(bankName)
                 {
-                    NormalState = { Current = SelectionHandler.SelectionBankStates[bankName], },
-                    AdditionsState = { Current = SelectionHandler.SelectionAdditionBankStates[bankName], },
+                    NormalState = { Current = Composer.SelectionBankStates[bankName], },
+                    AdditionsState = { Current = Composer.SelectionAdditionBankStates[bankName], },
                     CreateIcon = () => getIconForBank(bankName),
                     CreateCompactIcon = () => getCompactIconForBank(bankName),
                 };
@@ -190,7 +191,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 Size = new Vector2(20, 20),
                 Icon = sampleName switch
                 {
-                    EditorSelectionHandler.HIT_BANK_AUTO => OsuIcon.EditorBankAuto,
+                    HitObjectComposer.HIT_BANK_AUTO => OsuIcon.EditorBankAuto,
                     HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormal,
                     HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoft,
                     HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrum,
@@ -206,7 +207,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
                 Size = new Vector2(10, 20),
                 Icon = sampleName switch
                 {
-                    EditorSelectionHandler.HIT_BANK_AUTO => OsuIcon.EditorBankAutoCompact,
+                    HitObjectComposer.HIT_BANK_AUTO => OsuIcon.EditorBankAutoCompact,
                     HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormalCompact,
                     HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoftCompact,
                     HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrumCompact,
@@ -234,9 +235,9 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updateAutoBankTernaryButtonTooltip()
         {
-            bool enabled = SelectionHandler.AutoSelectionBankEnabled.Value;
+            bool enabled = Composer.AutoSelectionBankEnabled.Value;
 
-            var autoBankButton = SampleBankTernaryStates.Single(t => t.BankName == EditorSelectionHandler.HIT_BANK_AUTO);
+            var autoBankButton = SampleBankTernaryStates.Single(t => t.BankName == HitObjectComposer.HIT_BANK_AUTO);
             autoBankButton.NormalButton.Enabled.Value = enabled;
             autoBankButton.NormalButton.TooltipText = !enabled ? "Auto normal bank can only be used during hit object placement" : string.Empty;
         }

--- a/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/EditorSelectionHandler.cs
@@ -1,13 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
-using Humanizer;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -17,7 +13,6 @@ using osu.Game.Localisation;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
-using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osuTK.Input;
 
 namespace osu.Game.Screens.Edit.Compose.Components
@@ -29,25 +24,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// </summary>
         public bool RightClickAlwaysQuickDeletes { get; set; }
 
-        /// <summary>
-        /// A special bank name that is only used in the editor UI.
-        /// When selected and in placement mode, the bank of the last hit object will always be used.
-        /// </summary>
-        public const string HIT_BANK_AUTO = "auto";
-
         [Resolved]
         protected EditorBeatmap EditorBeatmap { get; private set; } = null!;
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            createStateBindables();
-
-            // bring in updates from selection changes
-            EditorBeatmap.HitObjectUpdated += _ => Scheduler.AddOnce(UpdateTernaryStates);
-
-            SelectedItems.CollectionChanged += onSelectedItemsChanged;
-        }
+        [Resolved]
+        private HitObjectComposer composer { get; set; } = null!;
 
         protected override bool ShouldQuickDelete(MouseButtonEvent e)
         {
@@ -59,483 +40,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void DeleteItems(IEnumerable<HitObject> items) => EditorBeatmap.RemoveRange(items);
 
-        #region Selection State
-
-        public event Action? SelectionStateChanged;
-
-        /// <summary>
-        /// The state of "new combo" for all selected hitobjects.
-        /// </summary>
-        public readonly Bindable<TernaryState> SelectionNewComboState = new Bindable<TernaryState>();
-
-        /// <summary>
-        /// The state of each sample type for all selected hitobjects. Keys match with <see cref="HitSampleInfo"/> constant specifications.
-        /// </summary>
-        public readonly Dictionary<string, Bindable<TernaryState>> SelectionSampleStates = new Dictionary<string, Bindable<TernaryState>>();
-
-        /// <summary>
-        /// The state of each sample bank type for all selected hitobjects.
-        /// </summary>
-        public readonly Dictionary<string, Bindable<TernaryState>> SelectionBankStates = new Dictionary<string, Bindable<TernaryState>>();
-
-        /// <summary>
-        /// The state of each sample addition bank type for all selected hitobjects.
-        /// </summary>
-        public readonly Dictionary<string, Bindable<TernaryState>> SelectionAdditionBankStates = new Dictionary<string, Bindable<TernaryState>>();
-
-        /// <summary>
-        /// Whether there is no selection and the auto <see cref="SelectionBankStates"/> can be used.
-        /// </summary>
-        public readonly Bindable<bool> AutoSelectionBankEnabled = new Bindable<bool>();
-
-        /// <summary>
-        /// Set up ternary state bindables and bind them to selection/hitobject changes (in both directions)
-        /// </summary>
-        private void createStateBindables()
-        {
-            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
-            {
-                var bindable = new Bindable<TernaryState>
-                {
-                    Description = bankName.Titleize()
-                };
-
-                bindable.ValueChanged += state =>
-                {
-                    switch (state.NewValue)
-                    {
-                        case TernaryState.False:
-                            if (SelectedItems.Count == 0)
-                            {
-                                // Ensure that if this is the last selected bank, it should remain selected.
-                                if (SelectionBankStates.Values.All(b => b.Value == TernaryState.False))
-                                    bindable.Value = TernaryState.True;
-                            }
-                            else
-                            {
-                                // Auto should never apply when there is a selection made.
-                                // This is also required to stop a bindable feedback loop when a HitObject has zero samples (and LINQ `All` below becomes true).
-                                if (bankName == HIT_BANK_AUTO)
-                                    break;
-
-                                // Never remove a sample bank.
-                                // These are basically radio buttons, not toggles.
-                                if (SelectedItems.All(h => h.Samples.Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName)))
-                                    bindable.Value = TernaryState.True;
-                            }
-
-                            break;
-
-                        case TernaryState.True:
-                            if (SelectedItems.Count == 0)
-                            {
-                                // Ensure the user can't stack multiple bank selections when there's no hitobject selection.
-                                // Note that in normal scenarios this is sorted out by the feedback from applying the bank to the selected objects.
-                                foreach (var other in SelectionBankStates.Values)
-                                {
-                                    if (other != bindable)
-                                        other.Value = TernaryState.False;
-                                }
-                            }
-                            else
-                            {
-                                // Auto should just not apply if there's a selection already made.
-                                // Maybe we could make it a disabled button in the future, but right now the editor buttons don't support disabled state.
-                                if (bankName == HIT_BANK_AUTO)
-                                {
-                                    bindable.Value = TernaryState.False;
-                                    break;
-                                }
-
-                                SetSampleBank(bankName);
-                            }
-
-                            break;
-                    }
-
-                    SelectionStateChanged?.Invoke();
-                };
-
-                SelectionBankStates[bankName] = bindable;
-            }
-
-            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
-            {
-                var bindable = new Bindable<TernaryState>
-                {
-                    Description = bankName.Titleize()
-                };
-
-                bindable.ValueChanged += state =>
-                {
-                    switch (state.NewValue)
-                    {
-                        case TernaryState.False:
-                            if (SelectedItems.Count == 0)
-                            {
-                                // Ensure that if this is the last selected bank, it should remain selected.
-                                if (SelectionAdditionBankStates.Values.All(b => b.Value == TernaryState.False))
-                                    bindable.Value = TernaryState.True;
-                            }
-                            else
-                            {
-                                // Completely empty selections should be allowed in the case that none of the selected objects have any addition samples.
-                                // This is also required to stop a bindable feedback loop when a HitObject has zero addition samples (and LINQ `All` below becomes true).
-                                if (SelectedItems.SelectMany(enumerateAllSamples).All(h => h.All(o => o.Name == HitSampleInfo.HIT_NORMAL)))
-                                    break;
-
-                                // Never remove a sample bank.
-                                // These are basically radio buttons, not toggles.
-                                if (bankName == HIT_BANK_AUTO)
-                                {
-                                    if (SelectedItems.SelectMany(enumerateAllSamples).All(h => h.Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.EditorAutoBank)))
-                                        bindable.Value = TernaryState.True;
-                                }
-                                else
-                                {
-                                    if (SelectedItems.SelectMany(enumerateAllSamples).All(h => h.Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName && !s.EditorAutoBank)))
-                                        bindable.Value = TernaryState.True;
-                                }
-                            }
-
-                            break;
-
-                        case TernaryState.True:
-                            // If any of the selected objects have any addition samples, we should apply the addition bank.
-                            if (SelectedItems.SelectMany(enumerateAllSamples).Any(h => h.Any(o => o.Name != HitSampleInfo.HIT_NORMAL)))
-                                SetSampleAdditionBank(bankName);
-
-                            // There are either no selected items, or none of the selected items have addition sounds.
-                            // This state is basically the user pre-selecting an addition bank before actually adding an addition.
-                            // Ensure the user can't stack multiple bank selections in this state.
-                            // Note that in normal scenarios this is sorted out by the feedback from applying the bank to the selected objects.
-                            foreach (var other in SelectionAdditionBankStates.Values)
-                            {
-                                if (other != bindable)
-                                    other.Value = TernaryState.False;
-                            }
-
-                            break;
-                    }
-
-                    SelectionStateChanged?.Invoke();
-                };
-
-                SelectionAdditionBankStates[bankName] = bindable;
-            }
-
-            resetTernaryStates();
-
-            foreach (string sampleName in HitSampleInfo.ALL_ADDITIONS)
-            {
-                var bindable = new Bindable<TernaryState>
-                {
-                    Description = sampleName.Replace("hit", string.Empty).Titleize()
-                };
-
-                bindable.ValueChanged += state =>
-                {
-                    switch (state.NewValue)
-                    {
-                        case TernaryState.False:
-                            RemoveHitSample(sampleName);
-                            break;
-
-                        case TernaryState.True:
-                            AddHitSample(sampleName);
-                            break;
-                    }
-
-                    SelectionStateChanged?.Invoke();
-                };
-
-                SelectionSampleStates[sampleName] = bindable;
-            }
-
-            // new combo
-            SelectionNewComboState.ValueChanged += state =>
-            {
-                switch (state.NewValue)
-                {
-                    case TernaryState.False:
-                        SetNewCombo(false);
-                        break;
-
-                    case TernaryState.True:
-                        SetNewCombo(true);
-                        break;
-                }
-
-                SelectionStateChanged?.Invoke();
-            };
-        }
-
-        private void resetTernaryStates()
-        {
-            if (SelectedItems.Count > 0)
-                return;
-
-            SelectionNewComboState.Value = TernaryState.False;
-            AutoSelectionBankEnabled.Value = true;
-            SelectionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;
-            SelectionAdditionBankStates[HIT_BANK_AUTO].Value = TernaryState.True;
-            foreach (var (_, sampleState) in SelectionSampleStates)
-                sampleState.Value = TernaryState.False;
-        }
-
-        /// <summary>
-        /// Called when context menu ternary states may need to be recalculated (selection changed or hitobject updated).
-        /// </summary>
-        protected virtual void UpdateTernaryStates()
-        {
-            if (SelectedItems.Any())
-                SelectionNewComboState.Value = GetStateFromSelection(SelectedItems.OfType<IHasComboInformation>(), h => h.NewCombo);
-            AutoSelectionBankEnabled.Value = SelectedItems.Count == 0;
-
-            var samplesInSelection = SelectedItems.SelectMany(enumerateAllSamples).ToArray();
-
-            if (samplesInSelection.Length > 0)
-            {
-                foreach ((string sampleName, var bindable) in SelectionSampleStates)
-                {
-                    bindable.Value = GetStateFromSelection(samplesInSelection, h => h.Any(s => s.Name == sampleName));
-                }
-
-                foreach ((string bankName, var bindable) in SelectionBankStates)
-                {
-                    bindable.Value = GetStateFromSelection(samplesInSelection.SelectMany(s => s).Where(o => o.Name == HitSampleInfo.HIT_NORMAL), h => h.Bank == bankName);
-                }
-
-                // if there are no addition samples in the selection, do not touch the state of addition bank bindables.
-                // this is to reduce annoyance from the bank resetting if the user wants to e.g. remove the only addition sound on an object, but then add another addition sound
-                // while keeping the bank the same.
-                // note that deselecting all objects will still reset the addition bank selection to auto via `ResetTernaryStates()`. this may need to be reconsidered later.
-                if (samplesInSelection.SelectMany(s => s).Any(o => o.Name != HitSampleInfo.HIT_NORMAL))
-                {
-                    foreach ((string bankName, var bindable) in SelectionAdditionBankStates)
-                    {
-                        bindable.Value = GetStateFromSelection(samplesInSelection.SelectMany(s => s).Where(o => o.Name != HitSampleInfo.HIT_NORMAL),
-                            h => (bankName != HIT_BANK_AUTO && h.Bank == bankName && !h.EditorAutoBank) || (bankName == HIT_BANK_AUTO && h.EditorAutoBank));
-                    }
-                }
-            }
-        }
-
-        private void onSelectedItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
-        {
-            // Reset the ternary states when the selection is cleared.
-            if (SelectedItems.Count == 0)
-                Scheduler.AddOnce(resetTernaryStates);
-            else
-                Scheduler.AddOnce(UpdateTernaryStates);
-        }
-
-        private IEnumerable<IList<HitSampleInfo>> enumerateAllSamples(HitObject hitObject)
-        {
-            yield return hitObject.Samples;
-
-            if (hitObject is IHasRepeats withRepeats)
-            {
-                foreach (var node in withRepeats.NodeSamples)
-                    yield return node;
-            }
-        }
-
-        #endregion
-
-        #region Ternary state changes
-
-        /// <summary>
-        /// Sets the sample bank for all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <remarks>
-        /// Should be kept in sync with <see cref="SamplePointPiece.SampleEditPopover.setBank"/>.
-        /// </remarks>
-        /// <param name="bankName">The name of the sample bank.</param>
-        public void SetSampleBank(string bankName)
-        {
-            bool hasRelevantBank(HitObject hitObject)
-            {
-                bool result = hitObject.Samples.Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName);
-
-                if (hitObject is IHasRepeats hasRepeats)
-                {
-                    foreach (var node in hasRepeats.NodeSamples)
-                        result &= node.Where(o => o.Name == HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName);
-                }
-
-                return result;
-            }
-
-            if (SelectedItems.All(hasRelevantBank))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                if (hasRelevantBank(h))
-                    return;
-
-                h.Samples = h.Samples.Select(s => s.Name == HitSampleInfo.HIT_NORMAL || s.EditorAutoBank ? s.With(newBank: bankName) : s).ToList();
-
-                if (h is IHasRepeats hasRepeats)
-                {
-                    for (int i = 0; i < hasRepeats.NodeSamples.Count; ++i)
-                        hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Select(s => s.Name == HitSampleInfo.HIT_NORMAL || s.EditorAutoBank ? s.With(newBank: bankName) : s).ToList();
-                }
-            });
-        }
-
-        /// <summary>
-        /// Sets the sample addition bank for all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <remarks>
-        /// Should be kept in sync with <see cref="SamplePointPiece.SampleEditPopover.setAdditionBank"/>.
-        /// </remarks>
-        /// <param name="bankName">The name of the sample bank.</param>
-        public void SetSampleAdditionBank(string bankName)
-        {
-            bool hasRelevantBank(HitObject hitObject) =>
-                bankName == HIT_BANK_AUTO
-                    ? enumerateAllSamples(hitObject).SelectMany(o => o).Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.EditorAutoBank)
-                    : enumerateAllSamples(hitObject).SelectMany(o => o).Where(o => o.Name != HitSampleInfo.HIT_NORMAL).All(s => s.Bank == bankName && !s.EditorAutoBank);
-
-            if (SelectedItems.All(hasRelevantBank))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                if (hasRelevantBank(h))
-                    return;
-
-                string normalBank = h.Samples.FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank ?? HitSampleInfo.BANK_SOFT;
-                h.Samples = h.Samples.Select(s =>
-                                 s.Name != HitSampleInfo.HIT_NORMAL
-                                     ? bankName == HIT_BANK_AUTO ? s.With(newBank: normalBank, newEditorAutoBank: true) : s.With(newBank: bankName, newEditorAutoBank: false)
-                                     : s)
-                             .ToList();
-
-                if (h is IHasRepeats hasRepeats)
-                {
-                    for (int i = 0; i < hasRepeats.NodeSamples.Count; ++i)
-                    {
-                        normalBank = hasRepeats.NodeSamples[i].FirstOrDefault(s => s.Name == HitSampleInfo.HIT_NORMAL)?.Bank ?? HitSampleInfo.BANK_SOFT;
-                        hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Select(s =>
-                            s.Name != HitSampleInfo.HIT_NORMAL
-                                ? bankName == HIT_BANK_AUTO ? s.With(newBank: normalBank, newEditorAutoBank: true) : s.With(newBank: bankName, newEditorAutoBank: false)
-                                : s).ToList();
-                    }
-                }
-            });
-        }
-
-        private bool hasRelevantSample(HitObject hitObject, string sampleName)
-        {
-            bool result = hitObject.Samples.Any(s => s.Name == sampleName);
-
-            if (hitObject is IHasRepeats hasRepeats)
-            {
-                foreach (var node in hasRepeats.NodeSamples)
-                    result &= node.Any(s => s.Name == sampleName);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Adds a hit sample to all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <remarks>
-        /// Should be kept in sync with <see cref="SamplePointPiece.SampleEditPopover.addHitSample"/>.
-        /// </remarks>
-        /// <param name="sampleName">The name of the hit sample.</param>
-        public void AddHitSample(string sampleName)
-        {
-            if (SelectedItems.All(h => hasRelevantSample(h, sampleName)))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                string? forcedBank = null;
-                // if the selected object(s) only have normal samples, check whether the user has preselected a singular non-auto bank using `SelectionAdditionBankStates`.
-                // other scenarios are already handled by `CreateHitSampleInfo()`:
-                // - if the selected object(s) already have addition samples, `CreateHitSampleInfo()` will copy the bank from said addition samples.
-                // - if the selected object(s) do not have addition samples but the user has preselected auto bank, `CreateHitSampleInfo()` will use the auto bank anyway.
-                if (h.Samples.All(s => s.Name == HitSampleInfo.HIT_NORMAL))
-                    forcedBank = SelectionAdditionBankStates.SingleOrDefault(kv => kv.Value.Value == TernaryState.True).Key;
-
-                // Make sure there isn't already an existing sample
-                if (h.Samples.All(s => s.Name != sampleName))
-                {
-                    var hitSample = h.CreateHitSampleInfo(sampleName);
-
-                    if (forcedBank != null && forcedBank != HIT_BANK_AUTO)
-                        hitSample = hitSample.With(newBank: forcedBank, newEditorAutoBank: false);
-
-                    h.Samples.Add(hitSample);
-                }
-
-                if (h is IHasRepeats hasRepeats)
-                {
-                    foreach (var node in hasRepeats.NodeSamples)
-                    {
-                        if (node.Any(s => s.Name == sampleName))
-                            continue;
-
-                        var hitSample = h.CreateHitSampleInfo(sampleName);
-
-                        HitSampleInfo? existingAddition = node.FirstOrDefault(s => s.Name != HitSampleInfo.HIT_NORMAL);
-                        if (existingAddition != null)
-                            hitSample = hitSample.With(newBank: existingAddition.Bank, newEditorAutoBank: existingAddition.EditorAutoBank);
-
-                        node.Add(hitSample);
-                    }
-                }
-            });
-        }
-
-        /// <summary>
-        /// Removes a hit sample from all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="sampleName">The name of the hit sample.</param>
-        public void RemoveHitSample(string sampleName)
-        {
-            if (SelectedItems.All(h => !hasRelevantSample(h, sampleName)))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                h.SamplesBindable.RemoveAll(s => s.Name == sampleName);
-
-                if (h is IHasRepeats hasRepeats)
-                {
-                    for (int i = 0; i < hasRepeats.NodeSamples.Count; ++i)
-                        hasRepeats.NodeSamples[i] = hasRepeats.NodeSamples[i].Where(s => s.Name != sampleName).ToList();
-                }
-            });
-        }
-
-        /// <summary>
-        /// Set the new combo state of all selected <see cref="HitObject"/>s.
-        /// </summary>
-        /// <param name="state">Whether to set or unset.</param>
-        /// <exception cref="InvalidOperationException">Throws if any selected object doesn't implement <see cref="IHasComboInformation"/></exception>
-        public void SetNewCombo(bool state)
-        {
-            if (SelectedItems.OfType<IHasComboInformation>().All(h => h.NewCombo == state))
-                return;
-
-            EditorBeatmap.PerformOnSelection(h =>
-            {
-                var comboInfo = h as IHasComboInformation;
-
-                if (comboInfo == null || comboInfo.NewCombo == state) return;
-
-                comboInfo.NewCombo = state;
-            });
-        }
-
-        #endregion
-
         #region Context Menu
 
         /// <summary>
@@ -545,11 +49,11 @@ namespace osu.Game.Screens.Edit.Compose.Components
         /// <returns>The relevant menu items.</returns>
         protected override IEnumerable<MenuItem> GetContextMenuItemsForSelection(IEnumerable<SelectionBlueprint<HitObject>> selection)
         {
-            if (SelectedBlueprints.All(b => b.Item is IHasComboInformation))
+            if (SelectedBlueprints.All(b => b.Item is IHasComboInformation) && composer.SelectionNewComboState != null)
             {
                 yield return new TernaryStateToggleMenuItem(EditorStrings.NewCombo)
                 {
-                    State = { BindTarget = SelectionNewComboState },
+                    State = { BindTarget = composer.SelectionNewComboState },
                     Hotkey = new Hotkey(new KeyCombination(InputKey.Q))
                 };
             }
@@ -560,21 +64,21 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private IEnumerable<MenuItem> getSampleSubmenuItems()
         {
-            var whistle = SelectionSampleStates[HitSampleInfo.HIT_WHISTLE];
+            var whistle = composer.SelectionSampleStates[HitSampleInfo.HIT_WHISTLE];
             yield return new TernaryStateToggleMenuItem(whistle.Description)
             {
                 State = { BindTarget = whistle },
                 Hotkey = new Hotkey(new KeyCombination(InputKey.W))
             };
 
-            var finish = SelectionSampleStates[HitSampleInfo.HIT_FINISH];
+            var finish = composer.SelectionSampleStates[HitSampleInfo.HIT_FINISH];
             yield return new TernaryStateToggleMenuItem(finish.Description)
             {
                 State = { BindTarget = finish },
                 Hotkey = new Hotkey(new KeyCombination(InputKey.E))
             };
 
-            var clap = SelectionSampleStates[HitSampleInfo.HIT_CLAP];
+            var clap = composer.SelectionSampleStates[HitSampleInfo.HIT_CLAP];
             yield return new TernaryStateToggleMenuItem(clap.Description)
             {
                 State = { BindTarget = clap },
@@ -584,28 +88,28 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private IEnumerable<MenuItem> getBankSubmenuItems()
         {
-            var auto = SelectionBankStates[HIT_BANK_AUTO];
+            var auto = composer.SelectionBankStates[HitObjectComposer.HIT_BANK_AUTO];
             yield return new TernaryStateToggleMenuItem(auto.Description)
             {
                 State = { BindTarget = auto },
                 Hotkey = new Hotkey(new KeyCombination(InputKey.Shift, InputKey.Q))
             };
 
-            var normal = SelectionBankStates[HitSampleInfo.BANK_NORMAL];
+            var normal = composer.SelectionBankStates[HitSampleInfo.BANK_NORMAL];
             yield return new TernaryStateToggleMenuItem(normal.Description)
             {
                 State = { BindTarget = normal },
                 Hotkey = new Hotkey(new KeyCombination(InputKey.Shift, InputKey.W))
             };
 
-            var soft = SelectionBankStates[HitSampleInfo.BANK_SOFT];
+            var soft = composer.SelectionBankStates[HitSampleInfo.BANK_SOFT];
             yield return new TernaryStateToggleMenuItem(soft.Description)
             {
                 State = { BindTarget = soft },
                 Hotkey = new Hotkey(new KeyCombination(InputKey.Shift, InputKey.E))
             };
 
-            var drum = SelectionBankStates[HitSampleInfo.BANK_DRUM];
+            var drum = composer.SelectionBankStates[HitSampleInfo.BANK_DRUM];
             yield return new TernaryStateToggleMenuItem(drum.Description)
             {
                 State = { BindTarget = drum },
@@ -614,7 +118,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             yield return new OsuMenuItem(EditorStrings.AdditionBank)
             {
-                Items = SelectionAdditionBankStates.Select(kvp =>
+                Items = composer.SelectionAdditionBankStates.Select(kvp =>
                     new TernaryStateToggleMenuItem(kvp.Value.Description) { State = { BindTarget = kvp.Value } }).ToArray()
             };
         }

--- a/osu.Game/Screens/Edit/Compose/Components/PlacementStateManager.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/PlacementStateManager.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Game.Audio;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 
@@ -26,7 +27,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         [Resolved]
-        private EditorSelectionHandler? selectionHandler { get; set; }
+        private HitObjectComposer? composer { get; set; }
 
         [Resolved]
         private EditorBeatmap editorBeatmap { get; set; } = null!;
@@ -34,8 +35,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            if (selectionHandler != null)
-                selectionHandler.SelectionStateChanged += updatePlacementFromSelectionStateChange;
+            if (composer != null)
+                composer.SelectionStateChanged += updatePlacementFromSelectionStateChange;
 
             updatePlacementFromSelectionStateChange();
             CopyStateFromPreviousObject();
@@ -49,7 +50,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updatePlacementNewCombo()
         {
-            if (selectionHandler == null)
+            if (composer == null)
                 return;
 
             IHasComboInformation? comboStarter = null;
@@ -63,7 +64,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
                 if (comboStarter == null)
                 {
-                    withCombo.NewCombo = selectionHandler.SelectionNewComboState.Value == TernaryState.True;
+                    withCombo.NewCombo = composer.SelectionNewComboState?.Value == TernaryState.True;
                     comboStarter = withCombo;
                 }
                 else
@@ -76,18 +77,18 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void updatePlacementSamples()
         {
-            if (selectionHandler == null)
+            if (composer == null)
                 return;
 
             foreach (var hitObject in hitObjects)
             {
-                foreach (var kvp in selectionHandler.SelectionSampleStates)
+                foreach (var kvp in composer.SelectionSampleStates)
                     sampleChanged(hitObject, kvp.Key, kvp.Value.Value);
 
-                foreach (var kvp in selectionHandler.SelectionBankStates)
+                foreach (var kvp in composer.SelectionBankStates)
                     bankChanged(hitObject, kvp.Key, kvp.Value.Value);
 
-                foreach (var kvp in selectionHandler.SelectionAdditionBankStates)
+                foreach (var kvp in composer.SelectionAdditionBankStates)
                     additionBankChanged(hitObject, kvp.Key, kvp.Value.Value);
             }
         }
@@ -117,7 +118,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void bankChanged(HitObject hitObject, string bankName, TernaryState state)
         {
-            if (bankName == EditorSelectionHandler.HIT_BANK_AUTO)
+            if (bankName == HitObjectComposer.HIT_BANK_AUTO)
             {
                 automaticBankAssignment = state == TernaryState.True;
                 if (automaticBankAssignment)
@@ -134,7 +135,7 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         private void additionBankChanged(HitObject hitObject, string bankName, TernaryState state)
         {
-            if (bankName == EditorSelectionHandler.HIT_BANK_AUTO)
+            if (bankName == HitObjectComposer.HIT_BANK_AUTO)
             {
                 automaticAdditionBankAssignment = state == TernaryState.True;
                 if (automaticAdditionBankAssignment)
@@ -210,8 +211,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
         protected override void Dispose(bool isDisposing)
         {
-            if (selectionHandler != null)
-                selectionHandler.SelectionStateChanged -= updatePlacementFromSelectionStateChange;
+            if (composer != null)
+                composer.SelectionStateChanged -= updatePlacementFromSelectionStateChange;
 
             base.Dispose(isDisposing);
         }

--- a/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/SelectionHandler.cs
@@ -310,17 +310,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         }
 
         /// <summary>
-        /// Given a selection target and a function of truth, retrieve the correct ternary state for display.
-        /// </summary>
-        public static TernaryState GetStateFromSelection<TObject>(IEnumerable<TObject> selection, Func<TObject, bool> func)
-        {
-            if (selection.Any(func))
-                return selection.All(func) ? TernaryState.True : TernaryState.Indeterminate;
-
-            return TernaryState.False;
-        }
-
-        /// <summary>
         /// Called whenever the deletion of items has been requested.
         /// </summary>
         /// <param name="items">The items to be deleted.</param>

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -22,11 +22,13 @@ using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
+using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Skinning;
+using osu.Game.Utils;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -169,7 +171,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             if (firstAddition == null)
                 return null;
 
-            return firstAddition.EditorAutoBank ? EditorSelectionHandler.HIT_BANK_AUTO : firstAddition.Bank;
+            return firstAddition.EditorAutoBank ? HitObjectComposer.HIT_BANK_AUTO : firstAddition.Bank;
         }
 
         public static int GetVolumeValue(ICollection<HitSampleInfo> samples)
@@ -477,7 +479,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
 
             /// <remarks>
-            /// Should be kept in sync with <see cref="EditorSelectionHandler.SetSampleBank"/>.
+            /// Should be kept in sync with <see cref="HitObjectComposer{T}.SetSampleBank"/>.
             /// </remarks>
             private void setBank(string newBank)
             {
@@ -493,7 +495,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
 
             /// <remarks>
-            /// Should be kept in sync with <see cref="EditorSelectionHandler.SetSampleAdditionBank"/>.
+            /// Should be kept in sync with <see cref="HitObjectComposer{T}.SetSampleAdditionBank"/>.
             /// </remarks>
             private void setAdditionBank(string newBank)
             {
@@ -507,7 +509,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                             continue;
 
                         // Addition samples with bank set to auto should inherit the bank of the normal sample
-                        if (newBank == EditorSelectionHandler.HIT_BANK_AUTO)
+                        if (newBank == HitObjectComposer.HIT_BANK_AUTO)
                         {
                             relevantSamples[i] = relevantSamples[i].With(newBank: normalBank, newEditorAutoBank: true);
                         }
@@ -576,14 +578,14 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     selectionSampleStates[sampleName] = bindable;
                 }
 
-                banks.AddRange(HitSampleInfo.ALL_BANKS.Prepend(EditorSelectionHandler.HIT_BANK_AUTO));
+                banks.AddRange(HitSampleInfo.ALL_BANKS.Prepend(HitObjectComposer.HIT_BANK_AUTO));
             }
 
             private void updateTernaryStates()
             {
                 foreach ((string sampleName, var bindable) in selectionSampleStates)
                 {
-                    bindable.Value = SelectionHandler<HitObject>.GetStateFromSelection(GetRelevantSamples(relevantObjects), h => h.samples.Any(s => s.Name == sampleName));
+                    bindable.Value = GetRelevantSamples(relevantObjects).GetTernaryState(h => h.samples.Any(s => s.Name == sampleName));
                 }
             }
 
@@ -603,7 +605,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             }
 
             /// <remarks>
-            /// Should be kept in sync with <see cref="EditorSelectionHandler.AddHitSample"/>.
+            /// Should be kept in sync with <see cref="HitObjectComposer{T}.AddHitSample"/>.
             /// </remarks>
             private void addHitSample(string sampleName)
             {
@@ -653,7 +655,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     if (string.IsNullOrEmpty(newBank))
                         return true;
 
-                    if (e.ShiftPressed && newBank != EditorSelectionHandler.HIT_BANK_AUTO)
+                    if (e.ShiftPressed && newBank != HitObjectComposer.HIT_BANK_AUTO)
                     {
                         setBank(newBank);
                         updatePrimaryBankState();

--- a/osu.Game/Utils/TernaryStateUtils.cs
+++ b/osu.Game/Utils/TernaryStateUtils.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Game.Graphics.UserInterface;
+
+namespace osu.Game.Utils
+{
+    public static class TernaryStateUtils
+    {
+        /// <summary>
+        /// Given a selection target and a function of truth, retrieve the correct ternary state for display.
+        /// </summary>
+        public static TernaryState GetTernaryState<T>(this IEnumerable<T> selection, Func<T, bool> func)
+        {
+            if (selection.Any(func))
+                return selection.All(func) ? TernaryState.True : TernaryState.Indeterminate;
+
+            return TernaryState.False;
+        }
+    }
+}


### PR DESCRIPTION
RFC.

This is an attempt to address https://github.com/ppy/osu/pull/38579#discussion_r3774170828 via executing on the sketch of a plan described in https://github.com/ppy/osu/pull/38579#discussion_r3774213455.

I apologise in advance for the diffstat. The reason why it's so large is that this PR lifts a huge chunk of `EditorSelectionHandler` up to `HitObjectComposer` (or, to be more precise, a new partial file of that class).

Initially I did not want to lift *all* of that logic out; I wanted to lift out just the definitions of the bindables to composer level, set up downwards bindings to `EditorSelectionHandler`, and thus keep the logic updating the *value* of the bindables in `EditorSelectionHandler`. This breaks in practice.

The reason why it breaks in practice is that even on master, the compose screen has *two* `EditorSelectionHandler`s present on the compose screen. One is in the actual `HitObjectComposer`, and the other is in the timeline. Of note, `HitObjectComposer` is exposed to the timeline via DI:

https://github.com/ppy/osu/blob/fc39aa5cecd3d87576107506fe8036fc891111bc/osu.Game/Screens/Edit/Compose/ComposeScreen.cs#L55-L57

This means that on master the `EditorSelectionHandler` from the timeline has its own set of ternary toggles, and even will update them to match selection state, but *nothing reads that state at all*. When moving the bindables out to `HitObjectComposer`, this breaks, because now the root bindables are bound to *two* `EditorSelectionHandler`s that try to update their state, and they end up fighting each other in a way that breaks sample buttons specifically.

Therefore, the bindables just have to move out of `EditorSelectionHandler` completely to ensure there is only one set of them around. You could argue that the logic could have stayed in `EditorSelectionHandler` relegated to a subclass or dependent on some flag, but I'm not sure that feels much better to me.

Of note, I have a [follow-up commit](https://github.com/bdach/osu/commit/46572faac883c8eac89bac1974993b44bc2de8fa) to this that can supersede https://github.com/ppy/osu/pull/37939 in a pretty clean way. I am not including it here for two reasons: one is keeping the already-obscene diffstat as low as possible, and the other is that my commit *also* completely removes the new combo button from taiko and mania, and as written that will break hotkeys. I have a plan to address this via other changes I have queued that introduce rebinding ruleset-specific keys in editor.