### PR TITLE
Allow reporting users in ranked play

### DIFF
--- a/osu.Game.Tests/Visual/RankedPlay/TestSceneUserReport.cs
+++ b/osu.Game.Tests/Visual/RankedPlay/TestSceneUserReport.cs
@@ -1,0 +1,84 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Testing;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays.Profile;
+using osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay;
+using osuTK.Input;
+
+namespace osu.Game.Tests.Visual.RankedPlay
+{
+    public partial class TestSceneUserReport : RankedPlayTestScene
+    {
+        private RankedPlayScreen screen = null!;
+        private ReportUserDialog dialog = null!;
+
+        private UserReportRequest pendingRequest = null!;
+
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        public override void SetUpSteps()
+        {
+            base.SetUpSteps();
+
+            AddStep("setup request handling", () =>
+            {
+                dummyAPI.HandleRequest += request =>
+                {
+                    if (request is UserReportRequest chatReportRequest)
+                    {
+                        pendingRequest = chatReportRequest;
+                        return true;
+                    }
+
+                    return false;
+                };
+            });
+
+            AddStep("join room", () => JoinRoom(CreateDefaultRoom(MatchType.RankedPlay)));
+            WaitForJoined();
+
+            AddStep("add other user", () => MultiplayerClient.AddUser(new MultiplayerRoomUser(2)));
+
+            AddStep("load screen", () => LoadScreen(screen = new RankedPlayScreen(MultiplayerClient.ClientRoom!)));
+            AddUntilStep("screen loaded", () => screen.IsLoaded);
+            AddStep("set pick state", () => MultiplayerClient.RankedPlayChangeStage(RankedPlayStage.CardPlay, state => state.ActiveUserId = API.LocalUser.Value.OnlineID).WaitSafely());
+
+            AddStep("open menu", () => this.ChildrenOfType<HamburgerMenu>().Single().TriggerClick());
+            AddStep("select report option", () =>
+            {
+                var text = this.ChildrenOfType<OsuPopover>().Single().ChildrenOfType<OsuSpriteText>().Single(t => t.Text == "Report opponent");
+                InputManager.MoveMouseTo(text);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("report dialog is present", () => (dialog = this.ChildrenOfType<ReportUserDialog>().Single()).IsPresent, () => Is.True);
+        }
+
+        [Test]
+        public void TestSuccess()
+        {
+            AddStep("input reason", () => dialog.ChildrenOfType<OsuTextBox>().First().Text = "reason");
+            AddStep("send report", () =>
+            {
+                var btn = this.ChildrenOfType<ReportUserDialog.SubmitButton>().Single();
+                InputManager.MoveMouseTo(btn);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddWaitStep("wait", 5);
+            AddStep("complete request", () => pendingRequest.TriggerSuccess());
+            AddUntilStep("wait for dialog to hide", () => this.ChildrenOfType<ReportUserDialog>().Any(), () => Is.False);
+        }
+    }
+}

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/HamburgerMenu.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/HamburgerMenu.cs
@@ -22,18 +22,22 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class HamburgerMenu : IconButton, IHasPopover
     {
+        public Action? ReportRequested { get; init; }
+
         public HamburgerMenu()
         {
             Icon = FontAwesome.Solid.Bars;
             Action = this.ShowPopover;
         }
 
-        public Framework.Graphics.UserInterface.Popover GetPopover() => new Popover();
+        public Framework.Graphics.UserInterface.Popover GetPopover() => new Popover { ReportRequested = ReportRequested };
 
         private partial class Popover : OsuPopover
         {
             [Resolved]
             private RankedPlayScreen? rankedPlayScreen { get; set; }
+
+            public Action? ReportRequested { get; init; }
 
             private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
             private FillFlowContainer buttonFlow = null!;
@@ -51,6 +55,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                 };
 
                 addButton(rankedPlayScreen?.ActiveSubScreen is not EndedScreen ? "Give up" : CommonStrings.Exit, FontAwesome.Solid.SignOutAlt, () => rankedPlayScreen?.Exit());
+
+                if (ReportRequested != null)
+                    addButton("Report opponent", FontAwesome.Solid.ExclamationTriangle, () => ReportRequested.Invoke());
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/HamburgerMenu.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/HamburgerMenu.cs
@@ -22,7 +22,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
 {
     public partial class HamburgerMenu : IconButton, IHasPopover
     {
-        public Action? ReportRequested { get; init; }
+        public required Action ReportRequested { get; init; }
 
         public HamburgerMenu()
         {
@@ -35,9 +35,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
         private partial class Popover : OsuPopover
         {
             [Resolved]
-            private RankedPlayScreen? rankedPlayScreen { get; set; }
+            private RankedPlayScreen rankedPlayScreen { get; set; } = null!;
 
-            public Action? ReportRequested { get; init; }
+            public required Action ReportRequested { get; init; }
 
             private readonly OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Pink);
             private FillFlowContainer buttonFlow = null!;
@@ -54,10 +54,9 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                     Spacing = new Vector2(3),
                 };
 
-                addButton(rankedPlayScreen?.ActiveSubScreen is not EndedScreen ? "Give up" : CommonStrings.Exit, FontAwesome.Solid.SignOutAlt, () => rankedPlayScreen?.Exit());
+                addButton(rankedPlayScreen.ActiveSubScreen is not EndedScreen ? "Give up" : CommonStrings.Exit, FontAwesome.Solid.SignOutAlt, () => rankedPlayScreen.Exit());
 
-                if (ReportRequested != null)
-                    addButton("Report opponent", FontAwesome.Solid.ExclamationTriangle, () => ReportRequested.Invoke());
+                addButton("Report opponent", FontAwesome.Solid.ExclamationTriangle, () => ReportRequested.Invoke());
             }
 
             protected override void LoadComplete()

--- a/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
+++ b/osu.Game/Screens/OnlinePlay/Matchmaking/RankedPlay/RankedPlayScreen.cs
@@ -25,6 +25,7 @@ using osu.Game.Online.Multiplayer.MatchTypes.RankedPlay;
 using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
+using osu.Game.Overlays.Profile;
 using osu.Game.Overlays.Volume;
 using osu.Game.Rulesets;
 using osu.Game.Screens.OnlinePlay.Components;
@@ -153,6 +154,7 @@ namespace osu.Game.Screens.OnlinePlay.Matchmaking.RankedPlay
                                     new HamburgerMenu
                                     {
                                         Size = new Vector2(56),
+                                        ReportRequested = () => dialogOverlay.Push(new ReportUserDialog(opponentUser)),
                                     }
                                 }
                             }


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu/pull/37651.

This commit adds a 'Report opponent' option in the hamburger menu on the ranked play screen. It's effectively a shorthand for manually opening the profile and using the report option that's available over there.

[Screencast_20260506_140136.webm](https://github.com/user-attachments/assets/ba953a3c-026f-467f-bc6b-3b723f2d38f1)