### PR TITLE
Use Inter font in chat for better legibility

### DIFF
--- a/osu.Game/Graphics/UserInterface/OsuTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/OsuTextBox.cs
@@ -279,8 +279,10 @@ namespace osu.Game.Graphics.UserInterface
         protected override Drawable GetDrawableCharacter(char c) => new FallingDownContainer
         {
             AutoSizeAxes = Axes.Both,
-            Child = new OsuSpriteText { Text = c.ToString(), Font = OsuFont.GetFont(size: FontSize) },
+            Child = new OsuSpriteText { Text = c.ToString(), Font = Font },
         };
+
+        protected virtual FontUsage Font => OsuFont.GetFont(size: FontSize);
 
         protected override Caret CreateCaret() => caret = new OsuCaret
         {

--- a/osu.Game/Online/Chat/StandAloneChatDisplay.cs
+++ b/osu.Game/Online/Chat/StandAloneChatDisplay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Graphics;
@@ -131,6 +132,8 @@ namespace osu.Game.Online.Chat
         {
             public Action? Focus;
             public Action? FocusLost;
+
+            protected override FontUsage Font => OsuFont.Inter.With(size: FontSize);
 
             protected override bool OnKeyDown(KeyDownEvent e)
             {

--- a/osu.Game/Overlays/Chat/ChatLine.cs
+++ b/osu.Game/Overlays/Chat/ChatLine.cs
@@ -258,7 +258,7 @@ namespace osu.Game.Overlays.Chat
         private void styleMessageContent(SpriteText text)
         {
             text.Shadow = false;
-            text.Font = text.Font.With(size: font_size, italics: Message.IsAction, weight: isMention ? FontWeight.SemiBold : FontWeight.Medium);
+            text.Font = OsuFont.Inter.With(size: font_size, italics: Message.IsAction, weight: isMention ? FontWeight.SemiBold : FontWeight.Regular);
 
             Color4 messageColour = colourProvider?.Content1 ?? Colour4.White;
 

--- a/osu.Game/Overlays/Chat/ChatTextBox.cs
+++ b/osu.Game/Overlays/Chat/ChatTextBox.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Bindables;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Resources.Localisation.Web;
 
@@ -14,6 +16,8 @@ namespace osu.Game.Overlays.Chat
         public override bool HandleLeftRightArrows => !ShowSearch.Value;
 
         protected override bool ClearTextOnBackKey => false;
+
+        protected override FontUsage Font => OsuFont.Inter.With(size: FontSize);
 
         protected override void LoadComplete()
         {


### PR DESCRIPTION
Coming from https://github.com/ppy/osu/discussions/35230#discussioncomment-18048776. Should have never been torus in the first place. Areas where there is long-form text content, we generally prefer using a readable font.

Unsure whether it should also be applied to username/timestamp. web doesn't do this for username, so I've skipped for now.

| Before | After |
| :---: | :---: |
| <img width="1009" height="368" alt="osu! 2026-08-17 at 09 10 30" src="https://github.com/user-attachments/assets/57bbb033-f332-43eb-81df-f1e10a1de590" /> | <img width="1009" height="368" alt="osu! 2026-08-17 at 09 09 48" src="https://github.com/user-attachments/assets/8f2c2d70-2dee-42fc-817c-dc86e0ba305a" /> |