### PR TITLE
Change extended result screen layout

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -289,7 +289,7 @@ namespace osu.Game.Rulesets.Catch
         {
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score)
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
@@ -41,6 +42,7 @@ using osu.Game.Scoring;
 using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
+using osuTK;
 
 namespace osu.Game.Rulesets.Mania
 {
@@ -424,16 +426,25 @@ namespace osu.Game.Rulesets.Mania
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y
             }),
-            new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(score.HitEvents)
+            new StatisticItem("Timing Distribution", () => new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
-                Height = 250
-            }, true),
-            new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
-            {
-                new AverageHitError(score.HitEvents),
-                new UnstableRate(score.HitEvents)
-            }), true)
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(20),
+                Children = new Drawable[]
+                {
+                    new HitEventTimingDistributionGraph(score.HitEvents)
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 220
+                    },
+                    new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                    {
+                        new AverageHitError(score.HitEvents),
+                        new UnstableRate(score.HitEvents)
+                    })
+                }
+            }, true)
         };
 
         /// <seealso cref="ManiaHitWindows"/>

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -421,7 +421,7 @@ namespace osu.Game.Rulesets.Mania
 
         public override StatisticItem[] CreateStatisticsForScore(ScoreInfo score, IBeatmap playableBeatmap) => new[]
         {
-            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
+            new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score)
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -430,7 +430,7 @@ namespace osu.Game.Rulesets.Mania
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Spacing = new Vector2(20),
+                Spacing = new Vector2(15),
                 Children = new Drawable[]
                 {
                     new HitEventTimingDistributionGraph(score.HitEvents)

--- a/osu.Game.Rulesets.Mania/ManiaRuleset.cs
+++ b/osu.Game.Rulesets.Mania/ManiaRuleset.cs
@@ -436,9 +436,9 @@ namespace osu.Game.Rulesets.Mania
                     new HitEventTimingDistributionGraph(score.HitEvents)
                     {
                         RelativeSizeAxes = Axes.X,
-                        Height = 220
+                        Height = 150
                     },
-                    new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                    new SimpleStatisticTable(1, new SimpleStatisticItem[]
                     {
                         new AverageHitError(score.HitEvents),
                         new UnstableRate(score.HitEvents)

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -350,7 +350,7 @@ namespace osu.Game.Rulesets.Osu
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score)
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -355,21 +355,30 @@ namespace osu.Game.Rulesets.Osu
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y
                 }),
-                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents)
+                new StatisticItem("Timing Distribution", () => new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = 250
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(20),
+                    Children = new Drawable[]
+                    {
+                        new HitEventTimingDistributionGraph(timedHitEvents)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 220
+                        },
+                        new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                        {
+                            new AverageHitError(timedHitEvents),
+                            new UnstableRate(timedHitEvents)
+                        })
+                    }
                 }, true),
                 new StatisticItem("Accuracy Heatmap", () => new AccuracyHeatmap(score, playableBeatmap)
                 {
                     RelativeSizeAxes = Axes.X,
                     Height = 250
                 }, true),
-                new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
-                {
-                    new AverageHitError(timedHitEvents),
-                    new UnstableRate(timedHitEvents)
-                }), true)
             };
         }
 

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -359,7 +359,7 @@ namespace osu.Game.Rulesets.Osu
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Spacing = new Vector2(20),
+                    Spacing = new Vector2(15),
                     Children = new Drawable[]
                     {
                         new HitEventTimingDistributionGraph(timedHitEvents)
@@ -377,7 +377,7 @@ namespace osu.Game.Rulesets.Osu
                 new StatisticItem("Accuracy Heatmap", () => new AccuracyHeatmap(score, playableBeatmap)
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = 150 + 20 + StatisticItem.FONT_SIZE * 2,
+                    Height = 150 + 15 + StatisticItem.FONT_SIZE * 2,
                 }, requiresHitEvents: true, fullWidth: false),
             };
         }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -365,20 +365,20 @@ namespace osu.Game.Rulesets.Osu
                         new HitEventTimingDistributionGraph(timedHitEvents)
                         {
                             RelativeSizeAxes = Axes.X,
-                            Height = 220
+                            Height = 150
                         },
-                        new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                        new SimpleStatisticTable(1, new SimpleStatisticItem[]
                         {
                             new AverageHitError(timedHitEvents),
                             new UnstableRate(timedHitEvents)
                         })
                     }
-                }, true),
+                }, requiresHitEvents: true, fullWidth: false),
                 new StatisticItem("Accuracy Heatmap", () => new AccuracyHeatmap(score, playableBeatmap)
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = 250
-                }, true),
+                    Height = 150 + 20 + StatisticItem.FONT_SIZE * 2,
+                }, requiresHitEvents: true, fullWidth: false),
             };
         }
 
@@ -440,7 +440,8 @@ namespace osu.Game.Rulesets.Osu
                 Description = OsuRulesetStrings.CircleSizeDescription,
                 AdditionalMetrics =
                 [
-                    new RulesetBeatmapAttribute.AdditionalMetric(OsuRulesetStrings.HitCircleRadius, (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize, applyFudge: true)).ToLocalisableString("0.#"))
+                    new RulesetBeatmapAttribute.AdditionalMetric(OsuRulesetStrings.HitCircleRadius,
+                        (OsuHitObject.OBJECT_RADIUS * LegacyRulesetExtensions.CalculateScaleFromCircleSize(effectiveDifficulty.CircleSize, applyFudge: true)).ToLocalisableString("0.#"))
                 ]
             };
 
@@ -474,8 +475,12 @@ namespace osu.Game.Rulesets.Osu
                                                   LocalisableString.Interpolate($@"±{hitWindows.WindowFor(window.result) / rate:0.##} ms"),
                                                   colours.ForHitResult(window.result)
                                               )).Concat([
-                                                  new RulesetBeatmapAttribute.AdditionalMetric(OsuRulesetStrings.RpmRequiredToClearSpinners, LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),
-                                                  new RulesetBeatmapAttribute.AdditionalMetric(OsuRulesetStrings.RpmRequiredToGetFullSpinnerBonus, LocalisableString.Interpolate($@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.COMPLETE_RPM_RANGE):N0} RPM")),
+                                                  new RulesetBeatmapAttribute.AdditionalMetric(OsuRulesetStrings.RpmRequiredToClearSpinners,
+                                                      LocalisableString.Interpolate(
+                                                          $@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.CLEAR_RPM_RANGE):N0} RPM")),
+                                                  new RulesetBeatmapAttribute.AdditionalMetric(OsuRulesetStrings.RpmRequiredToGetFullSpinnerBonus,
+                                                      LocalisableString.Interpolate(
+                                                          $@"{IBeatmapDifficultyInfo.DifficultyRange(modAdjustedDifficulty.OverallDifficulty, Spinner.COMPLETE_RPM_RANGE):N0} RPM")),
                                               ]).ToArray()
             };
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -279,7 +279,7 @@ namespace osu.Game.Rulesets.Taiko
 
             return new[]
             {
-                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score, playableBeatmap)
+                new StatisticItem("Performance Breakdown", () => new PerformanceBreakdownChart(score)
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -6,42 +6,44 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Legacy;
+using osu.Game.Configuration;
 using osu.Game.Graphics;
+using osu.Game.Localisation;
+using osu.Game.Localisation.Taiko;
+using osu.Game.Overlays.Settings;
+using osu.Game.Rulesets.Configuration;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Replays.Types;
 using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Rulesets.Taiko.Beatmaps;
+using osu.Game.Rulesets.Taiko.Configuration;
 using osu.Game.Rulesets.Taiko.Difficulty;
 using osu.Game.Rulesets.Taiko.Edit;
+using osu.Game.Rulesets.Taiko.Edit.Setup;
 using osu.Game.Rulesets.Taiko.Mods;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Rulesets.Taiko.Replays;
 using osu.Game.Rulesets.Taiko.Scoring;
 using osu.Game.Rulesets.Taiko.Skinning.Argon;
+using osu.Game.Rulesets.Taiko.Skinning.Default;
 using osu.Game.Rulesets.Taiko.Skinning.Legacy;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
-using osu.Game.Overlays.Settings;
 using osu.Game.Scoring;
+using osu.Game.Screens.Edit.Setup;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
-using osu.Game.Rulesets.Configuration;
-using osu.Game.Configuration;
-using osu.Game.Localisation;
-using osu.Game.Localisation.Taiko;
-using osu.Game.Rulesets.Scoring.Legacy;
-using osu.Game.Rulesets.Taiko.Configuration;
-using osu.Game.Rulesets.Taiko.Edit.Setup;
-using osu.Game.Rulesets.Taiko.Skinning.Default;
-using osu.Game.Screens.Edit.Setup;
 using osu.Game.Utils;
+using osuTK;
 
 namespace osu.Game.Rulesets.Taiko
 {
@@ -282,16 +284,25 @@ namespace osu.Game.Rulesets.Taiko
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y
                 }),
-                new StatisticItem("Timing Distribution", () => new HitEventTimingDistributionGraph(timedHitEvents)
+                new StatisticItem("Timing Distribution", () => new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
-                    Height = 250
-                }, true),
-                new StatisticItem("Statistics", () => new SimpleStatisticTable(2, new SimpleStatisticItem[]
-                {
-                    new AverageHitError(timedHitEvents),
-                    new UnstableRate(timedHitEvents)
-                }), true)
+                    AutoSizeAxes = Axes.Y,
+                    Spacing = new Vector2(20),
+                    Children = new Drawable[]
+                    {
+                        new HitEventTimingDistributionGraph(timedHitEvents)
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 220
+                        },
+                        new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                        {
+                            new AverageHitError(timedHitEvents),
+                            new UnstableRate(timedHitEvents)
+                        })
+                    }
+                }, true)
             };
         }
 

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -294,9 +294,9 @@ namespace osu.Game.Rulesets.Taiko
                         new HitEventTimingDistributionGraph(timedHitEvents)
                         {
                             RelativeSizeAxes = Axes.X,
-                            Height = 220
+                            Height = 150
                         },
-                        new SimpleStatisticTable(2, new SimpleStatisticItem[]
+                        new SimpleStatisticTable(1, new SimpleStatisticItem[]
                         {
                             new AverageHitError(timedHitEvents),
                             new UnstableRate(timedHitEvents)

--- a/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
+++ b/osu.Game.Rulesets.Taiko/TaikoRuleset.cs
@@ -288,7 +288,7 @@ namespace osu.Game.Rulesets.Taiko
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Spacing = new Vector2(20),
+                    Spacing = new Vector2(15),
                     Children = new Drawable[]
                     {
                         new HitEventTimingDistributionGraph(timedHitEvents)

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Screens;
@@ -16,6 +17,10 @@ using osu.Framework.Utils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
+using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Osu;
@@ -29,6 +34,7 @@ using osu.Game.Screens.Ranking.Expanded.Statistics;
 using osu.Game.Screens.Ranking.Statistics;
 using osu.Game.Skinning;
 using osu.Game.Tests.Resources;
+using osu.Game.Users;
 using osuTK;
 using osuTK.Input;
 using Realms;
@@ -47,6 +53,12 @@ namespace osu.Game.Tests.Visual.Ranking
         [Resolved]
         private SkinManager skins { get; set; }
 
+        private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
+
+        private BeatmapInfo beatmap;
+
+        private TestResultsContainer resultsContainer;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
@@ -54,7 +66,7 @@ namespace osu.Game.Tests.Visual.Ranking
             realm.Run(r =>
             {
                 var beatmapInfo = r.All<BeatmapInfo>()
-                                   .Filter($"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} = $0", 0)
+                                   .Filter($"{nameof(BeatmapInfo.Ruleset)}.{nameof(RulesetInfo.OnlineID)} = $0 AND {nameof(BeatmapInfo.StatusInt)} = 1", 0)
                                    .FirstOrDefault();
 
                 if (beatmapInfo != null)
@@ -77,6 +89,124 @@ namespace osu.Game.Tests.Visual.Ranking
                 if (skins != null)
                     skins.CurrentSkinInfo.Value = v ? skins.DefaultClassicSkin.SkinInfo : skins.CurrentSkinInfo.Default;
             });
+        }
+
+        [Test]
+        public void TestFullyPopulated()
+        {
+            TestResultsScreen screen = null;
+            ScoreInfo score = null;
+
+            AddStep("set up network requests", () =>
+            {
+                dummyAPI.HandleRequest = request =>
+                {
+                    switch (request)
+                    {
+                        case ListTagsRequest listTagsRequest:
+                        {
+                            Scheduler.AddDelayed(() => listTagsRequest.TriggerSuccess(new APITagCollection
+                            {
+                                Tags =
+                                [
+                                    new APITag { Id = 0, Name = "uncategorised tag", Description = "This probably isn't real but could be and should be handled.", },
+                                    new APITag { Id = 1, Name = "song representation/simple", Description = "Accessible and straightforward map design.", },
+                                    new APITag
+                                    {
+                                        Id = 2, Name = "style/clean",
+                                        Description = "Visually uncluttered and organised patterns, often involving few overlaps and equal visual spacing between objects.",
+                                    },
+                                    new APITag
+                                    {
+                                        Id = 3, Name = "aim/aim control", Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern.",
+                                    },
+                                    new APITag { Id = 4, Name = "tap/bursts", Description = "Patterns requiring continuous movement and alternating, typically 9 notes or less.", },
+                                    new APITag { Id = 5, Name = "style/long tag number 5", Description = "More tags for the sake of tags" },
+                                    new APITag { Id = 6, Name = "style/long tag number 6", Description = "More tags for the sake of tags" },
+                                    new APITag { Id = 7, Name = "style/long tag number 7", Description = "More tags for the sake of tags" },
+                                    new APITag { Id = 8, Name = "style/long tag number 8", Description = "More tags for the sake of tags" },
+                                    new APITag
+                                    {
+                                        Id = 23,
+                                        Name = "aim/aim control",
+                                        Description = "Patterns with velocity or direction changes which strongly go against a player's natural movement pattern."
+                                    }
+                                ]
+                            }), 500);
+                            return true;
+                        }
+
+                        case GetBeatmapSetRequest getBeatmapSetRequest:
+                        {
+                            var beatmapSet = CreateAPIBeatmapSet(beatmap);
+                            beatmapSet.Beatmaps.Single().TopTags =
+                            [
+                                new APIBeatmapTag { TagId = 3, VoteCount = 8 },
+                                new APIBeatmapTag { TagId = 2, VoteCount = 5 },
+                                new APIBeatmapTag { TagId = 0, VoteCount = 4 },
+                                new APIBeatmapTag { TagId = 1, VoteCount = 4 },
+                                new APIBeatmapTag { TagId = 4, VoteCount = 4 },
+                                new APIBeatmapTag { TagId = 5, VoteCount = 4 },
+                                new APIBeatmapTag { TagId = 6, VoteCount = 3 },
+                                new APIBeatmapTag { TagId = 7, VoteCount = 3 },
+                                new APIBeatmapTag { TagId = 8, VoteCount = 3 },
+                                new APIBeatmapTag { TagId = 23, VoteCount = 3 },
+                            ];
+                            Scheduler.AddDelayed(() => getBeatmapSetRequest.TriggerSuccess(beatmapSet), 100);
+                            return true;
+                        }
+
+                        case AddBeatmapTagRequest:
+                        case RemoveBeatmapTagRequest:
+                        {
+                            Scheduler.AddDelayed(request.TriggerSuccess, 100);
+                            return true;
+                        }
+                    }
+
+                    return false;
+                };
+            });
+
+            loadResultsScreen(() =>
+            {
+                score = TestResources.CreateTestScoreInfo();
+
+                score.OnlineID = onlineScoreID++;
+                score.HitEvents = TestSceneStatisticsPanel.CreatePositionDistributedHitEvents();
+                score.Accuracy = 0.99;
+                score.Rank = ScoreRank.D;
+
+                score.Statistics[HitResult.Miss] = 2;
+
+                beatmap = score.BeatmapInfo = Beatmap.Value.BeatmapInfo;
+
+                return screen = createResultsScreen(score);
+            });
+
+            AddStep("click panel", () => screen.ChildrenOfType<ScorePanel>().Single(p => p.State == PanelState.Expanded).TriggerClick());
+
+            AddStep("display overall stats update",
+                () => ((Bindable<ScoreBasedUserStatisticsUpdate>)resultsContainer.UserStatisticsWatcher.LatestUpdate).Value = new ScoreBasedUserStatisticsUpdate(score,
+                    new UserStatistics
+                    {
+                        GlobalRank = 12_345,
+                        Accuracy = 98.99,
+                        MaxCombo = 500,
+                        RankedScore = 23_123_543_456,
+                        TotalScore = 123_123_543_456,
+                        PP = 5_072
+                    },
+                    new UserStatistics
+                    {
+                        GlobalRank = 12_301,
+                        Accuracy = 99.07,
+                        MaxCombo = 999,
+                        RankedScore = 23_126_543_456,
+                        TotalScore = 123_128_543_456,
+                        PP = 5_072
+                    }
+                ));
         }
 
         private int onlineScoreID = 1;
@@ -359,7 +489,7 @@ namespace osu.Game.Tests.Visual.Ranking
         {
             ResultsScreen results = null;
 
-            AddStep("load results", () => Child = new TestResultsContainer(results = createResults()));
+            AddStep("load results", () => Child = resultsContainer = new TestResultsContainer(results = createResults()));
 
             // expanded panel should be centered the moment results screen is loaded
             // but can potentially be scrolled away on certain specific load scenarios.
@@ -378,16 +508,23 @@ namespace osu.Game.Tests.Visual.Ranking
         private partial class TestResultsContainer : Container
         {
             [Cached(typeof(Player))]
-            private readonly Player player = new TestPlayer();
+            public readonly Player Player = new TestPlayer();
+
+            [Cached(typeof(UserStatisticsWatcher))]
+            public readonly UserStatisticsWatcher UserStatisticsWatcher;
 
             public TestResultsContainer(IScreen screen)
             {
                 RelativeSizeAxes = Axes.Both;
                 OsuScreenStack stack;
 
-                InternalChild = stack = new OsuScreenStack
+                InternalChildren = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    UserStatisticsWatcher = new UserStatisticsWatcher(new LocalUserStatisticsProvider()),
+                    stack = new OsuScreenStack
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    }
                 };
 
                 stack.Push(screen);

--- a/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneResultsScreen.cs
@@ -60,14 +60,7 @@ namespace osu.Game.Tests.Visual.Ranking
                 if (beatmapInfo != null)
                     Beatmap.Value = beatmaps.GetWorkingBeatmap(beatmapInfo);
             });
-        }
 
-        [SetUp]
-        public void SetUp() => Schedule(() => skins.CurrentSkinInfo.SetDefault());
-
-        [Test]
-        public void TestScaling()
-        {
             // scheduling is needed as scaling the content immediately causes the entire scene to shake badly, for some odd reason.
             AddSliderStep("scale", 0.5f, 1.6f, 1f, v => Schedule(() =>
             {
@@ -76,8 +69,8 @@ namespace osu.Game.Tests.Visual.Ranking
             }));
         }
 
-        [Test]
-        public void TestLegacySkin()
+        [SetUpSteps]
+        public void SetUpSteps()
         {
             AddToggleStep("toggle legacy classic skin", v =>
             {

--- a/osu.Game.Tests/Visual/Ranking/TestSceneSoloResultsScreenLeaderboard.cs
+++ b/osu.Game.Tests/Visual/Ranking/TestSceneSoloResultsScreenLeaderboard.cs
@@ -25,7 +25,7 @@ using osu.Game.Tests.Resources;
 
 namespace osu.Game.Tests.Visual.Ranking
 {
-    public partial class TestSceneSoloResultsScreen : ScreenTestScene
+    public partial class TestSceneSoloResultsScreenLeaderboard : ScreenTestScene
     {
         private ScoreManager scoreManager = null!;
         private RulesetStore rulesetStore = null!;

--- a/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
+++ b/osu.Game/Screens/Ranking/Statistics/PerformanceBreakdownChart.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         [Resolved]
         private BeatmapDifficultyCache difficultyCache { get; set; } = null!;
 
-        public PerformanceBreakdownChart(ScoreInfo score, IBeatmap playableBeatmap)
+        public PerformanceBreakdownChart(ScoreInfo score)
         {
             this.score = score;
         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -32,16 +32,19 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// </summary>
         public readonly bool RequiresHitEvents;
 
+        public readonly bool FullWidth;
+
         /// <summary>
         /// Creates a new <see cref="StatisticItem"/>, to be displayed in the results screen.
         /// </summary>
         /// <param name="name">The name of the item. Can be <see langword="null"/> to hide the item header.</param>
         /// <param name="createContent">A function returning the <see cref="Drawable"/> content to be displayed.</param>
         /// <param name="requiresHitEvents">Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.</param>
-        public StatisticItem(LocalisableString name, Func<Drawable> createContent, bool requiresHitEvents = false)
+        public StatisticItem(LocalisableString name, Func<Drawable> createContent, bool requiresHitEvents = false, bool fullWidth = true)
         {
             Name = name;
             RequiresHitEvents = requiresHitEvents;
+            FullWidth = fullWidth;
             CreateContent = createContent;
         }
     }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItem.cs
@@ -40,6 +40,7 @@ namespace osu.Game.Screens.Ranking.Statistics
         /// <param name="name">The name of the item. Can be <see langword="null"/> to hide the item header.</param>
         /// <param name="createContent">A function returning the <see cref="Drawable"/> content to be displayed.</param>
         /// <param name="requiresHitEvents">Whether this item requires hit events. If true, <see cref="CreateContent"/> will not be called if no hit events are available.</param>
+        /// <param name="fullWidth">Whether the statistic should take full width, instead of half.</param>
         public StatisticItem(LocalisableString name, Func<Drawable> createContent, bool requiresHitEvents = false, bool fullWidth = true)
         {
             Name = name;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -5,9 +5,11 @@ using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Localisation;
 using osu.Game.Graphics;
+using osuTK.Graphics;
 
 namespace osu.Game.Screens.Ranking.Statistics
 {
@@ -35,7 +37,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 Masking = true,
                 CornerRadius = 20,
                 CornerExponent = 2.5f,
-                Children = new Drawable[]
+                Children = new[]
                 {
                     new Box
                     {
@@ -52,18 +54,73 @@ namespace osu.Game.Screens.Ranking.Statistics
                         Padding = new MarginPadding(2),
                         Children = new[]
                         {
-                            LocalisableString.IsNullOrEmpty(item.Name) ? Empty() : new StatisticItemHeader { Text = item.Name },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
                                 Padding = new MarginPadding(15) { Top = 40 },
                                 Child = item.CreateContent()
-                            }
+                            },
                         }
                     },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Colour = ColourInfo.GradientVertical(
+                                    OsuColour.Gray(0.25f),
+                                    OsuColour.Gray(0.25f).Opacity(0)
+                                ),
+                                RelativeSizeAxes = Axes.X,
+                                Height = 30,
+                            },
+                            new Box
+                            {
+                                Anchor = Anchor.BottomLeft,
+                                Origin = Anchor.BottomLeft,
+                                Colour = ColourInfo.GradientVertical(
+                                    OsuColour.Gray(0.18f).Opacity(0),
+                                    OsuColour.Gray(0.18f)
+                                ),
+                                RelativeSizeAxes = Axes.X,
+                                Height = 20,
+                            },
+                        }
+                    },
+                    LocalisableString.IsNullOrEmpty(item.Name)
+                        ? Empty()
+                        : new StatisticItemHeader
+                        {
+                            Text = item.Name
+                        },
                 }
             };
+
+            AddInternal(new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Masking = true,
+                CornerRadius = 20,
+                CornerExponent = 2.5f,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Radius = 2,
+                    Hollow = true,
+                    Colour = OsuColour.Gray(0.18f),
+                    Type = EdgeEffectType.Shadow,
+                },
+                Children = new[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.Transparent,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                }
+            });
         }
     }
 }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -57,7 +57,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                             {
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
-                                Padding = new MarginPadding(10) { Top = 45 },
+                                Padding = new MarginPadding(15) { Top = 40 },
                                 Child = item.CreateContent()
                             }
                         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemContainer.cs
@@ -26,13 +26,15 @@ namespace osu.Game.Screens.Ranking.Statistics
             AutoSizeAxes = Axes.Y;
 
             Padding = new MarginPadding(5);
+            Width = item.FullWidth ? 1 : 0.5f;
 
             InternalChild = new Container
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
                 Masking = true,
-                CornerRadius = 10,
+                CornerRadius = 20,
+                CornerExponent = 2.5f,
                 Children = new Drawable[]
                 {
                     new Box
@@ -47,17 +49,15 @@ namespace osu.Game.Screens.Ranking.Statistics
                     {
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Padding = new MarginPadding(5),
+                        Padding = new MarginPadding(2),
                         Children = new[]
                         {
-                            LocalisableString.IsNullOrEmpty(item.Name)
-                                ? Empty()
-                                : new StatisticItemHeader { Text = item.Name },
+                            LocalisableString.IsNullOrEmpty(item.Name) ? Empty() : new StatisticItemHeader { Text = item.Name },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
-                                Padding = new MarginPadding(20) { Top = 45 },
+                                Padding = new MarginPadding(10) { Top = 45 },
                                 Child = item.CreateContent()
                             }
                         }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticItemHeader.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticItemHeader.cs
@@ -37,30 +37,33 @@ namespace osu.Game.Screens.Ranking.Statistics
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
 
-            InternalChild = new Container
+            InternalChildren = new Drawable[]
             {
-                AutoSizeAxes = Axes.Both,
-                Margin = new MarginPadding
+                new Container
                 {
-                    Horizontal = 10,
-                    Top = 5,
-                    Bottom = 20,
-                },
-                Children = new Drawable[]
-                {
-                    spriteText = new OsuSpriteText
+                    AutoSizeAxes = Axes.Both,
+                    Margin = new MarginPadding
                     {
-                        Text = text,
-                        Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                        Horizontal = 12,
+                        Top = 8,
+                        Bottom = 20,
                     },
-                    new Box
+                    Children = new Drawable[]
                     {
-                        Anchor = Anchor.BottomCentre,
-                        Origin = Anchor.TopCentre,
-                        Margin = new MarginPadding { Top = 4 },
-                        RelativeSizeAxes = Axes.X,
-                        Height = 2,
-                        Colour = Color4Extensions.FromHex("#66FFCC")
+                        spriteText = new OsuSpriteText
+                        {
+                            Text = text,
+                            Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                        },
+                        new Box
+                        {
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.TopCentre,
+                            Margin = new MarginPadding { Top = 4 },
+                            RelativeSizeAxes = Axes.X,
+                            Height = 2,
+                            Colour = Color4Extensions.FromHex("#66FFCC")
+                        }
                     }
                 }
             };

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -70,8 +70,6 @@ namespace osu.Game.Screens.Ranking.Statistics
                 {
                     Left = ScorePanel.EXPANDED_WIDTH + SIDE_PADDING * 2,
                     Right = SIDE_PADDING,
-                    Top = ScorePanel.EXPANDED_TOP_LAYER_HEIGHT,
-                    Bottom = 15 // Approximate padding to the bottom of the score panel.
                 },
                 Children = new Drawable[]
                 {

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 {
     public partial class StatisticsPanel : VisibilityContainer
     {
-        public const float SIDE_PADDING = 30;
+        public const float SIDE_PADDING = 20;
 
         public readonly Bindable<ScoreInfo?> Score = new Bindable<ScoreInfo?>();
 
@@ -142,24 +142,14 @@ namespace osu.Game.Screens.Ranking.Statistics
                 else
                 {
                     FillFlowContainer flow;
-                    container = new OsuScrollContainer(Direction.Vertical)
+                    container = flow = new FillFlowContainer
                     {
-                        RelativeSizeAxes = Axes.Both,
+                        Alpha = 0,
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
-                        Masking = false,
-                        ScrollbarOverlapsContent = false,
-                        Alpha = 0,
-                        Children = new[]
-                        {
-                            flow = new FillFlowContainer
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                Spacing = new Vector2(30, 10),
-                                Direction = FillDirection.Full,
-                            }
-                        }
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Full,
                     };
 
                     bool anyRequiredHitEvents = false;

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -12,6 +12,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
@@ -262,31 +263,42 @@ namespace osu.Game.Screens.Ranking.Statistics
                 }
                 else
                 {
-                    yield return new StatisticItem("Beatmap tags", () => new FillFlowContainer<CompositeDrawable>
+                    yield return new StatisticItem("Beatmap tags", () => new Container
                     {
-                        Children = new CompositeDrawable[]
+                        Children = new Drawable[]
                         {
-                            new OsuTextFlowContainer(cp => cp.Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold))
-                            {
-                                RelativeSizeAxes = Axes.X,
-                                AutoSizeAxes = Axes.Y,
-                                TextAnchor = Anchor.Centre,
-                                Text = preventTaggingReason,
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                            },
                             new UserTagControl(newScore.BeatmapInfo)
                             {
                                 Writable = false,
                                 RelativeSizeAxes = Axes.X,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                            },
+                            new Container
+                            {
                                 Anchor = Anchor.Centre,
                                 Origin = Anchor.Centre,
-                            }
+                                AutoSizeAxes = Axes.Both,
+                                Masking = true,
+                                EdgeEffect = new EdgeEffectParameters
+                                {
+                                    Radius = 60,
+                                    Roundness = 8,
+                                    Colour = OsuColour.Gray(0.18f),
+                                    Type = EdgeEffectType.Shadow,
+                                },
+                                Children = new Drawable[]
+                                {
+                                    new OsuTextFlowContainer(cp => cp.Font = OsuFont.GetFont(size: StatisticItem.FONT_SIZE, weight: FontWeight.SemiBold))
+                                    {
+                                        AutoSizeAxes = Axes.Both,
+                                        Text = preventTaggingReason,
+                                    },
+                                }
+                            },
                         },
                         RelativeSizeAxes = Axes.X,
                         AutoSizeAxes = Axes.Y,
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(4),
                     });
                 }
             }

--- a/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
+++ b/osu.Game/Screens/Ranking/Statistics/StatisticsPanel.cs
@@ -252,7 +252,7 @@ namespace osu.Game.Screens.Ranking.Statistics
 
                 if (preventTaggingReason == null)
                 {
-                    yield return new StatisticItem("Tag the beatmap!", () => new UserTagControl(newScore.BeatmapInfo)
+                    yield return new StatisticItem("Beatmap tags", () => new UserTagControl(newScore.BeatmapInfo)
                     {
                         Writable = true,
                         RelativeSizeAxes = Axes.X,
@@ -262,7 +262,7 @@ namespace osu.Game.Screens.Ranking.Statistics
                 }
                 else
                 {
-                    yield return new StatisticItem("Tag the beatmap!", () => new FillFlowContainer<CompositeDrawable>
+                    yield return new StatisticItem("Beatmap tags", () => new FillFlowContainer<CompositeDrawable>
                     {
                         Children = new CompositeDrawable[]
                         {

--- a/osu.Game/Screens/Ranking/UserTagControl.cs
+++ b/osu.Game/Screens/Ranking/UserTagControl.cs
@@ -18,6 +18,7 @@ using osu.Framework.Input.Events;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Extensions;
+using osu.Game.Graphics.Containers;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -67,52 +68,39 @@ namespace osu.Game.Screens.Ranking
 
             InternalChildren = new Drawable[]
             {
-                new GridContainer
+                new OsuScrollContainer
                 {
                     RelativeSizeAxes = Axes.X,
-                    AutoSizeAxes = Axes.Y,
-                    Padding = new MarginPadding(10),
-                    ColumnDimensions =
-                    [
-                        new Dimension(),
-                        new Dimension(GridSizeMode.AutoSize)
-                    ],
-                    RowDimensions = [new Dimension(GridSizeMode.AutoSize, minSize: 40)],
-                    Content = new[]
+                    Height = 48,
+                    Masking = false,
+                    Child = new FillFlowContainer
                     {
-                        new Drawable[]
+                        Direction = FillDirection.Vertical,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(8),
+                        Children = new Drawable[]
                         {
-                            new FillFlowContainer
+                            tagFlow = new FillFlowContainer<DrawableUserTag>
                             {
-                                Direction = FillDirection.Vertical,
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
-                                Spacing = new Vector2(8),
-                                Children = new Drawable[]
-                                {
-                                    tagFlow = new FillFlowContainer<DrawableUserTag>
-                                    {
-                                        RelativeSizeAxes = Axes.X,
-                                        AutoSizeAxes = Axes.Y,
-                                        Direction = FillDirection.Full,
-                                        Spacing = new Vector2(4),
-                                        Children = Writable
-                                            ?
-                                            [
-                                                addNewTagUserTag = new AddNewTagUserTag
-                                                {
-                                                    AvailableTags = { BindTarget = relevantTagsById },
-                                                    OnTagSelected = toggleVote,
-                                                }
-                                            ]
-                                            : []
-                                    }
-                                },
-                            },
-                        }
-                    }
-                },
+                                Direction = FillDirection.Full,
+                                Spacing = new Vector2(4),
+                            }
+                        },
+                    },
+                }
             };
+
+            if (Writable)
+            {
+                tagFlow.Add(addNewTagUserTag = new AddNewTagUserTag
+                {
+                    AvailableTags = { BindTarget = relevantTagsById },
+                    OnTagSelected = toggleVote,
+                });
+            }
 
             apiTags = sessionStatics.GetBindable<APITag[]?>(Static.AllBeatmapTags);
 


### PR DESCRIPTION
Before: 
<img width="1368" height="800" alt="image" src="https://github.com/user-attachments/assets/f89b716b-c60e-48d1-a198-29ed002f5030" />

After:
<img width="1368" height="800" alt="image" src="https://github.com/user-attachments/assets/a443bfd2-830a-4ad2-8d7a-15dfedcb2fba" />


It always annoyed me that UR/hiterror stats are both off-screen and under the aim distribution graph for some reason. 

`HitEventTimingDistributionGraph` height has been shrunk slightly to make it so that new stats don't make already giant timing panel even bigger (i'd love to make it even smaller cos i've seen complaints from people that it's just way too big)