### PR TITLE
Fix infinite recursion in song select logic in certain circumstances

### DIFF
--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -139,7 +137,7 @@ namespace osu.Game.Tests.Visual.Editing
         [FlakyTest]
         public void TestLengthAndStarRatingUpdated()
         {
-            WorkingBeatmap working = null;
+            WorkingBeatmap working = null!;
             double lastStarRating = 0;
             double lastLength = 0;
 
@@ -223,7 +221,7 @@ namespace osu.Game.Tests.Visual.Editing
             AddAssert("beatmap version is populated", () => EditorBeatmap.BeatmapVersion > 0);
         }
 
-        private DialogOverlay dialogOverlay => Game.ChildrenOfType<DialogOverlay>().FirstOrDefault();
+        private DialogOverlay? dialogOverlay => Game.ChildrenOfType<DialogOverlay>().FirstOrDefault();
 
         [Test]
         public void TestReplacingEntireSetInsideEditorDoesNotCrashOnExitToSongSelect()
@@ -241,18 +239,18 @@ namespace osu.Game.Tests.Visual.Editing
             });
 
             AddUntilStep("wait for dialog", () => dialogOverlay?.CurrentDialog is CreateNewDifficultyDialog);
-            AddStep("confirm creation with no objects", () => dialogOverlay.CurrentDialog!.PerformOkAction());
+            AddStep("confirm creation with no objects", () => dialogOverlay!.CurrentDialog!.PerformOkAction());
 
             AddUntilStep("wait for created", () =>
             {
                 string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
                 return difficultyName != null && difficultyName != currentDifficulty;
             });
-            AddUntilStep("wait for editor load", () => Editor.ReadyForUse && dialogOverlay.IsLoaded);
+            AddUntilStep("wait for editor load", () => Editor.ReadyForUse && dialogOverlay!.IsLoaded);
 
             ReloadEditorToSameBeatmap();
 
-            Task<Live<BeatmapSetInfo>> importAsUpdateTask = null!;
+            Task<Live<BeatmapSetInfo>?> importAsUpdateTask = null!;
             AddStep("import as update edited beatmap inside editor", () =>
             {
                 using var stream = TestResources.GetTestBeatmapStream();

--- a/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
+++ b/osu.Game.Tests/Visual/Editing/TestSceneEditorSaving.cs
@@ -3,7 +3,9 @@
 
 #nullable disable
 
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -12,10 +14,16 @@ using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.ControlPoints;
+using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Overlays;
+using osu.Game.Overlays.Notifications;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Screens.Edit;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Screens.Select;
+using osu.Game.Screens.Select.Filter;
+using osu.Game.Tests.Resources;
 using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Editing
@@ -213,6 +221,47 @@ namespace osu.Game.Tests.Visual.Editing
         public void TestBeatmapVersionPopulatedCorrectly()
         {
             AddAssert("beatmap version is populated", () => EditorBeatmap.BeatmapVersion > 0);
+        }
+
+        private DialogOverlay dialogOverlay => Game.ChildrenOfType<DialogOverlay>().FirstOrDefault();
+
+        [Test]
+        public void TestReplacingEntireSetInsideEditorDoesNotCrashOnExitToSongSelect()
+        {
+            SaveEditor();
+            // required to provoke crash
+            AddStep("set sort mode to difficulty", () => Game.LocalConfig.SetValue(OsuSetting.SongSelectSortingMode, SortMode.Difficulty));
+
+            string? currentDifficulty = null;
+
+            AddStep("create second difficulty", () =>
+            {
+                currentDifficulty = EditorBeatmap.BeatmapInfo.DifficultyName;
+                Editor.CreateNewDifficulty(new OsuRuleset().RulesetInfo);
+            });
+
+            AddUntilStep("wait for dialog", () => dialogOverlay?.CurrentDialog is CreateNewDifficultyDialog);
+            AddStep("confirm creation with no objects", () => dialogOverlay.CurrentDialog!.PerformOkAction());
+
+            AddUntilStep("wait for created", () =>
+            {
+                string? difficultyName = Editor.ChildrenOfType<EditorBeatmap>().SingleOrDefault()?.BeatmapInfo.DifficultyName;
+                return difficultyName != null && difficultyName != currentDifficulty;
+            });
+            AddUntilStep("wait for editor load", () => Editor.ReadyForUse && dialogOverlay.IsLoaded);
+
+            ReloadEditorToSameBeatmap();
+
+            Task<Live<BeatmapSetInfo>> importAsUpdateTask = null!;
+            AddStep("import as update edited beatmap inside editor", () =>
+            {
+                using var stream = TestResources.GetTestBeatmapStream();
+                var memoryStream = new MemoryStream();
+                stream.CopyTo(memoryStream);
+                importAsUpdateTask = Game.BeatmapManager.ImportAsUpdate(new ProgressNotification(), new ImportTask(memoryStream, "test.osz"), Editor.Beatmap.Value.BeatmapSetInfo);
+            });
+            AddUntilStep("wait for import", () => importAsUpdateTask.Status, () => Is.EqualTo(TaskStatus.RanToCompletion));
+            AddStep("exit to song select", () => Editor.Exit());
         }
     }
 }

--- a/osu.Game/Screens/Edit/Editor.cs
+++ b/osu.Game/Screens/Edit/Editor.cs
@@ -1478,7 +1478,7 @@ namespace osu.Game.Screens.Edit
             return new EditorMenuItem(EditorStrings.CreateNewDifficulty) { Items = rulesetItems };
         }
 
-        protected void CreateNewDifficulty(RulesetInfo rulesetInfo)
+        protected internal void CreateNewDifficulty(RulesetInfo rulesetInfo)
         {
             if (isNewBeatmap)
             {

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -459,7 +459,11 @@ namespace osu.Game.Screens.Select
                 if (Beatmap.Value.BeatmapInfo.Equals(debounceQueuedSelection))
                     return;
 
-                Beatmap.Value = beatmaps.GetWorkingBeatmap(debounceQueuedSelection);
+                var workingBeatmap = beatmaps.GetWorkingBeatmap(debounceQueuedSelection);
+                if (!checkBeatmapValidForSelection(workingBeatmap.BeatmapInfo))
+                    return;
+
+                Beatmap.Value = workingBeatmap;
             }
             finally
             {

--- a/osu.Game/Tests/Visual/EditorTestScene.cs
+++ b/osu.Game/Tests/Visual/EditorTestScene.cs
@@ -119,8 +119,6 @@ namespace osu.Game.Tests.Visual
 
             public new void SwitchToDifficulty(BeatmapInfo beatmapInfo) => base.SwitchToDifficulty(beatmapInfo);
 
-            public new void CreateNewDifficulty(RulesetInfo rulesetInfo) => base.CreateNewDifficulty(rulesetInfo);
-
             public new bool HasUnsavedChanges => base.HasUnsavedChanges;
 
             public override bool OnExiting(ScreenExitEvent e)


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38620.

Note that in this description I am *very intentionally* making no reference to the editor at all. This is because this is ostensibly a *song select* bug, and I see no room for discussion in that regard.

The explanation in https://github.com/ppy/osu/issues/38620#issuecomment-5322410469 is pretty much spot-on, though I find that it a bit disjointed, and that it dawdles a bit too much on individual details in the bug description rather than focus on the core point. So here's an attempt to restate that in a hopefully more digestible manner.

The set-up of this bug involves the following:

1. Song select is not the active screen and instead is suspended in the background.
2. Some other screen is calling `ImportAsUpdate()` while song select isn't active, which ends up marking the previous selection in song select as no longer valid (primary reason is deletion).
3. There must have been at least one alternate selection candidate at the point of suspension of song select. (This is important, because if there isn't, `SelectNextRandom()` gives up and does nothing.)
4. *All of the other selection candidates* that were visible at song select at the point of suspension are also invalidated by (2).

The way this explodes at `SongSelect.ensureGlobalBeatmapValid()` is the following:

1. On resume to song select, the selection verification logic fires. It correctly clocks that the current selection is now deleted and thus invalid.
2. In order to select *something*, song select defers to the carousel. But the carousel has not yet had a chance to update its models to the database changes that occurred in the background, so it has all models stale. Thus it picks *another* deleted and invalid beatmap to pick.
3. `ensureGlobalBeatmapValid()` takes that pick *at face value without validation* and dispatches it immediately via `performDebounceSelection()`, which changes `Beatmap.Value`.
4. Changes to `Beatmap.Value` are hooked up to fire `ensureGlobalBeatmapValid()` and therefore we go to step (1), 💥 when stack runs out.

The proposed fix here is to target step (3) in the explosion; `performDebounceSelection()` has the wherewithal to perform a sanity check, detect that the beatmap is deleted, and cut off the infinite recursion.

The fix *isn't great*. I don't particularly like it. That said anything else would probably amount to rewriting half of song select again. `SongSelect` and `BeatmapCarousel` are joined at the hip in weird ways to a degree that limits movement. It does not help that `SongSelect.ensureGlobalBeatmapValid()`, which is designed to ensure instant correctness and stability, attempts to rely on `BeatmapCarousel`, which is allowed to have stale state because of realm subscription performance issues. I will refrain from retreading that ground again, see https://github.com/ppy/osu/issues/34583#issuecomment-3183653834 and https://github.com/ppy/osu/issues/35129#issuecomment-3472864944.