### PR TITLE
Improve settings sidebar and ruleset visibility

### DIFF
--- a/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Mania/ManiaSettingsSubsection.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
@@ -17,8 +16,6 @@ namespace osu.Game.Rulesets.Mania
 {
     public partial class ManiaSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override LocalisableString Header => "osu!mania";
-
         public ManiaSettingsSubsection(ManiaRuleset ruleset)
             : base(ruleset)
         {

--- a/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Osu/UI/OsuSettingsSubsection.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
@@ -15,8 +14,6 @@ namespace osu.Game.Rulesets.Osu.UI
 {
     public partial class OsuSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override LocalisableString Header => "osu!";
-
         public OsuSettingsSubsection(Ruleset ruleset)
             : base(ruleset)
         {

--- a/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoSettingsSubsection.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Localisation;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
@@ -14,8 +13,6 @@ namespace osu.Game.Rulesets.Taiko
 {
     public partial class TaikoSettingsSubsection : RulesetSettingsSubsection
     {
-        protected override LocalisableString Header => "osu!taiko";
-
         public TaikoSettingsSubsection(TaikoRuleset ruleset)
             : base(ruleset)
         {

--- a/osu.Game/Localisation/InputSettingsStrings.cs
+++ b/osu.Game/Localisation/InputSettingsStrings.cs
@@ -35,11 +35,6 @@ namespace osu.Game.Localisation
         public static LocalisableString SongSelectSection => new TranslatableString(getKey(@"song_select_section"), @"Song Select");
 
         /// <summary>
-        /// "In Game"
-        /// </summary>
-        public static LocalisableString InGameSection => new TranslatableString(getKey(@"in_game_section"), @"In Game");
-
-        /// <summary>
         /// "Replay"
         /// </summary>
         public static LocalisableString ReplaySection => new TranslatableString(getKey(@"replay_section"), @"Replay");

--- a/osu.Game/Localisation/InputSettingsStrings.cs
+++ b/osu.Game/Localisation/InputSettingsStrings.cs
@@ -55,9 +55,9 @@ namespace osu.Game.Localisation
         public static LocalisableString EditorSection => new TranslatableString(getKey(@"editor_section"), @"Editor");
 
         /// <summary>
-        /// "Editor: Test play"
+        /// "Test play"
         /// </summary>
-        public static LocalisableString EditorTestPlaySection => new TranslatableString(getKey(@"editor_test_play_section"), @"Editor: Test play");
+        public static LocalisableString EditorTestPlaySection => new TranslatableString(getKey(@"editor_test_play_section"), @"Test play");
 
         /// <summary>
         /// "Reset all bindings in section"

--- a/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
+++ b/osu.Game/Overlays/FirstRunSetup/ScreenBehaviour.cs
@@ -83,7 +83,6 @@ namespace osu.Game.Overlays.FirstRunSetup
                         // InputSection is intentionally omitted for now due to its sub-panel being a pain to set up.
                         new UserInterfaceSection(),
                         new GameplaySection(),
-                        new RulesetSection(),
                         new AudioSection(),
                         new GraphicsSection(),
                         new OnlineSection(),

--- a/osu.Game/Overlays/Settings/RulesetSettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/RulesetSettingsSubsection.cs
@@ -4,6 +4,8 @@
 #nullable disable
 
 using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Localisation;
 using osu.Game.Configuration;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Configuration;
@@ -37,5 +39,8 @@ namespace osu.Game.Overlays.Settings
 
             return dependencies;
         }
+
+        protected sealed override LocalisableString Header => string.Empty;
+        protected sealed override Drawable CreateHeader() => Empty();
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
+++ b/osu.Game/Overlays/Settings/Sections/GameplaySection.cs
@@ -25,8 +25,8 @@ namespace osu.Game.Overlays.Settings.Sections
             {
                 new GeneralSettings(),
                 new AudioSettings(),
-                new BeatmapSettings(),
                 new BackgroundSettings(),
+                new BeatmapSettings(),
                 new HUDSettings(),
                 new InputSettings(),
                 new ModsSettings(),

--- a/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/GlobalKeyBindingsSection.cs
@@ -1,38 +1,24 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Input.Bindings;
-using osu.Game.Localisation;
 
 namespace osu.Game.Overlays.Settings.Sections.Input
 {
     public partial class GlobalKeyBindingsSection : SettingsSection
     {
-        public override Drawable CreateIcon() => new SpriteIcon
-        {
-            Icon = FontAwesome.Solid.Globe
-        };
+        private readonly IconUsage icon;
 
-        public override LocalisableString Header => InputSettingsStrings.GlobalKeyBindingHeader;
-
-        [BackgroundDependencyLoader]
-        private void load()
+        public GlobalKeyBindingsSection(IconUsage icon, LocalisableString header)
         {
-            AddRange(new[]
-            {
-                new GlobalKeyBindingsSubsection(string.Empty, GlobalActionCategory.General),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.OverlaysSection, GlobalActionCategory.Overlays),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.AudioSection, GlobalActionCategory.AudioControl),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.SongSelectSection, GlobalActionCategory.SongSelect),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.InGameSection, GlobalActionCategory.InGame),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.ReplaySection, GlobalActionCategory.Replay),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.EditorSection, GlobalActionCategory.Editor),
-                new GlobalKeyBindingsSubsection(InputSettingsStrings.EditorTestPlaySection, GlobalActionCategory.EditorTestPlay),
-            });
+            this.icon = icon;
+            Header = header;
         }
+
+        public override Drawable CreateIcon() => new SpriteIcon { Icon = icon };
+
+        public override LocalisableString Header { get; }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
@@ -28,7 +30,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             });
 
-            AddSection(new GlobalKeyBindingsSection(OsuIcon.GameplayC, InputSettingsStrings.InGameSection)
+            AddSection(new GlobalKeyBindingsSection(OsuIcon.GameplayC, GameplaySettingsStrings.GameplaySectionHeader)
             {
                 Children = new[]
                 {
@@ -48,13 +50,18 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             });
 
+            List<KeyBindingsSubsection> rulesetEditorVariants = new List<KeyBindingsSubsection>();
+
+            foreach (var ruleset in rulesets.AvailableRulesets)
+                rulesetEditorVariants.Add(new RulesetEditorBindingsSubsection(ruleset));
+
             AddSection(new GlobalKeyBindingsSection(OsuIcon.EditorSelect, InputSettingsStrings.EditorSection)
             {
-                Children = new[]
+                ChildrenEnumerable = new KeyBindingsSubsection[]
                 {
                     new GlobalKeyBindingsSubsection(CommonStrings.General, GlobalActionCategory.Editor),
                     new GlobalKeyBindingsSubsection(InputSettingsStrings.EditorTestPlaySection, GlobalActionCategory.EditorTestPlay),
-                }
+                }.Concat(rulesetEditorVariants),
             });
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
@@ -37,6 +37,9 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 }
             });
 
+            foreach (var ruleset in rulesets.AvailableRulesets)
+                AddSection(new RulesetBindingsSection(ruleset));
+
             AddSection(new GlobalKeyBindingsSection(OsuIcon.Beatmap, InputSettingsStrings.SongSelectSection)
             {
                 Children = new[]
@@ -53,9 +56,6 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                     new GlobalKeyBindingsSubsection(InputSettingsStrings.EditorTestPlaySection, GlobalActionCategory.EditorTestPlay),
                 }
             });
-
-            foreach (var ruleset in rulesets.AvailableRulesets)
-                AddSection(new RulesetBindingsSection(ruleset));
         }
     }
 }

--- a/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/KeyBindingPanel.cs
@@ -3,6 +3,9 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Rulesets;
 
@@ -15,7 +18,41 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         [BackgroundDependencyLoader(permitNulls: true)]
         private void load(RulesetStore rulesets)
         {
-            AddSection(new GlobalKeyBindingsSection());
+            AddSection(new GlobalKeyBindingsSection(FontAwesome.Solid.Globe, InputSettingsStrings.GlobalKeyBindingHeader)
+            {
+                Children = new[]
+                {
+                    new GlobalKeyBindingsSubsection(CommonStrings.General, GlobalActionCategory.General),
+                    new GlobalKeyBindingsSubsection(InputSettingsStrings.AudioSection, GlobalActionCategory.AudioControl),
+                    new GlobalKeyBindingsSubsection(InputSettingsStrings.OverlaysSection, GlobalActionCategory.Overlays),
+                }
+            });
+
+            AddSection(new GlobalKeyBindingsSection(OsuIcon.GameplayC, InputSettingsStrings.InGameSection)
+            {
+                Children = new[]
+                {
+                    new GlobalKeyBindingsSubsection(CommonStrings.General, GlobalActionCategory.InGame),
+                    new GlobalKeyBindingsSubsection(InputSettingsStrings.ReplaySection, GlobalActionCategory.Replay),
+                }
+            });
+
+            AddSection(new GlobalKeyBindingsSection(OsuIcon.Beatmap, InputSettingsStrings.SongSelectSection)
+            {
+                Children = new[]
+                {
+                    new GlobalKeyBindingsSubsection(CommonStrings.General, GlobalActionCategory.SongSelect),
+                }
+            });
+
+            AddSection(new GlobalKeyBindingsSection(OsuIcon.EditorSelect, InputSettingsStrings.EditorSection)
+            {
+                Children = new[]
+                {
+                    new GlobalKeyBindingsSubsection(CommonStrings.General, GlobalActionCategory.Editor),
+                    new GlobalKeyBindingsSubsection(InputSettingsStrings.EditorTestPlaySection, GlobalActionCategory.EditorTestPlay),
+                }
+            });
 
             foreach (var ruleset in rulesets.AvailableRulesets)
                 AddSection(new RulesetBindingsSection(ruleset));

--- a/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
@@ -18,6 +18,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
 
         public RulesetBindingsSection(RulesetInfo ruleset)
         {
+            UseSmallerSidebarButton = true;
             this.ruleset = ruleset;
         }
 

--- a/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RulesetBindingsSection.cs
@@ -26,7 +26,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         {
             var r = ruleset.CreateInstance();
 
-            foreach (int variant in r.AllVariants)
+            foreach (int variant in r.GameplayVariants)
                 Add(new VariantBindingsSubsection(ruleset, variant));
         }
     }

--- a/osu.Game/Overlays/Settings/Sections/Input/RulesetEditorBindingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/RulesetEditorBindingsSubsection.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Localisation;
+using osu.Game.Input.Bindings;
+using osu.Game.Rulesets;
+using Realms;
+
+namespace osu.Game.Overlays.Settings.Sections.Input
+{
+    public partial class RulesetEditorBindingsSubsection : KeyBindingsSubsection
+    {
+        protected override LocalisableString Header { get; }
+
+        public RulesetInfo Ruleset { get; }
+
+        private const int variant = Rulesets.Ruleset.EDITOR_VARIANT;
+
+        public RulesetEditorBindingsSubsection(RulesetInfo ruleset)
+        {
+            Ruleset = ruleset;
+
+            var rulesetInstance = ruleset.CreateInstance();
+
+            Header = ruleset.Name;
+            Defaults = rulesetInstance.GetDefaultKeyBindings(variant);
+        }
+
+        protected override IEnumerable<RealmKeyBinding> GetKeyBindings(Realm realm)
+        {
+            string rulesetName = Ruleset.ShortName;
+
+            return realm.All<RealmKeyBinding>()
+                        .Where(b => b.RulesetName == rulesetName && b.Variant == variant);
+        }
+
+        protected override KeyBindingRow CreateKeyBindingRow(object action, IEnumerable<KeyBinding> defaults)
+            => new KeyBindingRow(action)
+            {
+                AllowMainMouseButtons = true,
+                Defaults = defaults.Select(d => d.KeyCombination),
+            };
+    }
+}

--- a/osu.Game/Overlays/Settings/Sections/RulesetSection.cs
+++ b/osu.Game/Overlays/Settings/Sections/RulesetSection.cs
@@ -1,44 +1,27 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Localisation;
-using osu.Game.Graphics;
-using osu.Game.Localisation;
 using osu.Game.Rulesets;
 
 namespace osu.Game.Overlays.Settings.Sections
 {
     public partial class RulesetSection : SettingsSection
     {
-        public override LocalisableString Header => RulesetSettingsStrings.Rulesets;
+        private readonly Ruleset ruleset;
 
-        public override Drawable CreateIcon() => new SpriteIcon
+        public RulesetSection(Ruleset ruleset, SettingsSubsection section)
         {
-            Icon = OsuIcon.Rulesets
-        };
+            UseSmallerSidebarButton = true;
 
-        [BackgroundDependencyLoader]
-        private void load(RulesetStore rulesets)
-        {
-            foreach (Ruleset ruleset in rulesets.AvailableRulesets.Select(info => info.CreateInstance()))
-            {
-                try
-                {
-                    SettingsSubsection? section = ruleset.CreateSettings();
+            this.ruleset = ruleset;
 
-                    if (section != null)
-                        Add(section);
-                }
-                catch (Exception e)
-                {
-                    RulesetStore.LogRulesetFailure(ruleset.RulesetInfo, e);
-                }
-            }
+            Add(section);
         }
+
+        public override LocalisableString Header => ruleset.RulesetInfo.Name;
+
+        public override Drawable CreateIcon() => ruleset.CreateIcon();
     }
 }

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Overlays.Settings
         public const int ITEM_SPACING = 14;
         public const int ITEM_SPACING_V2 = 4;
 
-        private const int header_size = 24;
+        private const int header_size = 30;
         private const int border_size = 2;
 
         private bool matchingFilter = true;
@@ -72,7 +72,7 @@ namespace osu.Game.Overlays.Settings
             {
                 Margin = new MarginPadding
                 {
-                    Top = 36
+                    Top = header_size + 6,
                 },
                 Spacing = new Vector2(0, ITEM_SPACING_V2),
                 Direction = FillDirection.Vertical,

--- a/osu.Game/Overlays/Settings/SettingsSection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSection.cs
@@ -32,6 +32,8 @@ namespace osu.Game.Overlays.Settings
         public abstract Drawable CreateIcon();
         public abstract LocalisableString Header { get; }
 
+        public bool UseSmallerSidebarButton { get; init; }
+
         public virtual IEnumerable<LocalisableString> FilterTerms => new[] { Header };
 
         public const int ITEM_SPACING = 14;

--- a/osu.Game/Overlays/Settings/SettingsSidebar.cs
+++ b/osu.Game/Overlays/Settings/SettingsSidebar.cs
@@ -19,7 +19,7 @@ namespace osu.Game.Overlays.Settings
 {
     public partial class SettingsSidebar : ExpandingContainer
     {
-        public const float CONTRACTED_WIDTH = 70;
+        public const float CONTRACTED_WIDTH = 60;
         public const int EXPANDED_WIDTH = 170;
 
         public Action? BackButtonAction;

--- a/osu.Game/Overlays/Settings/SettingsSubsection.cs
+++ b/osu.Game/Overlays/Settings/SettingsSubsection.cs
@@ -66,7 +66,7 @@ namespace osu.Game.Overlays.Settings
             {
                 Text = Header,
                 Font = OsuFont.GetFont(size: header_font_size),
-                Margin = new MarginPadding { Vertical = VERTICAL_PADDING },
+                Margin = new MarginPadding { Vertical = VERTICAL_PADDING, Horizontal = 5 },
                 Padding = SettingsPanel.CONTENT_PADDING,
             };
         }

--- a/osu.Game/Overlays/Settings/SidebarIconButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarIconButton.cs
@@ -60,7 +60,7 @@ namespace osu.Game.Overlays.Settings
             RelativeSizeAxes = Axes.X;
             Height = 46;
 
-            Padding = new MarginPadding(5);
+            Padding = new MarginPadding { Horizontal = 5, Vertical = 2.5f };
 
             AddRange(new Drawable[]
             {

--- a/osu.Game/Overlays/Settings/SidebarIconButton.cs
+++ b/osu.Game/Overlays/Settings/SidebarIconButton.cs
@@ -8,7 +8,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.Containers;
@@ -20,26 +19,13 @@ namespace osu.Game.Overlays.Settings
         private const float selection_indicator_height_active = 18;
         private const float selection_indicator_height_inactive = 4;
 
-        private readonly ConstrainedIconContainer iconContainer;
-        private readonly SpriteText headerText;
-        private readonly CircularContainer selectionIndicator;
-        private readonly Container textIconContent;
+        private CircularContainer selectionIndicator;
+        private Container textIconContent;
 
         // always consider as part of flow, even when not visible (for the sake of the initial animation).
         public override bool IsPresent => true;
 
-        private SettingsSection section;
-
-        public SettingsSection Section
-        {
-            get => section;
-            set
-            {
-                section = value;
-                headerText.Text = value.Header;
-                iconContainer.Icon = value.CreateIcon();
-            }
-        }
+        public required SettingsSection Section { get; init; }
 
         private bool selected;
 
@@ -58,9 +44,17 @@ namespace osu.Game.Overlays.Settings
         public SidebarIconButton()
         {
             RelativeSizeAxes = Axes.X;
-            Height = 46;
+        }
 
-            Padding = new MarginPadding { Horizontal = 5, Vertical = 2.5f };
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            const float icon_size = 20;
+
+            float scale = Section.UseSmallerSidebarButton ? 0.8f : 1;
+
+            Height = 46 * scale;
+            Padding = new MarginPadding { Horizontal = 5 + (Section.UseSmallerSidebarButton ? icon_size : 0), Vertical = 2.5f * scale };
 
             AddRange(new Drawable[]
             {
@@ -70,16 +64,20 @@ namespace osu.Game.Overlays.Settings
                     Colour = OsuColour.Gray(0.6f),
                     Children = new Drawable[]
                     {
-                        iconContainer = new ConstrainedIconContainer
+                        new ConstrainedIconContainer
                         {
                             Anchor = Anchor.CentreLeft,
-                            Origin = Anchor.CentreLeft,
-                            Size = new Vector2(20),
+                            Origin = Anchor.Centre,
+                            X = icon_size,
+                            Size = new Vector2(icon_size * scale),
+                            Icon = Section.CreateIcon(),
                             Margin = new MarginPadding { Left = 25 }
                         },
-                        headerText = new OsuSpriteText
+                        new OsuSpriteText
                         {
-                            Position = new Vector2(60, 0),
+                            Text = Section.Header,
+                            Font = OsuFont.Default.With(size: OsuFont.DEFAULT_FONT_SIZE * scale),
+                            Position = new Vector2(50, 0),
                             Anchor = Anchor.CentreLeft,
                             Origin = Anchor.CentreLeft,
                         },
@@ -87,6 +85,8 @@ namespace osu.Game.Overlays.Settings
                 },
                 selectionIndicator = new CircularContainer
                 {
+                    Colour = ColourProvider.Highlight1,
+
                     Alpha = 0,
                     Width = 4,
                     Height = selection_indicator_height_inactive,
@@ -105,12 +105,6 @@ namespace osu.Game.Overlays.Settings
                     }
                 },
             });
-        }
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            selectionIndicator.Colour = ColourProvider.Highlight1;
         }
 
         protected override void UpdateState()

--- a/osu.Game/Overlays/SettingsOverlay.cs
+++ b/osu.Game/Overlays/SettingsOverlay.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,6 +17,7 @@ using osu.Game.Localisation;
 using osu.Game.Overlays.Settings;
 using osu.Game.Overlays.Settings.Sections;
 using osu.Game.Overlays.Settings.Sections.Input;
+using osu.Game.Rulesets;
 using osuTK.Graphics;
 
 namespace osu.Game.Overlays
@@ -29,34 +28,9 @@ namespace osu.Game.Overlays
         public LocalisableString Title => SettingsStrings.HeaderTitle;
         public LocalisableString Description => SettingsStrings.HeaderDescription;
 
-        protected override IEnumerable<SettingsSection> CreateSections()
-        {
-            var sections = new List<SettingsSection>
-            {
-                // This list should be kept in sync with ScreenBehaviour.
-                new GeneralSection(),
-                new SkinSection(),
-                new InputSection(createSubPanel(new KeyBindingPanel())),
-                new UserInterfaceSection(),
-                new GameplaySection(),
-                new RulesetSection(),
-                new AudioSection(),
-                new GraphicsSection(),
-                new OnlineSection(),
-                new MaintenanceSection(),
-                new DebugSection()
-            };
-
-            var today = DateTimeOffset.Now;
-            if (today.Month == 4 && today.Day == 1)
-                sections.Insert(9, new AfToggleSection());
-
-            return sections;
-        }
-
         private readonly List<SettingsSubPanel> subPanels = new List<SettingsSubPanel>();
 
-        private SettingsSubPanel lastOpenedSubPanel;
+        private SettingsSubPanel? lastOpenedSubPanel;
 
         protected override Drawable CreateHeader() => new SettingsHeader(Title, Description);
 
@@ -74,8 +48,7 @@ namespace osu.Game.Overlays
 
         public override bool AcceptsFocus => lastOpenedSubPanel == null || lastOpenedSubPanel.State.Value == Visibility.Hidden;
 
-        public void ShowAtControl<T>()
-            where T : Drawable
+        public void ShowAtControl<T>() where T : Drawable
         {
             // if search isn't cleared then the target control won't be visible if it doesn't match the query
             SearchTextBox.Current.SetDefault();
@@ -90,6 +63,56 @@ namespace osu.Game.Overlays
             }
 
             SectionsContainer.ScrollTo(SectionsContainer.ChildrenOfType<T>().Single());
+        }
+
+        protected override float ExpandedPosition => lastOpenedSubPanel?.State.Value == Visibility.Visible ? -PANEL_WIDTH : base.ExpandedPosition;
+
+        [BackgroundDependencyLoader]
+        private void load(RulesetStore rulesets)
+        {
+            var sections = new List<SettingsSection>
+            {
+                // This list should be kept in sync with ScreenBehaviour.
+                new GeneralSection(),
+                new SkinSection(),
+                new InputSection(createSubPanel(new KeyBindingPanel())),
+                new UserInterfaceSection(),
+                new GameplaySection()
+            };
+
+            foreach (Ruleset ruleset in rulesets.AvailableRulesets.Select(info => info.CreateInstance()))
+            {
+                try
+                {
+                    SettingsSubsection? section = ruleset.CreateSettings();
+
+                    if (section != null)
+                        sections.Add(new RulesetSection(ruleset, section));
+                }
+                catch (Exception e)
+                {
+                    RulesetStore.LogRulesetFailure(ruleset.RulesetInfo, e);
+                }
+            }
+
+            sections.AddRange(new SettingsSection[]
+            {
+                new AudioSection(),
+                new GraphicsSection(),
+                new OnlineSection(),
+                new MaintenanceSection(),
+                new DebugSection()
+            });
+
+            var today = DateTimeOffset.Now;
+            if (today.Month == 4 && today.Day == 1)
+                sections.Insert(9, new AfToggleSection());
+
+            foreach (var s in sections)
+                AddSection(s);
+
+            foreach (var s in subPanels)
+                ContentContainer.Add(s);
         }
 
         private T createSubPanel<T>(T subPanel)
@@ -127,15 +150,6 @@ namespace osu.Game.Overlays
                     ContentContainer.MoveToX(0, 500, Easing.OutQuint);
                     break;
             }
-        }
-
-        protected override float ExpandedPosition => lastOpenedSubPanel?.State.Value == Visibility.Visible ? -PANEL_WIDTH : base.ExpandedPosition;
-
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            foreach (var s in subPanels)
-                ContentContainer.Add(s);
         }
     }
 }

--- a/osu.Game/Overlays/SettingsPanel.cs
+++ b/osu.Game/Overlays/SettingsPanel.cs
@@ -11,7 +11,6 @@ using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -81,8 +80,6 @@ namespace osu.Game.Overlays
             RelativeSizeAxes = Axes.Y;
             AutoSizeAxes = Axes.X;
         }
-
-        protected virtual IEnumerable<SettingsSection> CreateSections() => null;
 
         [BackgroundDependencyLoader]
         private void load()
@@ -155,8 +152,6 @@ namespace osu.Game.Overlays
                 BackButtonAction = Hide,
                 Width = sidebar_width
             });
-
-            CreateSections()?.ForEach(AddSection);
         }
 
         protected void AddSection(SettingsSection section)

--- a/osu.Game/Rulesets/Ruleset.cs
+++ b/osu.Game/Rulesets/Ruleset.cs
@@ -346,17 +346,7 @@ namespace osu.Game.Rulesets
         /// </summary>
         /// <param name="variant">The variant.</param>
         /// <returns>A descriptive name of the variant.</returns>
-        public virtual LocalisableString GetVariantName(int variant)
-        {
-            switch (variant)
-            {
-                default:
-                    return GameplaySettingsStrings.GameplaySectionHeader;
-
-                case EDITOR_VARIANT:
-                    return EditorStrings.BeatmapEditor;
-            }
-        }
+        public virtual LocalisableString GetVariantName(int variant) => string.Empty;
 
         /// <summary>
         /// Returns the ID of the variant that is applicable for the given <paramref name="beatmapInfo"/>, given the current active <paramref name="mods"/>.


### PR DESCRIPTION
Grab bag improvements to settings UX.

- Key bindings sections show in sidebar
- Drop the "ruleset" terminology – user's don't get this and we shouldn't use it in the game IMO
- Expose ruleset settings and key bindings at a top level (with slight cosmetic nesting) for easy access

| Before | After |
| :---: | :---: |
| <img width="1484" height="1498" alt="2026-08-18 21 33 47@2x" src="https://github.com/user-attachments/assets/089b6dcb-d16f-4261-84de-40fb8f59225d" /> | <img width="1484" height="1498" alt="2026-08-18 21 32 48@2x" src="https://github.com/user-attachments/assets/4e1e2f71-f00c-44f0-ae92-631fe6647350" /> |
| <img width="1680" height="1498" alt="2026-08-18 21 34 10@2x" src="https://github.com/user-attachments/assets/45650acc-7ae7-4550-9939-ee5c68f31d05" /> | <img width="1646" height="1498" alt="2026-08-18 21 36 29@2x" src="https://github.com/user-attachments/assets/a7fb5430-6c47-46f1-80e0-f1f9be5792d1" /> |