### PR TITLE
Fix replay analysis cursor path shifting in rare cases

### DIFF
--- a/osu.Game.Rulesets.Osu/UI/ReplayAnalysis/CursorPathContainer.cs
+++ b/osu.Game.Rulesets.Osu/UI/ReplayAnalysis/CursorPathContainer.cs
@@ -55,19 +55,10 @@ namespace osu.Game.Rulesets.Osu.UI.ReplayAnalysis
         {
             ClearVertices();
 
-            Vector2 min = Vector2.Zero;
-
             foreach (var entry in aliveEntries)
-            {
                 AddVertex(entry.Position);
-                if (entry.Position.X < min.X)
-                    min.X = entry.Position.X;
 
-                if (entry.Position.Y < min.Y)
-                    min.Y = entry.Position.Y;
-            }
-
-            Position = min;
+            OriginPosition = PositionInBoundingBox(Vector2.Zero);
         }
 
         private sealed class AimLinePointComparator : IComparer<AnalysisFrameEntry>


### PR DESCRIPTION
Reported via e-mails.

Can reproduce on something like https://osu.ppy.sh/beatmapsets/478917#osu/1151834, most apparent around ~1:00.

There was code attempting to account for this but it was failing. The failure happens because the framework path bounding box calculation accounts not only for vertex position, [but also *path radius*](https://github.com/ppy/osu-framework/blob/b483ad4e4fd2bf05f5a92d65b2111b120ba0e5e9/osu.Framework/Graphics/Lines/Path.cs#L191-L194). So if the replay contained frames with X or Y positions in the range [0, 1] (as 1 is the relevant path radius here), the previous calculation would presume no correction is needed, while framework-side the bounding box would get further offset by the radius, thus causing the shifting.

Fixed via framework idiom I stumbled upon (e.g. see [[1]](https://github.com/ppy/osu-framework/blob/08d5163f0fa8fe12e62a0e7a9d05180aded3021c/osu.Framework.Tests/Visual/Drawables/TestSceneCubicBezierEasing.cs#L175), [[2]](https://github.com/ppy/osu-framework/blob/4c3004e77484700502c5f57ee43ef1c6da3396e1/osu.Framework.Tests/Visual/Drawables/TestSceneSpring.cs#L265)).