### PR TITLE
Made so speed change mods shows correct time during breaks.

### DIFF
--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
@@ -3,16 +3,22 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osu.Game.Beatmaps.Timing;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.Break;
 using osuTK.Graphics;
 
 namespace osu.Game.Tests.Visual.Gameplay
@@ -121,6 +127,41 @@ namespace osu.Game.Tests.Visual.Gameplay
 
             seekAndAssertBreak("seek to break intro time", -100, true);
             seekAndAssertBreak("seek to break intro time", 0, false);
+        }
+
+        /// <remarks>
+        /// The countdown is displayed in real time, so a 10 second break should read as 5 seconds under 2x rate.
+        /// </remarks>
+        [TestCase(1, "10")]
+        [TestCase(2, "5")]
+        [TestCase(1.5, "7")]
+        [TestCase(0.5, "20")]
+        public void TestRemainingTimeAdjustedForRateChangingMods(double rate, string expectedInitialCountdown)
+        {
+            var testBreak = new BreakPeriod(1000, 11000);
+
+            setClock(true);
+            setRateAdjustMod(rate);
+            loadBreaksStep("10s break", new[] { testBreak });
+
+            seekAndAssertBreak("seek to break start", testBreak.StartTime, true);
+            AddUntilStep("countdown shows remaining real time", () => remainingTimeText, () => Is.EqualTo(expectedInitialCountdown));
+        }
+
+        private string remainingTimeText => breakOverlay.ChildrenOfType<RemainingTimeCounter>().Single()
+                                                        .ChildrenOfType<OsuSpriteText>().Single().Text.ToString();
+
+        private void setRateAdjustMod(double rate)
+        {
+            AddStep($"set rate to {rate}x", () =>
+            {
+                if (rate == 1)
+                    SelectedMods.Value = Array.Empty<Mod>();
+                else if (rate > 1)
+                    SelectedMods.Value = new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = rate } } };
+                else
+                    SelectedMods.Value = new Mod[] { new OsuModHalfTime { SpeedChange = { Value = rate } } };
+            });
         }
 
         private void addShowBreakStep(double seconds)

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Tests.Visual.Gameplay
     [TestFixture]
     public partial class TestSceneBreakTracker : OsuTestScene
     {
-        private readonly BreakOverlay breakOverlay;
+        private BreakOverlay breakOverlay;
 
         private readonly TestBreakTracker breakTracker;
 
@@ -48,11 +48,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     RelativeSizeAxes = Axes.Both,
                 },
                 breakTracker = new TestBreakTracker(),
-                breakOverlay = new BreakOverlay(new ScoreProcessor(new OsuRuleset()))
-                {
-                    ProcessCustomClock = false,
-                    BreakTracker = breakTracker,
-                },
+                breakOverlay = createBreakOverlay(),
                 new LetterboxOverlay
                 {
                     ProcessCustomClock = false,
@@ -172,28 +168,20 @@ namespace osu.Game.Tests.Visual.Gameplay
         }
 
         /// <remarks>
-        /// Adaptive speed's rate is driven by how the player is performing, so it can only be assumed to hold for the
-        /// remainder of the break. The countdown should follow it as it changes.
+        /// Adaptive speed's rate is driven by how the player is performing and can change at any point, so its breaks
+        /// are deliberately left counting down in beatmap time.
         /// </remarks>
         [Test]
-        public void TestRemainingTimeAdjustedForAdaptiveSpeed()
+        public void TestRemainingTimeUnaffectedByAdaptiveSpeed()
         {
             var testBreak = new BreakPeriod(1000, 11000);
-            var adaptiveSpeed = new ModAdaptiveSpeed();
 
             setClock(true);
-            AddStep("apply adaptive speed at 2x", () =>
-            {
-                adaptiveSpeed.SpeedChange.Value = 2;
-                SelectedMods.Value = new Mod[] { adaptiveSpeed };
-            });
+            setMods("adaptive speed at 2x", () => new Mod[] { new ModAdaptiveSpeed { InitialRate = { Value = 2 } } });
             loadBreaksStep("10s break", new[] { testBreak });
 
             seekAndAssertBreak("seek to break start", testBreak.StartTime, true);
-            assertRemainingTime("countdown uses current rate", "5");
-
-            AddStep("slow down to 0.5x", () => adaptiveSpeed.SpeedChange.Value = 0.5);
-            assertRemainingTime("countdown follows the rate change", "20");
+            assertRemainingTime("countdown is left in beatmap time", "10");
         }
 
         private string remainingTimeText => breakOverlay.ChildrenOfType<RemainingTimeCounter>().Single()
@@ -202,22 +190,42 @@ namespace osu.Game.Tests.Visual.Gameplay
         private void assertRemainingTime(string description, string expected)
             => AddUntilStep(description, () => remainingTimeText, () => Is.EqualTo(expected));
 
+        private BreakOverlay createBreakOverlay(params Mod[] mods) => new BreakOverlay(new ScoreProcessor(new OsuRuleset()))
+        {
+            ProcessCustomClock = false,
+            BreakTracker = breakTracker,
+            Mods = mods,
+        };
+
+        /// <remarks>
+        /// The overlay reads its mods once on construction, mirroring how <see cref="Player"/> hands it the mods
+        /// gameplay is running with, so it has to be recreated to change them.
+        /// </remarks>
+        private void setMods(string description, Func<Mod[]> createMods)
+        {
+            AddStep($"set mods to {description}", () =>
+            {
+                Remove(breakOverlay, true);
+                Add(breakOverlay = createBreakOverlay(createMods()));
+            });
+        }
+
         private void setRateAdjustMod(double rate)
         {
-            AddStep($"set rate to {rate}x", () =>
+            setMods($"{rate}x rate adjust", () =>
             {
                 if (rate == 1)
-                    SelectedMods.Value = Array.Empty<Mod>();
-                else if (rate > 1)
-                    SelectedMods.Value = new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = rate } } };
-                else
-                    SelectedMods.Value = new Mod[] { new OsuModHalfTime { SpeedChange = { Value = rate } } };
+                    return Array.Empty<Mod>();
+
+                return rate > 1
+                    ? new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = rate } } }
+                    : new Mod[] { new OsuModHalfTime { SpeedChange = { Value = rate } } };
             });
         }
 
         private void setTimeRampMod(double initialRate, double finalRate)
         {
-            AddStep($"set rate to ramp from {initialRate}x to {finalRate}x", () =>
+            setMods($"ramp from {initialRate}x to {finalRate}x", () =>
             {
                 ModTimeRamp mod = finalRate > initialRate
                     ? new ModWindUp { FinalRate = { Value = finalRate }, InitialRate = { Value = initialRate } }
@@ -234,7 +242,7 @@ namespace osu.Game.Tests.Visual.Gameplay
                     }
                 });
 
-                SelectedMods.Value = new Mod[] { mod };
+                return new Mod[] { mod };
             });
         }
 

--- a/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
+++ b/osu.Game.Tests/Visual/Gameplay/TestSceneBreakTracker.cs
@@ -11,11 +11,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
+using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Screens.Play;
 using osu.Game.Screens.Play.Break;
@@ -145,11 +147,60 @@ namespace osu.Game.Tests.Visual.Gameplay
             loadBreaksStep("10s break", new[] { testBreak });
 
             seekAndAssertBreak("seek to break start", testBreak.StartTime, true);
-            AddUntilStep("countdown shows remaining real time", () => remainingTimeText, () => Is.EqualTo(expectedInitialCountdown));
+            assertRemainingTime("countdown shows remaining real time", expectedInitialCountdown);
+        }
+
+        /// <remarks>
+        /// Wind up and wind down change their rate as the beatmap progresses, so the countdown has to follow whichever
+        /// rate is in effect at the point in time it is being displayed at.
+        /// </remarks>
+        [TestCase(1, 2, "10", "4")]
+        [TestCase(1, 0.5, "11", "7")]
+        public void TestRemainingTimeAdjustedForTimeRampMods(double initialRate, double finalRate, string countdownAtStart, string countdownAtMiddle)
+        {
+            var testBreak = new BreakPeriod(1000, 11000);
+
+            setClock(true);
+            setTimeRampMod(initialRate, finalRate);
+            loadBreaksStep("10s break", new[] { testBreak });
+
+            seekAndAssertBreak("seek to break start", testBreak.StartTime, true);
+            assertRemainingTime("countdown uses rate at break start", countdownAtStart);
+
+            seekAndAssertBreak("seek to break middle", 6000, true);
+            assertRemainingTime("countdown uses ramped rate at break middle", countdownAtMiddle);
+        }
+
+        /// <remarks>
+        /// Adaptive speed's rate is driven by how the player is performing, so it can only be assumed to hold for the
+        /// remainder of the break. The countdown should follow it as it changes.
+        /// </remarks>
+        [Test]
+        public void TestRemainingTimeAdjustedForAdaptiveSpeed()
+        {
+            var testBreak = new BreakPeriod(1000, 11000);
+            var adaptiveSpeed = new ModAdaptiveSpeed();
+
+            setClock(true);
+            AddStep("apply adaptive speed at 2x", () =>
+            {
+                adaptiveSpeed.SpeedChange.Value = 2;
+                SelectedMods.Value = new Mod[] { adaptiveSpeed };
+            });
+            loadBreaksStep("10s break", new[] { testBreak });
+
+            seekAndAssertBreak("seek to break start", testBreak.StartTime, true);
+            assertRemainingTime("countdown uses current rate", "5");
+
+            AddStep("slow down to 0.5x", () => adaptiveSpeed.SpeedChange.Value = 0.5);
+            assertRemainingTime("countdown follows the rate change", "20");
         }
 
         private string remainingTimeText => breakOverlay.ChildrenOfType<RemainingTimeCounter>().Single()
                                                         .ChildrenOfType<OsuSpriteText>().Single().Text.ToString();
+
+        private void assertRemainingTime(string description, string expected)
+            => AddUntilStep(description, () => remainingTimeText, () => Is.EqualTo(expected));
 
         private void setRateAdjustMod(double rate)
         {
@@ -161,6 +212,29 @@ namespace osu.Game.Tests.Visual.Gameplay
                     SelectedMods.Value = new Mod[] { new OsuModDoubleTime { SpeedChange = { Value = rate } } };
                 else
                     SelectedMods.Value = new Mod[] { new OsuModHalfTime { SpeedChange = { Value = rate } } };
+            });
+        }
+
+        private void setTimeRampMod(double initialRate, double finalRate)
+        {
+            AddStep($"set rate to ramp from {initialRate}x to {finalRate}x", () =>
+            {
+                ModTimeRamp mod = finalRate > initialRate
+                    ? new ModWindUp { FinalRate = { Value = finalRate }, InitialRate = { Value = initialRate } }
+                    : new ModWindDown { FinalRate = { Value = finalRate }, InitialRate = { Value = initialRate } };
+
+                // the ramp is defined relative to the first and last hitobjects, so it needs a beatmap to apply to
+                // before it can report a rate. this one reaches its final rate at 15,000ms.
+                mod.ApplyToBeatmap(new Beatmap
+                {
+                    HitObjects =
+                    {
+                        new HitCircle { StartTime = 0 },
+                        new HitCircle { StartTime = 20000 },
+                    }
+                });
+
+                SelectedMods.Value = new Mod[] { mod };
             });
         }
 

--- a/osu.Game/Screens/Play/Break/RemainingTimeCounter.cs
+++ b/osu.Game/Screens/Play/Break/RemainingTimeCounter.cs
@@ -3,15 +3,38 @@
 
 using System;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics.Containers;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 
 namespace osu.Game.Screens.Play.Break
 {
-    public partial class RemainingTimeCounter : Counter
+    public partial class RemainingTimeCounter : CompositeDrawable
     {
         private readonly OsuSpriteText counter;
+
+        private double remainingTime;
+        private int displayedSeconds = -1;
+
+        /// <summary>
+        /// The amount of time left to display, in milliseconds.
+        /// </summary>
+        public double RemainingTime
+        {
+            get => remainingTime;
+            set
+            {
+                remainingTime = value;
+
+                int seconds = (int)Math.Ceiling(value / 1000);
+
+                if (seconds == displayedSeconds)
+                    return;
+
+                displayedSeconds = seconds;
+                counter.Text = seconds.ToString();
+            }
+        }
 
         public RemainingTimeCounter()
         {
@@ -23,7 +46,5 @@ namespace osu.Game.Screens.Play.Break
                 Font = OsuFont.Numeric.With(size: 33),
             };
         }
-
-        protected override void OnCountChanged(double count) => counter.Text = ((int)Math.Ceiling(count / 1000)).ToString();
     }
 }

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -39,6 +38,15 @@ namespace osu.Game.Screens.Play
 
         public required BreakTracker BreakTracker { get; init; }
 
+        /// <summary>
+        /// The mods in effect for this gameplay session.
+        /// </summary>
+        /// <remarks>
+        /// Must be the mod instances gameplay is running with rather than the selected ones, as mods which vary their
+        /// rate only track that rate on the former.
+        /// </remarks>
+        public required IReadOnlyList<Mod> Mods { get; init; }
+
         private readonly Container remainingTimeAdjustmentBox;
         private readonly Container remainingTimeBox;
         private readonly RemainingTimeCounter remainingTimeCounter;
@@ -56,9 +64,6 @@ namespace osu.Game.Screens.Play
         /// down to zero while the overlay is still fading out.
         /// </remarks>
         private double? breakEndTime;
-
-        [Resolved]
-        private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         public BreakOverlay(ScoreProcessor scoreProcessor)
         {
@@ -151,9 +156,9 @@ namespace osu.Game.Screens.Play
         /// active mods.
         /// </summary>
         /// <remarks>
-        /// Mods which vary their rate over the course of a beatmap are sampled at the current point in time rather than
-        /// projected forward. For wind up / wind down the rate drifts slowly enough over a single break for this to be
-        /// imperceptible, while adaptive speed is driven by the player's input and cannot be predicted at all.
+        /// Wind up / wind down are sampled at the current point in time rather than projected forward over the break.
+        /// Their rate drifts slowly enough across a single break for the difference to be well under the one second
+        /// granularity the countdown is displayed at.
         /// </remarks>
         private double gameplayRate
         {
@@ -161,13 +166,14 @@ namespace osu.Game.Screens.Play
             {
                 double rate = 1;
 
-                foreach (var mod in mods.Value.OfType<IApplicableToRate>())
+                foreach (var mod in Mods.OfType<IApplicableToRate>())
                 {
-                    // adaptive speed's `ApplyToRate()` can only report the rate gameplay started at,
-                    // so read the rate it is actually running at instead.
-                    rate = mod is ModAdaptiveSpeed adaptiveSpeed
-                        ? rate * adaptiveSpeed.SpeedChange.Value
-                        : mod.ApplyToRate(Time.Current, rate);
+                    // adaptive speed's rate is driven by how the player is performing and can change at any point,
+                    // so there is nothing meaningful to count down towards. its breaks are left in beatmap time.
+                    if (mod is ModAdaptiveSpeed)
+                        continue;
+
+                    rate = mod.ApplyToRate(Time.Current, rate);
                 }
 
                 return rate;

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -48,6 +48,15 @@ namespace osu.Game.Screens.Play
 
         private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
 
+        /// <summary>
+        /// The beatmap time at which the current break finishes fading out.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately retained after <see cref="currentPeriod"/> elapses, so that the countdown can keep ticking
+        /// down to zero while the overlay is still fading out.
+        /// </remarks>
+        private double? breakEndTime;
+
         [Resolved]
         private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
@@ -138,14 +147,32 @@ namespace osu.Game.Screens.Play
             currentPeriod.Value == null ? 0 : (float)Math.Max(0, (currentPeriod.Value.Value.End - Time.Current - BREAK_FADE_DURATION) / currentPeriod.Value.Value.Duration);
 
         /// <summary>
-        /// How fast beatmap time progresses relative to real time, as dictated by the active mods.
+        /// How fast beatmap time is progressing relative to real time at the current point in time, as dictated by the
+        /// active mods.
         /// </summary>
         /// <remarks>
-        /// Only mods applying a constant rate change (ie. double time / nightcore / half time / daycore) are considered.
-        /// Mods which vary the rate over the course of a beatmap (ie. wind up / wind down / adaptive speed) are not
-        /// handled yet, and will fall back to a rate of 1.
+        /// Mods which vary their rate over the course of a beatmap are sampled at the current point in time rather than
+        /// projected forward. For wind up / wind down the rate drifts slowly enough over a single break for this to be
+        /// imperceptible, while adaptive speed is driven by the player's input and cannot be predicted at all.
         /// </remarks>
-        private double gameplayRate => mods.Value.OfType<ModRateAdjust>().Aggregate(1.0, (rate, mod) => mod.ApplyToRate(0, rate));
+        private double gameplayRate
+        {
+            get
+            {
+                double rate = 1;
+
+                foreach (var mod in mods.Value.OfType<IApplicableToRate>())
+                {
+                    // adaptive speed's `ApplyToRate()` can only report the rate gameplay started at,
+                    // so read the rate it is actually running at instead.
+                    rate = mod is ModAdaptiveSpeed adaptiveSpeed
+                        ? rate * adaptiveSpeed.SpeedChange.Value
+                        : mod.ApplyToRate(Time.Current, rate);
+                }
+
+                return rate;
+            }
+        }
 
         protected override void Update()
         {
@@ -153,6 +180,12 @@ namespace osu.Game.Screens.Play
 
             remainingTimeBox.Width = (float)Interpolation.DampContinuously(remainingTimeBox.Width, remainingTimeForCurrentPeriod, 40, Math.Abs(Time.Elapsed));
             remainingTimeBox.Height = Math.Min(8, remainingTimeBox.DrawWidth);
+
+            // the countdown is displayed in real time rather than beatmap time, so that it lines up with how long the
+            // break will actually last for the user when rate-changing mods are active. it is updated every frame
+            // rather than transformed, as the rate can change over the course of a break.
+            if (breakEndTime != null)
+                remainingTimeCounter.RemainingTime = Math.Max(0, breakEndTime.Value - Time.Current) / gameplayRate;
         }
 
         private void updateDisplay(ValueChangedEvent<Period?> period)
@@ -164,6 +197,8 @@ namespace osu.Game.Screens.Play
 
             var b = period.NewValue.Value;
 
+            breakEndTime = b.End + BREAK_FADE_DURATION;
+
             using (BeginAbsoluteSequence(b.Start))
             {
                 fadeContainer.FadeIn(BREAK_FADE_DURATION);
@@ -173,12 +208,6 @@ namespace osu.Game.Screens.Play
                     .ResizeWidthTo(remaining_time_container_max_size, BREAK_FADE_DURATION, Easing.OutQuint)
                     .Delay(b.Duration)
                     .ResizeWidthTo(0);
-
-                double countdownDuration = b.Duration + BREAK_FADE_DURATION;
-
-                // the countdown is displayed in real time rather than beatmap time, so that it lines up with how long
-                // the break will actually last for the user when rate-changing mods are active.
-                remainingTimeCounter.CountTo(countdownDuration / gameplayRate).CountTo(0, countdownDuration);
 
                 remainingTimeCounter.MoveToX(-50)
                                     .MoveToX(0, BREAK_FADE_DURATION, Easing.OutQuint);

--- a/osu.Game/Screens/Play/BreakOverlay.cs
+++ b/osu.Game/Screens/Play/BreakOverlay.cs
@@ -2,6 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -12,6 +15,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps.Timing;
 using osu.Game.Graphics;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.Break;
@@ -43,6 +47,9 @@ namespace osu.Game.Screens.Play
         private readonly BreakInfo info;
 
         private readonly IBindable<Period?> currentPeriod = new Bindable<Period?>();
+
+        [Resolved]
+        private Bindable<IReadOnlyList<Mod>> mods { get; set; } = null!;
 
         public BreakOverlay(ScoreProcessor scoreProcessor)
         {
@@ -130,6 +137,16 @@ namespace osu.Game.Screens.Play
         private float remainingTimeForCurrentPeriod =>
             currentPeriod.Value == null ? 0 : (float)Math.Max(0, (currentPeriod.Value.Value.End - Time.Current - BREAK_FADE_DURATION) / currentPeriod.Value.Value.Duration);
 
+        /// <summary>
+        /// How fast beatmap time progresses relative to real time, as dictated by the active mods.
+        /// </summary>
+        /// <remarks>
+        /// Only mods applying a constant rate change (ie. double time / nightcore / half time / daycore) are considered.
+        /// Mods which vary the rate over the course of a beatmap (ie. wind up / wind down / adaptive speed) are not
+        /// handled yet, and will fall back to a rate of 1.
+        /// </remarks>
+        private double gameplayRate => mods.Value.OfType<ModRateAdjust>().Aggregate(1.0, (rate, mod) => mod.ApplyToRate(0, rate));
+
         protected override void Update()
         {
             base.Update();
@@ -157,7 +174,11 @@ namespace osu.Game.Screens.Play
                     .Delay(b.Duration)
                     .ResizeWidthTo(0);
 
-                remainingTimeCounter.CountTo(b.Duration + BREAK_FADE_DURATION).CountTo(0, b.Duration + BREAK_FADE_DURATION);
+                double countdownDuration = b.Duration + BREAK_FADE_DURATION;
+
+                // the countdown is displayed in real time rather than beatmap time, so that it lines up with how long
+                // the break will actually last for the user when rate-changing mods are active.
+                remainingTimeCounter.CountTo(countdownDuration / gameplayRate).CountTo(0, countdownDuration);
 
                 remainingTimeCounter.MoveToX(-50)
                                     .MoveToX(0, BREAK_FADE_DURATION, Easing.OutQuint);

--- a/osu.Game/Screens/Play/Player.cs
+++ b/osu.Game/Screens/Play/Player.cs
@@ -504,6 +504,7 @@ namespace osu.Game.Screens.Play
                         Clock = DrawableRuleset.FrameStableClock,
                         ProcessCustomClock = false,
                         BreakTracker = breakTracker,
+                        Mods = GameplayState.Mods,
                     },
                     // display the cursor above some HUD elements.
                     DrawableRuleset.Cursor?.CreateProxy() ?? new Container(),


### PR DESCRIPTION
Previously it showed the default time but sped up. Now it adjusts with mods but i couldn't figure out how to do it with Adaptive Speed mod dt/nc ht/dc wu/wd works