### PR TITLE
Fix presenting beatmap sometimes not working correctly when scoped to beatmap

### DIFF
--- a/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFiltering.cs
+++ b/osu.Game.Tests/Visual/SongSelect/TestSceneSongSelectFiltering.cs
@@ -10,12 +10,15 @@ using osu.Framework.Screens;
 using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
+using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.Chat;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania.Mods;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Screens;
 using osu.Game.Screens.Select;
 using osu.Game.Screens.Select.Filter;
 using osuTK.Input;
@@ -570,6 +573,37 @@ namespace osu.Game.Tests.Visual.SongSelect
             WaitForFiltering();
 
             AddAssert("normal difficulty is selected", () => Beatmap.Value.BeatmapInfo, () => Is.EqualTo(findBeatmap("Normal")));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestUnscopeByPresentingBeatmap(bool grouped)
+        {
+            bool showConverts = Config.Get<bool>(OsuSetting.ShowConvertedBeatmaps);
+
+            AddStep("hide converts", () => Config.SetValue(OsuSetting.ShowConvertedBeatmaps, false));
+
+            ImportBeatmapForRuleset(_ => { }, 2, 0, 0);
+            ImportBeatmapForRuleset(_ => { }, 4, 0, 0, 0, 0);
+            ImportBeatmapForRuleset(_ => { }, 3, 1, 1, 1);
+
+            LoadSongSelect();
+            ChangeRuleset(1);
+            SortBy(grouped ? SortMode.Title : SortMode.Difficulty);
+            checkMatchedBeatmaps(3);
+
+            scopeBeatmap(grouped);
+            checkMatchedBeatmaps(3);
+
+            AddStep("present osu! beatmap", () =>
+            {
+                var beatmap = Realm.Run(r => r.All<BeatmapSetInfo>().AsEnumerable().First(s => s.Beatmaps.Count == 2).Beatmaps.First().Detach());
+                var working = Beatmaps.GetWorkingBeatmap(beatmap);
+                ((IHandlePresentBeatmap)SongSelect).PresentBeatmap(working, new OsuRuleset().RulesetInfo);
+            });
+            AddUntilStep("selection changed", () => Beatmap.Value.BeatmapSetInfo.Beatmaps, () => Has.Count.EqualTo(2));
+
+            AddStep("revert convert setting", () => Config.SetValue(OsuSetting.ShowConvertedBeatmaps, showConverts));
         }
 
         private void scopeBeatmap(bool grouped)

--- a/osu.Game/Screens/Select/SongSelect.cs
+++ b/osu.Game/Screens/Select/SongSelect.cs
@@ -1178,6 +1178,7 @@ namespace osu.Game.Screens.Select
 
         void IHandlePresentBeatmap.PresentBeatmap(WorkingBeatmap workingBeatmap, RulesetInfo ruleset)
         {
+            unscopeBeatmapSet(restorePreviousSelection: false);
             cancelDebounceSelection();
 
             var beatmapInfo = workingBeatmap.BeatmapInfo;
@@ -1265,12 +1266,14 @@ namespace osu.Game.Screens.Select
             scopedBeatmapSet.Value = beatmapSet;
         }
 
-        public void UnscopeBeatmapSet()
+        public void UnscopeBeatmapSet() => unscopeBeatmapSet(restorePreviousSelection: true);
+
+        private void unscopeBeatmapSet(bool restorePreviousSelection)
         {
             if (scopedBeatmapSet.Value == null)
                 return;
 
-            if (beforeScopedSelection != null)
+            if (beforeScopedSelection != null && restorePreviousSelection)
                 queueBeatmapSelection(beforeScopedSelection);
 
             scopedBeatmapSet.Value = null;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38631.

This only occurs when the beatmap presented is from another ruleset than the current selection in song select, and showing converted difficulties is turned off.

On master, the following sequence of events occurs:

1. `SongSelect.PresentBeatmap()` runs, determines that a ruleset switch is necessary because the user has converts turned off, and performs the switch.
2. `FilterControl.updateCriteria()` fires due to the ruleset change. It clears the scoped set via `SongSelect.UnscopeBeatmapSet()`.
3. `SongSelect.UnscopeBeatmapSet()` queues up a restore of the global beatmap to what it was before scoping was engaged. Most likely, this is a beatmap valid only for the ruleset prior to the ruleset switch. Of note, this operation is *debounced*, so it happens *in the future*.
4. `SongSelect.PresentBeatmap()` sets the correct global beatmap.
5. The debounced restore from step (3) fires here. At this point the ruleset doesn't match, so `SongSelect.ensureGlobalBeatmapValid()` rejects it and selects something random instead.

The fix is to not attempt to restore the previous selection when dismissing the scoped beatmap via presenting another.