### PR TITLE
Adjust operation of left sidebar toggles in editor

### DIFF
--- a/osu.Game.Rulesets.Catch/CatchInputManager.cs
+++ b/osu.Game.Rulesets.Catch/CatchInputManager.cs
@@ -37,5 +37,8 @@ namespace osu.Game.Rulesets.Catch
 
         [LocalisableDescription(typeof(CatchEditorStrings), nameof(CatchEditorStrings.BananaShowerTool))]
         EditorBananaShowerTool,
+
+        [LocalisableDescription(typeof(CatchEditorStrings), nameof(CatchEditorStrings.ToggleDistanceSnap))]
+        EditorToggleDistanceSnap,
     }
 }

--- a/osu.Game.Rulesets.Catch/CatchInputManager.cs
+++ b/osu.Game.Rulesets.Catch/CatchInputManager.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Localisation;
+using osu.Game.Localisation;
 using osu.Game.Localisation.Catch;
 using osu.Game.Rulesets.UI;
 
@@ -38,7 +39,7 @@ namespace osu.Game.Rulesets.Catch
         [LocalisableDescription(typeof(CatchEditorStrings), nameof(CatchEditorStrings.BananaShowerTool))]
         EditorBananaShowerTool,
 
-        [LocalisableDescription(typeof(CatchEditorStrings), nameof(CatchEditorStrings.ToggleDistanceSnap))]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleDistanceSnap))]
         EditorToggleDistanceSnap,
     }
 }

--- a/osu.Game.Rulesets.Catch/CatchRuleset.cs
+++ b/osu.Game.Rulesets.Catch/CatchRuleset.cs
@@ -80,6 +80,7 @@ namespace osu.Game.Rulesets.Catch
                         new KeyBinding(InputKey.Number2, CatchAction.EditorFruitTool),
                         new KeyBinding(InputKey.Number3, CatchAction.EditorJuiceStreamTool),
                         new KeyBinding(InputKey.Number4, CatchAction.EditorBananaShowerTool),
+                        new KeyBinding(InputKey.T, CatchAction.EditorToggleDistanceSnap),
                     ];
             }
         }

--- a/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchBlueprintContainer.cs
@@ -3,16 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Catch.Edit.Blueprints;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -26,29 +21,6 @@ namespace osu.Game.Rulesets.Catch.Edit
             : base(composer)
         {
         }
-
-        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        Icon = OsuIcon.EditorFruit,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new CatchSelectionHandler();
 

--- a/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Catch/Edit/CatchDistanceSnapProvider.cs
@@ -2,9 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 
 namespace osu.Game.Rulesets.Catch.Edit
 {
@@ -24,5 +29,17 @@ namespace osu.Game.Rulesets.Catch.Edit
 
             return actualDistance / expectedDistance;
         }
+
+        public override IEnumerable<DrawableTernaryButton> CreateTernaryButtons() => new[]
+        {
+            new DrawableTernaryButton<CatchAction>
+            {
+                Current = DistanceSnapToggle,
+                Description = "Distance Snap",
+                CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorDistanceSnap },
+                Action = CatchAction.EditorToggleDistanceSnap,
+                Hotkey = new Hotkey(CatchRuleset.SHORT_NAME, Ruleset.EDITOR_VARIANT, (int)CatchAction.EditorToggleDistanceSnap),
+            }
+        };
     }
 }

--- a/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Mania/Edit/ManiaBlueprintContainer.cs
@@ -3,16 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mania.Edit.Blueprints;
 using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Objects;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -26,29 +21,6 @@ namespace osu.Game.Rulesets.Mania.Edit
             : base(composer)
         {
         }
-
-        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        Icon = OsuIcon.EditorNote,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
 
         public override HitObjectSelectionBlueprint? CreateHitObjectBlueprintFor(HitObject hitObject)
         {

--- a/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuDistanceSnapProvider.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Graphics.Sprites;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
@@ -9,6 +12,7 @@ using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Rulesets.Osu.Beatmaps;
 using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
 
 namespace osu.Game.Rulesets.Osu.Edit
@@ -37,5 +41,17 @@ namespace osu.Game.Rulesets.Osu.Edit
 
             return base.AdjustDistanceSpacing(action, amount);
         }
+
+        public override IEnumerable<DrawableTernaryButton> CreateTernaryButtons() => new[]
+        {
+            new DrawableTernaryButton<OsuAction>
+            {
+                Current = DistanceSnapToggle,
+                Description = "Distance Snap",
+                CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorDistanceSnap },
+                Action = OsuAction.EditorToggleDistanceSnap,
+                Hotkey = new Hotkey(OsuRuleset.SHORT_NAME, Ruleset.EDITOR_VARIANT, (int)OsuAction.EditorToggleDistanceSnap),
+            }
+        };
     }
 }

--- a/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
+++ b/osu.Game.Rulesets.Osu/Edit/OsuHitObjectComposer.cs
@@ -63,11 +63,13 @@ namespace osu.Game.Rulesets.Osu.Edit
 
         protected override IEnumerable<Drawable> CreateTernaryButtons()
             => base.CreateTernaryButtons()
-                   .Append(new DrawableTernaryButton
+                   .Append(new DrawableTernaryButton<OsuAction>
                    {
                        Current = rectangularGridSnapToggle,
                        Description = "Grid Snap",
                        CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorGridSnap },
+                       Action = OsuAction.EditorToggleGridSnap,
+                       Hotkey = HotkeyForAction(OsuAction.EditorToggleGridSnap)
                    })
                    .Concat(DistanceSnapProvider.CreateTernaryButtons());
 

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -126,5 +126,11 @@ namespace osu.Game.Rulesets.Osu
 
         [LocalisableDescription(typeof(OsuEditorStrings), nameof(OsuEditorStrings.GridFromPointsTool))]
         EditorGridFromPointsTool,
+
+        [LocalisableDescription(typeof(OsuEditorStrings), nameof(OsuEditorStrings.ToggleGridSnap))]
+        EditorToggleGridSnap,
+
+        [LocalisableDescription(typeof(OsuEditorStrings), nameof(OsuEditorStrings.ToggleDistanceSnap))]
+        EditorToggleDistanceSnap,
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuInputManager.cs
+++ b/osu.Game.Rulesets.Osu/OsuInputManager.cs
@@ -9,6 +9,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Lists;
 using osu.Framework.Localisation;
 using osu.Game.Input.Bindings;
+using osu.Game.Localisation;
 using osu.Game.Localisation.Osu;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
@@ -130,7 +131,7 @@ namespace osu.Game.Rulesets.Osu
         [LocalisableDescription(typeof(OsuEditorStrings), nameof(OsuEditorStrings.ToggleGridSnap))]
         EditorToggleGridSnap,
 
-        [LocalisableDescription(typeof(OsuEditorStrings), nameof(OsuEditorStrings.ToggleDistanceSnap))]
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleDistanceSnap))]
         EditorToggleDistanceSnap,
     }
 }

--- a/osu.Game.Rulesets.Osu/OsuRuleset.cs
+++ b/osu.Game.Rulesets.Osu/OsuRuleset.cs
@@ -87,6 +87,8 @@ namespace osu.Game.Rulesets.Osu
                         new KeyBinding(InputKey.Number3, OsuAction.EditorSliderTool),
                         new KeyBinding(InputKey.Number4, OsuAction.EditorSpinnerTool),
                         new KeyBinding(InputKey.Number5, OsuAction.EditorGridFromPointsTool),
+                        new KeyBinding(InputKey.T, OsuAction.EditorToggleGridSnap),
+                        new KeyBinding(InputKey.Y, OsuAction.EditorToggleDistanceSnap),
                     ];
             }
         }

--- a/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/TaikoBlueprintContainer.cs
@@ -3,15 +3,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Graphics;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Taiko.Edit.Blueprints;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
 
@@ -25,29 +20,6 @@ namespace osu.Game.Rulesets.Taiko.Edit
             : base(composer)
         {
         }
-
-        protected override Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        Icon = OsuIcon.EditorHit,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
 
         protected override SelectionHandler<HitObject> CreateSelectionHandler() => new TaikoSelectionHandler();
 

--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -433,10 +433,12 @@ namespace osu.Game.Tests.Visual.Editing
             AddStep("select drum bank", () =>
             {
                 InputManager.PressKey(Key.LShift);
+                InputManager.Key(Key.R);
+                InputManager.ReleaseKey(Key.LShift);
+
                 InputManager.PressKey(Key.LAlt);
                 InputManager.Key(Key.R);
                 InputManager.ReleaseKey(Key.LAlt);
-                InputManager.ReleaseKey(Key.LShift);
             });
             AddStep("enable clap addition", () => InputManager.Key(Key.R));
 

--- a/osu.Game/Graphics/UserInterface/OsuButton.cs
+++ b/osu.Game/Graphics/UserInterface/OsuButton.cs
@@ -138,7 +138,7 @@ namespace osu.Game.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (Enabled.Value)
-                flashLayer.FadeOutFromOne(800, Easing.OutQuint);
+                flashLayer.FadeOutFromOne(500, Easing.OutQuint);
 
             return base.OnClick(e);
         }

--- a/osu.Game/Input/Bindings/GlobalActionContainer.cs
+++ b/osu.Game/Input/Bindings/GlobalActionContainer.cs
@@ -131,6 +131,18 @@ namespace osu.Game.Input.Bindings
             new KeyBinding(new[] { InputKey.F4 }, GlobalAction.EditorSetupMode),
             new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, GlobalAction.EditorVerifyMode),
             new KeyBinding(new[] { InputKey.Number1 }, GlobalAction.EditorSelectTool),
+            new KeyBinding(new[] { InputKey.Q }, GlobalAction.EditorToggleNewCombo),
+            new KeyBinding(new[] { InputKey.W }, GlobalAction.EditorToggleWhistleSound),
+            new KeyBinding(new[] { InputKey.E }, GlobalAction.EditorToggleFinishSound),
+            new KeyBinding(new[] { InputKey.R }, GlobalAction.EditorToggleClapSound),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.Q }, GlobalAction.EditorToggleNormalAutoBank),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.W }, GlobalAction.EditorToggleNormalNormalBank),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.E }, GlobalAction.EditorToggleNormalSoftBank),
+            new KeyBinding(new[] { InputKey.Shift, InputKey.R }, GlobalAction.EditorToggleNormalDrumBank),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Q }, GlobalAction.EditorToggleAdditionAutoBank),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.W }, GlobalAction.EditorToggleAdditionNormalBank),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.E }, GlobalAction.EditorToggleAdditionSoftBank),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.R }, GlobalAction.EditorToggleAdditionDrumBank),
             new KeyBinding(new[] { InputKey.Control, InputKey.D }, GlobalAction.EditorCloneSelection),
             new KeyBinding(new[] { InputKey.J }, GlobalAction.EditorNudgeLeft),
             new KeyBinding(new[] { InputKey.K }, GlobalAction.EditorNudgeRight),
@@ -544,6 +556,42 @@ namespace osu.Game.Input.Bindings
 
         [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.SelectTool))]
         EditorSelectTool,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleNewCombo))]
+        EditorToggleNewCombo,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleWhistleSound))]
+        EditorToggleWhistleSound,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleFinishSound))]
+        EditorToggleFinishSound,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleClapSound))]
+        EditorToggleClapSound,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleNormalAutoBank))]
+        EditorToggleNormalAutoBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleNormalNormalBank))]
+        EditorToggleNormalNormalBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleNormalSoftBank))]
+        EditorToggleNormalSoftBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleNormalDrumBank))]
+        EditorToggleNormalDrumBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleAdditionAutoBank))]
+        EditorToggleAdditionAutoBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleAdditionNormalBank))]
+        EditorToggleAdditionNormalBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleAdditionSoftBank))]
+        EditorToggleAdditionSoftBank,
+
+        [LocalisableDescription(typeof(EditorStrings), nameof(EditorStrings.ToggleAdditionDrumBank))]
+        EditorToggleAdditionDrumBank,
     }
 
     public enum GlobalActionCategory

--- a/osu.Game/Localisation/Catch/CatchEditorStrings.cs
+++ b/osu.Game/Localisation/Catch/CatchEditorStrings.cs
@@ -24,6 +24,11 @@ namespace osu.Game.Localisation.Catch
         /// </summary>
         public static LocalisableString BananaShowerTool => new TranslatableString(getKey(@"banana_shower_tool"), @"Banana shower");
 
+        /// <summary>
+        /// "Toggle distance snap grid"
+        /// </summary>
+        public static LocalisableString ToggleDistanceSnap => new TranslatableString(getKey(@"toggle_distance_snap"), @"Toggle distance snap grid");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/Catch/CatchEditorStrings.cs
+++ b/osu.Game/Localisation/Catch/CatchEditorStrings.cs
@@ -24,11 +24,6 @@ namespace osu.Game.Localisation.Catch
         /// </summary>
         public static LocalisableString BananaShowerTool => new TranslatableString(getKey(@"banana_shower_tool"), @"Banana shower");
 
-        /// <summary>
-        /// "Toggle distance snap grid"
-        /// </summary>
-        public static LocalisableString ToggleDistanceSnap => new TranslatableString(getKey(@"toggle_distance_snap"), @"Toggle distance snap grid");
-
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -52,7 +52,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Move already placed objects when changing timing"
         /// </summary>
-        public static LocalisableString AdjustExistingObjectsOnTimingChanges => new TranslatableString(getKey(@"adjust_existing_objects_on_timing_changes"), @"Move already placed objects when changing timing");
+        public static LocalisableString AdjustExistingObjectsOnTimingChanges =>
+            new TranslatableString(getKey(@"adjust_existing_objects_on_timing_changes"), @"Move already placed objects when changing timing");
 
         /// <summary>
         /// "For editing (.olz)"
@@ -272,7 +273,8 @@ namespace osu.Game.Localisation
         /// <summary>
         /// "Any changes made to the exported folder will be imported to the game, including file additions, modifications and deletions."
         /// </summary>
-        public static LocalisableString ExternalEditMountedExplanation => new TranslatableString(getKey(@"external_edit_mounted_explanation"), @"Any changes made to the exported folder will be imported to the game, including file additions, modifications and deletions.");
+        public static LocalisableString ExternalEditMountedExplanation => new TranslatableString(getKey(@"external_edit_mounted_explanation"),
+            @"Any changes made to the exported folder will be imported to the game, including file additions, modifications and deletions.");
 
         /// <summary>
         /// "New combo"
@@ -313,6 +315,66 @@ namespace osu.Game.Localisation
         /// "Select"
         /// </summary>
         public static LocalisableString SelectTool => new TranslatableString(getKey(@"select_tool"), @"Select");
+
+        /// <summary>
+        /// "Toggle new combo"
+        /// </summary>
+        public static LocalisableString ToggleNewCombo => new TranslatableString(getKey(@"toggle_new_combo"), @"Toggle new combo");
+
+        /// <summary>
+        /// "Toggle whistle sound"
+        /// </summary>
+        public static LocalisableString ToggleWhistleSound => new TranslatableString(getKey(@"toggle_whistle_sound"), @"Toggle whistle sound");
+
+        /// <summary>
+        /// "Toggle finish sound"
+        /// </summary>
+        public static LocalisableString ToggleFinishSound => new TranslatableString(getKey(@"toggle_finish_sound"), @"Toggle finish sound");
+
+        /// <summary>
+        /// "Toggle clap sound"
+        /// </summary>
+        public static LocalisableString ToggleClapSound => new TranslatableString(getKey(@"toggle_clap_sound"), @"Toggle clap sound");
+
+        /// <summary>
+        /// "Set normal sample bank to auto"
+        /// </summary>
+        public static LocalisableString ToggleNormalAutoBank => new TranslatableString(getKey(@"toggle_normal_auto_bank"), @"Set normal sample bank to auto");
+
+        /// <summary>
+        /// "Set normal sample bank to normal"
+        /// </summary>
+        public static LocalisableString ToggleNormalNormalBank => new TranslatableString(getKey(@"toggle_normal_normal_bank"), @"Set normal sample bank to normal");
+
+        /// <summary>
+        /// "Set normal sample bank to soft"
+        /// </summary>
+        public static LocalisableString ToggleNormalSoftBank => new TranslatableString(getKey(@"toggle_normal_soft_bank"), @"Set normal sample bank to soft");
+
+        /// <summary>
+        /// "Set normal sample bank to drum"
+        /// </summary>
+        public static LocalisableString ToggleNormalDrumBank => new TranslatableString(getKey(@"toggle_normal_drum_bank"), @"Set normal sample bank to drum");
+
+        /// <summary>
+        /// "Set addition sample bank to auto"
+        /// </summary>
+        public static LocalisableString ToggleAdditionAutoBank => new TranslatableString(getKey(@"toggle_addition_auto_bank"), @"Set addition sample bank to auto");
+
+        /// <summary>
+        /// "Set addition sample bank to normal"
+        /// </summary>
+        public static LocalisableString ToggleAdditionNormalBank => new TranslatableString(getKey(@"toggle_addition_normal_bank"), @"Set addition sample bank to normal");
+
+        /// <summary>
+        /// "Set addition sample bank to soft"
+        /// </summary>
+        public static LocalisableString ToggleAdditionSoftBank => new TranslatableString(getKey(@"toggle_addition_soft_bank"), @"Set addition sample bank to soft");
+
+        /// <summary>
+        /// "Set addition sample bank to drum"
+        /// </summary>
+        public static LocalisableString ToggleAdditionDrumBank => new TranslatableString(getKey(@"toggle_addition_drum_bank"), @"Set addition sample bank to drum");
 
         private static string getKey(string key) => $@"{prefix}:{key}";
     }

--- a/osu.Game/Localisation/EditorStrings.cs
+++ b/osu.Game/Localisation/EditorStrings.cs
@@ -381,6 +381,11 @@ namespace osu.Game.Localisation
         /// </summary>
         public static LocalisableString ToggleAdditionDrumBank => new TranslatableString(getKey(@"toggle_addition_drum_bank"), @"Set addition sample bank to drum");
 
+        /// <summary>
+        /// "Toggle distance snap grid"
+        /// </summary>
+        public static LocalisableString ToggleDistanceSnap => new TranslatableString(getKey(@"toggle_distance_snap"), @"Toggle distance snap grid");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/Osu/OsuEditorStrings.cs
+++ b/osu.Game/Localisation/Osu/OsuEditorStrings.cs
@@ -29,6 +29,16 @@ namespace osu.Game.Localisation.Osu
         /// </summary>
         public static LocalisableString GridFromPointsTool => new TranslatableString(getKey(@"grid_from_points_tool"), @"Grid");
 
+        /// <summary>
+        /// "Toggle position snap grid"
+        /// </summary>
+        public static LocalisableString ToggleGridSnap => new TranslatableString(getKey(@"toggle_grid_snap"), @"Toggle position snap grid");
+
+        /// <summary>
+        /// "Toggle distance snap grid"
+        /// </summary>
+        public static LocalisableString ToggleDistanceSnap => new TranslatableString(getKey(@"toggle_distance_snap"), @"Toggle distance snap grid");
+
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Localisation/Osu/OsuEditorStrings.cs
+++ b/osu.Game/Localisation/Osu/OsuEditorStrings.cs
@@ -34,11 +34,6 @@ namespace osu.Game.Localisation.Osu
         /// </summary>
         public static LocalisableString ToggleGridSnap => new TranslatableString(getKey(@"toggle_grid_snap"), @"Toggle position snap grid");
 
-        /// <summary>
-        /// "Toggle distance snap grid"
-        /// </summary>
-        public static LocalisableString ToggleDistanceSnap => new TranslatableString(getKey(@"toggle_distance_snap"), @"Toggle distance snap grid");
-
         private static string getKey(string key) => $@"{prefix}:{key}";
     }
 }

--- a/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
+++ b/osu.Game/Rulesets/Edit/ComposerDistanceSnapProvider.cs
@@ -9,12 +9,10 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.LocalisationExtensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Framework.Utils;
-using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Input;
 using osu.Game.Input.Bindings;
@@ -193,15 +191,7 @@ namespace osu.Game.Rulesets.Edit
             }
         }
 
-        public IEnumerable<DrawableTernaryButton> CreateTernaryButtons() => new[]
-        {
-            new DrawableTernaryButton
-            {
-                Current = DistanceSnapToggle,
-                Description = "Distance Snap",
-                CreateIcon = () => new SpriteIcon { Icon = OsuIcon.EditorDistanceSnap },
-            }
-        };
+        public abstract IEnumerable<DrawableTernaryButton> CreateTernaryButtons();
 
         public void HandleToggleViaKey(KeyboardEvent key)
         {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.SelectionState.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.SelectionState.cs
@@ -6,12 +6,18 @@ using System.Collections.Generic;
 using System.Linq;
 using Humanizer;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
 using osu.Game.Audio;
+using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose.Components.Timeline;
 using osu.Game.Utils;
+using osuTK;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -284,6 +290,108 @@ namespace osu.Game.Rulesets.Edit
 
         #endregion
 
+        #region Ternary button creation
+
+        /// <summary>
+        /// Create all ternary states required to be displayed to the user.
+        /// </summary>
+        protected virtual IEnumerable<Drawable> CreateTernaryButtons()
+        {
+            if (SelectionNewComboState != null && CompositionTools.Count > 0)
+            {
+                yield return new NewComboTernaryButton
+                {
+                    Current = SelectionNewComboState,
+                    CreateIcon = () => new Container
+                    {
+                        Children = new[]
+                        {
+                            CompositionTools[0].CreateIcon()?.With(d =>
+                            {
+                                d.Anchor = Anchor.BottomLeft;
+                                d.Origin = Anchor.BottomLeft;
+                                d.Size = new Vector2(15);
+                            }) ?? Empty(),
+                            new SpriteIcon
+                            {
+                                Icon = OsuIcon.EditorNewComboSparkles,
+                                Size = new Vector2(20),
+                            }
+                        },
+                    },
+                };
+            }
+
+            foreach (var kvp in SelectionSampleStates)
+            {
+                yield return new DrawableTernaryButton
+                {
+                    Current = kvp.Value,
+                    Description = kvp.Key.Replace(@"hit", string.Empty).Titleize(),
+                    CreateIcon = () => GetIconForSample(kvp.Key),
+                };
+            }
+        }
+
+        private IEnumerable<SampleBankTernaryButton> createSampleBankTernaryButtons()
+        {
+            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HIT_BANK_AUTO))
+            {
+                yield return new SampleBankTernaryButton(bankName)
+                {
+                    NormalState = { Current = SelectionBankStates[bankName], },
+                    AdditionsState = { Current = SelectionAdditionBankStates[bankName], },
+                    CreateIcon = () => getIconForBank(bankName),
+                    CreateCompactIcon = () => getCompactIconForBank(bankName),
+                };
+            }
+
+            AutoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip(), true);
+        }
+
+        private Drawable getIconForBank(string sampleName)
+        {
+            return new SpriteIcon
+            {
+                Size = new Vector2(20, 20),
+                Icon = sampleName switch
+                {
+                    HIT_BANK_AUTO => OsuIcon.EditorBankAuto,
+                    HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormal,
+                    HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoft,
+                    HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrum,
+                    _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
+                },
+            };
+        }
+
+        private Drawable getCompactIconForBank(string sampleName)
+        {
+            return new SpriteIcon
+            {
+                Size = new Vector2(10, 20),
+                Icon = sampleName switch
+                {
+                    HIT_BANK_AUTO => OsuIcon.EditorBankAutoCompact,
+                    HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormalCompact,
+                    HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoftCompact,
+                    HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrumCompact,
+                    _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
+                },
+            };
+        }
+
+        private void updateAutoBankTernaryButtonTooltip()
+        {
+            bool enabled = AutoSelectionBankEnabled.Value;
+
+            var autoBankButton = sampleBankTogglesCollection.Single(t => t.BankName == HIT_BANK_AUTO);
+            autoBankButton.NormalButton.Enabled.Value = enabled;
+            autoBankButton.NormalButton.TooltipText = !enabled ? "Auto normal bank can only be used during hit object placement" : string.Empty;
+        }
+
+        #endregion
+
         #region Ternary state changes
 
         /// <summary>
@@ -518,5 +626,22 @@ namespace osu.Game.Rulesets.Edit
         public abstract Bindable<bool> AutoSelectionBankEnabled { get; }
 
         #endregion
+
+        public static Drawable GetIconForSample(string sampleName)
+        {
+            switch (sampleName)
+            {
+                case HitSampleInfo.HIT_CLAP:
+                    return new SpriteIcon { Icon = OsuIcon.EditorClap };
+
+                case HitSampleInfo.HIT_WHISTLE:
+                    return new SpriteIcon { Icon = OsuIcon.EditorWhistle };
+
+                case HitSampleInfo.HIT_FINISH:
+                    return new SpriteIcon { Icon = OsuIcon.EditorFinish };
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null);
+        }
     }
 }

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.SelectionState.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.SelectionState.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
 using osu.Game.Screens.Edit.Components.TernaryButtons;
@@ -324,11 +325,13 @@ namespace osu.Game.Rulesets.Edit
 
             foreach (var kvp in SelectionSampleStates)
             {
-                yield return new DrawableTernaryButton
+                yield return new DrawableTernaryButton<GlobalAction>
                 {
                     Current = kvp.Value,
                     Description = kvp.Key.Replace(@"hit", string.Empty).Titleize(),
                     CreateIcon = () => GetIconForSample(kvp.Key),
+                    Action = GetActionForSample(kvp.Key),
+                    Hotkey = new Hotkey(GetActionForSample(kvp.Key)),
                 };
             }
         }
@@ -341,6 +344,8 @@ namespace osu.Game.Rulesets.Edit
                 {
                     NormalState = { Current = SelectionBankStates[bankName], },
                     AdditionsState = { Current = SelectionAdditionBankStates[bankName], },
+                    NormalHotkey = getHotkeyForBank(bankName, false),
+                    AdditionsHotkey = getHotkeyForBank(bankName, true),
                     CreateIcon = () => getIconForBank(bankName),
                     CreateCompactIcon = () => getCompactIconForBank(bankName),
                 };
@@ -380,6 +385,21 @@ namespace osu.Game.Rulesets.Edit
                 },
             };
         }
+
+        private GlobalAction getHotkeyForBank(string sampleName, bool addition) => (sampleName, addition) switch
+        {
+            (HIT_BANK_AUTO, false) => GlobalAction.EditorToggleNormalAutoBank,
+            (HitSampleInfo.BANK_NORMAL, false) => GlobalAction.EditorToggleNormalNormalBank,
+            (HitSampleInfo.BANK_SOFT, false) => GlobalAction.EditorToggleNormalSoftBank,
+            (HitSampleInfo.BANK_DRUM, false) => GlobalAction.EditorToggleNormalDrumBank,
+
+            (HIT_BANK_AUTO, true) => GlobalAction.EditorToggleAdditionAutoBank,
+            (HitSampleInfo.BANK_NORMAL, true) => GlobalAction.EditorToggleAdditionNormalBank,
+            (HitSampleInfo.BANK_SOFT, true) => GlobalAction.EditorToggleAdditionSoftBank,
+            (HitSampleInfo.BANK_DRUM, true) => GlobalAction.EditorToggleAdditionDrumBank,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
+        };
 
         private void updateAutoBankTernaryButtonTooltip()
         {
@@ -626,6 +646,14 @@ namespace osu.Game.Rulesets.Edit
         public abstract Bindable<bool> AutoSelectionBankEnabled { get; }
 
         #endregion
+
+        public static GlobalAction GetActionForSample(string sampleName) => sampleName switch
+        {
+            HitSampleInfo.HIT_CLAP => GlobalAction.EditorToggleClapSound,
+            HitSampleInfo.HIT_WHISTLE => GlobalAction.EditorToggleWhistleSound,
+            HitSampleInfo.HIT_FINISH => GlobalAction.EditorToggleFinishSound,
+            _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null),
+        };
 
         public static Drawable GetIconForSample(string sampleName)
         {

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -90,7 +90,7 @@ namespace osu.Game.Rulesets.Edit
 
         private EditorRadioButtonCollection toolboxCollection = null!;
         private FillFlowContainer togglesCollection = null!;
-        private FillFlowContainer sampleBankTogglesCollection = null!;
+        private FillFlowContainer<SampleBankTernaryButton> sampleBankTogglesCollection = null!;
 
         private IBindable<bool> hasTiming = null!;
         private Bindable<bool> autoSeekOnPlacement = null!;
@@ -230,7 +230,7 @@ namespace osu.Game.Rulesets.Edit
                                                         },
                                                     }
                                                 },
-                                                sampleBankTogglesCollection = new FillFlowContainer
+                                                sampleBankTogglesCollection = new FillFlowContainer<SampleBankTernaryButton>
                                                 {
                                                     RelativeSizeAxes = Axes.X,
                                                     AutoSizeAxes = Axes.Y,
@@ -286,7 +286,7 @@ namespace osu.Game.Rulesets.Edit
 
             togglesCollection.AddRange(CreateTernaryButtons().ToArray());
 
-            sampleBankTogglesCollection.AddRange(BlueprintContainer.SampleBankTernaryStates);
+            sampleBankTogglesCollection.AddRange(createSampleBankTernaryButtons());
 
             SetSelectTool();
 
@@ -384,11 +384,6 @@ namespace osu.Game.Rulesets.Edit
         /// A "select" tool is automatically added as the first tool.
         /// </remarks>
         protected abstract IReadOnlyList<CompositionTool<TAction>> CompositionTools { get; }
-
-        /// <summary>
-        /// Create all ternary states required to be displayed to the user.
-        /// </summary>
-        protected virtual IEnumerable<Drawable> CreateTernaryButtons() => BlueprintContainer.MainTernaryStates;
 
         /// <summary>
         /// Construct a relevant blueprint container. This will manage hitobject selection/placement input handling and display logic.

--- a/osu.Game/Rulesets/Edit/HitObjectComposer.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectComposer.cs
@@ -14,9 +14,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Input.Events;
 using osu.Framework.Logging;
-using osu.Framework.Testing;
 using osu.Game.Beatmaps;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
@@ -36,7 +34,6 @@ using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osu.Game.Screens.Edit.Compose;
 using osu.Game.Screens.Edit.Compose.Components;
 using osuTK;
-using osuTK.Input;
 
 namespace osu.Game.Rulesets.Edit
 {
@@ -138,9 +135,6 @@ namespace osu.Game.Rulesets.Edit
 
             dependencies.CacheAs(Playfield);
 
-            string shiftDisplay = keyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Shift));
-            string altDisplay = keyCombinationProvider.GetReadableString(new KeyCombination(InputKey.Alt));
-
             createSelectionStateBindables();
 
             InternalChild = new DatabasedKeyBindingContainer<TAction>(Ruleset.RulesetInfo, Ruleset.EDITOR_VARIANT, matchingMode: KeyCombinationMatchingMode.Modifiers)
@@ -180,7 +174,7 @@ namespace osu.Game.Rulesets.Edit
                                     {
                                         Child = toolboxCollection = new EditorRadioButtonCollection { RelativeSizeAxes = Axes.X }
                                     },
-                                    new EditorToolboxGroup("toggles (Q~P)")
+                                    new EditorToolboxGroup("toggles")
                                     {
                                         Child = togglesCollection = new FillFlowContainer
                                         {
@@ -190,7 +184,7 @@ namespace osu.Game.Rulesets.Edit
                                             Spacing = new Vector2(0, 5),
                                         },
                                     },
-                                    new EditorToolboxGroup($"bank ({shiftDisplay}/{altDisplay}-Q~R)")
+                                    new EditorToolboxGroup("bank")
                                     {
                                         Child = new FillFlowContainer
                                         {
@@ -279,7 +273,7 @@ namespace osu.Game.Rulesets.Edit
                 toolboxCollection.AddButton(new HitObjectCompositionToolButton<TAction>(compositionTool, toolSelected)
                 {
                     Hotkey = compositionTool.Action != null
-                        ? new Hotkey(Ruleset.ShortName, Ruleset.EDITOR_VARIANT, (int)Convert.ChangeType(compositionTool.Action.Value, typeof(int)))
+                        ? HotkeyForAction(compositionTool.Action.Value)
                         : null,
                 });
             }
@@ -408,91 +402,6 @@ namespace osu.Game.Rulesets.Edit
 
         #region Tool selection logic
 
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (e.ControlPressed || e.SuperPressed)
-                return false;
-
-            if (checkToggleMappingFromKey(e.Key, out int rightIndex))
-            {
-                if (e.ShiftPressed || e.AltPressed)
-                {
-                    if (sampleBankTogglesCollection.ElementAtOrDefault(rightIndex) is SampleBankTernaryButton sampleBankTernaryButton)
-                    {
-                        if (e.ShiftPressed)
-                            sampleBankTernaryButton.NormalButton.Toggle();
-
-                        if (e.AltPressed)
-                            sampleBankTernaryButton.AdditionsButton.Toggle();
-
-                        return true;
-                    }
-                }
-                else
-                {
-                    if (togglesCollection.ChildrenOfType<DrawableTernaryButton>().ElementAtOrDefault(rightIndex) is DrawableTernaryButton button)
-                    {
-                        button.Toggle();
-                        return true;
-                    }
-                }
-            }
-
-            return base.OnKeyDown(e);
-        }
-
-        private bool checkToggleMappingFromKey(Key key, out int index)
-        {
-            switch (key)
-            {
-                case Key.Q:
-                    index = 0;
-                    break;
-
-                case Key.W:
-                    index = 1;
-                    break;
-
-                case Key.E:
-                    index = 2;
-                    break;
-
-                case Key.R:
-                    index = 3;
-                    break;
-
-                case Key.T:
-                    index = 4;
-                    break;
-
-                case Key.Y:
-                    index = 5;
-                    break;
-
-                case Key.U:
-                    index = 6;
-                    break;
-
-                case Key.I:
-                    index = 7;
-                    break;
-
-                case Key.O:
-                    index = 8;
-                    break;
-
-                case Key.P:
-                    index = 9;
-                    break;
-
-                default:
-                    index = -1;
-                    break;
-            }
-
-            return index >= 0;
-        }
-
         private void selectionChanged(object? sender, NotifyCollectionChangedEventArgs changedArgs)
         {
             if (EditorBeatmap.SelectedHitObjects.Any())
@@ -581,6 +490,11 @@ namespace osu.Game.Rulesets.Edit
             }
 
             base.Dispose(isDisposing);
+        }
+
+        public Hotkey HotkeyForAction(TAction action)
+        {
+            return new Hotkey(Ruleset.ShortName, Ruleset.EDITOR_VARIANT, (int)Convert.ChangeType(action, typeof(int)));
         }
     }
 

--- a/osu.Game/Rulesets/Edit/HitObjectCompositionToolButton.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectCompositionToolButton.cs
@@ -39,7 +39,7 @@ namespace osu.Game.Rulesets.Edit
         {
             if (Nullable.Equals(e.Action, Tool.Action) && Enabled.Value)
             {
-                Select();
+                TriggerClick();
                 return true;
             }
 

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -93,7 +93,6 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             }
         }
 
-
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -10,6 +10,8 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Framework.Localisation;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Graphics.UserInterface;
@@ -48,6 +50,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
         private Color4 selectedIconColour;
 
         public Drawable Icon { get; private set; } = null!;
+        protected HotkeyDisplay HotkeyDisplay { get; private set; } = null!;
+        public Hotkey? Hotkey { get; init; }
 
         public DrawableTernaryButton(HoverSampleSet? hoverSampleSet = HoverSampleSet.Button)
             : base(hoverSampleSet)
@@ -72,7 +76,23 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 b.Size = new Vector2(20);
                 b.X = 10;
             }));
+
+            if (Hotkey != null)
+            {
+                SpriteText.Origin = Anchor.BottomLeft;
+                SpriteText.Y = -1;
+
+                Add(HotkeyDisplay = new HotkeyDisplay
+                {
+                    Hotkey = Hotkey.Value,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.TopLeft,
+                    X = 40,
+                    Y = 1,
+                });
+            }
         }
+
 
         protected override void LoadComplete()
         {
@@ -137,5 +157,29 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             Anchor = Anchor.CentreLeft,
             X = 40f
         };
+    }
+
+    public partial class DrawableTernaryButton<TAction> : DrawableTernaryButton, IKeyBindingHandler<TAction>
+        where TAction : struct, Enum
+    {
+        public new TAction? Action { get; init; }
+
+        public DrawableTernaryButton(HoverSampleSet? hoverSampleSet = HoverSampleSet.Button)
+            : base(hoverSampleSet)
+        {
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<TAction> e)
+        {
+            if (e.Repeat || !Nullable.Equals(Action, e.Action))
+                return false;
+
+            Toggle();
+            return true;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<TAction> e)
+        {
+        }
     }
 }

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/DrawableTernaryButton.cs
@@ -173,7 +173,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
             if (e.Repeat || !Nullable.Equals(Action, e.Action))
                 return false;
 
-            Toggle();
+            TriggerClick();
             return true;
         }
 

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/NewComboTernaryButton.cs
@@ -16,10 +16,13 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Objects;
@@ -28,7 +31,7 @@ using osuTK;
 
 namespace osu.Game.Screens.Edit.Components.TernaryButtons
 {
-    public partial class NewComboTernaryButton : CompositeDrawable, IHasCurrentValue<TernaryState>
+    public partial class NewComboTernaryButton : CompositeDrawable, IHasCurrentValue<TernaryState>, IKeyBindingHandler<GlobalAction>
     {
         public Func<Drawable>? CreateIcon { get; init; }
 
@@ -60,11 +63,13 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Child = mainButton = new DrawableTernaryButton
+                    Child = mainButton = new DrawableTernaryButton<GlobalAction>
                     {
                         Current = Current,
                         Description = EditorStrings.NewCombo,
                         CreateIcon = CreateIcon,
+                        Action = GlobalAction.EditorToggleNewCombo,
+                        Hotkey = new Hotkey(GlobalAction.EditorToggleNewCombo),
                     },
                 },
                 pickerButton = new ColourPickerButton
@@ -113,6 +118,19 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 mainButtonContainer.TransformTo(nameof(mainButtonContainer.Padding), new MarginPadding(), ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
                 mainButton.Icon.MoveToX(10, ExpandingContainer.TRANSITION_DURATION, Easing.OutQuint);
             }
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Action != GlobalAction.EditorToggleNewCombo || e.Repeat)
+                return false;
+
+            mainButton.Toggle();
+            return true;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
 
         private partial class ColourPickerButton : OsuButton, IHasPopover

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
@@ -157,13 +157,13 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
             if (e.Action == NormalHotkey)
             {
-                NormalButton.Toggle();
+                NormalButton.TriggerClick();
                 return true;
             }
 
             if (e.Action == AdditionsHotkey)
             {
-                AdditionsButton.Toggle();
+                AdditionsButton.TriggerClick();
                 return true;
             }
 

--- a/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
+++ b/osu.Game/Screens/Edit/Components/TernaryButtons/SampleBankTernaryButton.cs
@@ -8,13 +8,16 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
 using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Input.Bindings;
 using osu.Game.Rulesets.Edit;
 
 namespace osu.Game.Screens.Edit.Components.TernaryButtons
 {
-    public partial class SampleBankTernaryButton : CompositeDrawable
+    public partial class SampleBankTernaryButton : CompositeDrawable, IKeyBindingHandler<GlobalAction>
     {
         public string BankName { get; }
         public required Func<Drawable> CreateIcon { get; init; }
@@ -23,6 +26,9 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
         public readonly BindableWithCurrent<TernaryState> NormalState = new BindableWithCurrent<TernaryState>();
         public readonly BindableWithCurrent<TernaryState> AdditionsState = new BindableWithCurrent<TernaryState>();
+
+        public required GlobalAction NormalHotkey { get; init; }
+        public required GlobalAction AdditionsHotkey { get; init; }
 
         public DrawableTernaryButton NormalButton { get; private set; } = null!;
         public DrawableTernaryButton AdditionsButton { get; private set; } = null!;
@@ -54,6 +60,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                         Description = BankName.Titleize(),
                         CreateIcon = CreateIcon,
                         CreateCompactIcon = CreateCompactIcon,
+                        Hotkey = new Hotkey(NormalHotkey),
                     },
                 },
                 new Container
@@ -70,6 +77,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                         Description = BankName.Titleize(),
                         CreateIcon = CreateIcon,
                         CreateCompactIcon = CreateCompactIcon,
+                        Hotkey = new Hotkey(AdditionsHotkey),
                     },
                 },
             };
@@ -77,6 +85,8 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
 
         private partial class InlineDrawableTernaryButton : DrawableTernaryButton, IExpandable
         {
+            private const float text_position = 31f;
+
             public new required Func<Drawable> CreateIcon { get; init; }
 
             public required Func<Drawable> CreateCompactIcon { get; init; }
@@ -111,6 +121,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 Content.Masking = false;
                 Content.CornerRadius = 0;
                 Icon.X = 4.5f;
+                HotkeyDisplay.X = text_position;
             }
 
             protected override void LoadComplete()
@@ -125,6 +136,7 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 Expanded.BindValueChanged(expanded =>
                 {
                     icon.FadeTo(expanded.NewValue ? 1 : 0, 150, Easing.OutQuint);
+                    HotkeyDisplay.FadeTo(expanded.NewValue ? 1 : 0, 150, Easing.OutQuint);
                     iconCompact.FadeTo(expanded.NewValue ? 0 : 1, 150, Easing.OutQuint);
                 }, true);
             }
@@ -134,8 +146,32 @@ namespace osu.Game.Screens.Edit.Components.TernaryButtons
                 Depth = -1,
                 Origin = Anchor.CentreLeft,
                 Anchor = Anchor.CentreLeft,
-                X = 31f
+                X = text_position,
             };
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Repeat)
+                return false;
+
+            if (e.Action == NormalHotkey)
+            {
+                NormalButton.Toggle();
+                return true;
+            }
+
+            if (e.Action == AdditionsHotkey)
+            {
+                AdditionsButton.Toggle();
+                return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
         }
     }
 }

--- a/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/ComposeBlueprintContainer.cs
@@ -6,24 +6,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Humanizer;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Game.Audio;
-using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Edit.Tools;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.UI;
-using osu.Game.Screens.Edit.Components.TernaryButtons;
 using osuTK;
 
 namespace osu.Game.Screens.Edit.Compose.Components
@@ -73,9 +67,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
         [BackgroundDependencyLoader]
         private void load()
         {
-            MainTernaryStates = CreateTernaryButtons().ToArray();
-            SampleBankTernaryStates = createSampleBankTernaryButtons().ToArray();
-
             AddInternal(new DrawableRulesetDependenciesProvidingContainer(Composer.Ruleset)
             {
                 Child = placementBlueprintContainer
@@ -89,12 +80,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
             base.LoadComplete();
 
             Beatmap.HitObjectAdded += hitObjectAdded;
-
-            // updates to selected are handled for us by SelectionHandler.
-            if (Composer.SelectionNewComboState != null)
-                NewCombo.BindTo(Composer.SelectionNewComboState);
-
-            Composer.AutoSelectionBankEnabled.BindValueChanged(_ => updateAutoBankTernaryButtonTooltip(), true);
         }
 
         protected override void TransferBlueprintFor(HitObject hitObject, DrawableHitObject drawableObject)
@@ -103,143 +88,6 @@ namespace osu.Game.Screens.Edit.Compose.Components
 
             var blueprint = (HitObjectSelectionBlueprint)GetBlueprintFor(hitObject);
             blueprint.DrawableObject = drawableObject;
-        }
-
-        public readonly Bindable<TernaryState> NewCombo = new Bindable<TernaryState> { Description = "New Combo" };
-
-        /// <summary>
-        /// A collection of states which will be displayed to the user in the toolbox.
-        /// </summary>
-        public Drawable[] MainTernaryStates { get; private set; }
-
-        public SampleBankTernaryButton[] SampleBankTernaryStates { get; private set; }
-
-        /// <summary>
-        /// Create the new combo ternary button. Mainly used to customize the displayed icon
-        /// depending on the ruleset. Can be overriden to return null if a ruleset does not
-        /// provide combo-supporting HitObjects.
-        /// </summary>
-        /// <returns></returns>
-        [CanBeNull]
-        protected virtual Drawable CreateNewComboButton() => new NewComboTernaryButton
-        {
-            Current = NewCombo,
-            CreateIcon = () => new Container
-            {
-                Children = new Drawable[]
-                {
-                    new SpriteIcon
-                    {
-                        Anchor = Anchor.BottomLeft,
-                        Origin = Anchor.BottomLeft,
-                        // This is currently using the osu! hitcircle icon as a default in order
-                        // not to break any custom rulesets that depend on there being a defined
-                        // new combo button.
-                        // Could consider removing it and let rulesets specify their own buttons/icons.
-                        Icon = OsuIcon.EditorHitCircle,
-                        Size = new Vector2(15),
-                    },
-                    new SpriteIcon
-                    {
-                        Icon = OsuIcon.EditorNewComboSparkles,
-                        Size = new Vector2(20),
-                    }
-                },
-            },
-        };
-
-        /// <summary>
-        /// Create all ternary states required to be displayed to the user.
-        /// </summary>
-        protected virtual IEnumerable<Drawable> CreateTernaryButtons()
-        {
-            //TODO: this should only be enabled (visible?) for rulesets that provide combo-supporting HitObjects.
-            var newComboButton = CreateNewComboButton();
-
-            if (newComboButton != null)
-                yield return newComboButton;
-
-            foreach (var kvp in Composer.SelectionSampleStates)
-            {
-                yield return new DrawableTernaryButton
-                {
-                    Current = kvp.Value,
-                    Description = kvp.Key.Replace(@"hit", string.Empty).Titleize(),
-                    CreateIcon = () => GetIconForSample(kvp.Key),
-                };
-            }
-        }
-
-        private IEnumerable<SampleBankTernaryButton> createSampleBankTernaryButtons()
-        {
-            foreach (string bankName in HitSampleInfo.ALL_BANKS.Prepend(HitObjectComposer.HIT_BANK_AUTO))
-            {
-                yield return new SampleBankTernaryButton(bankName)
-                {
-                    NormalState = { Current = Composer.SelectionBankStates[bankName], },
-                    AdditionsState = { Current = Composer.SelectionAdditionBankStates[bankName], },
-                    CreateIcon = () => getIconForBank(bankName),
-                    CreateCompactIcon = () => getCompactIconForBank(bankName),
-                };
-            }
-        }
-
-        private Drawable getIconForBank(string sampleName)
-        {
-            return new SpriteIcon
-            {
-                Size = new Vector2(20, 20),
-                Icon = sampleName switch
-                {
-                    HitObjectComposer.HIT_BANK_AUTO => OsuIcon.EditorBankAuto,
-                    HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormal,
-                    HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoft,
-                    HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrum,
-                    _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
-                },
-            };
-        }
-
-        private Drawable getCompactIconForBank(string sampleName)
-        {
-            return new SpriteIcon
-            {
-                Size = new Vector2(10, 20),
-                Icon = sampleName switch
-                {
-                    HitObjectComposer.HIT_BANK_AUTO => OsuIcon.EditorBankAutoCompact,
-                    HitSampleInfo.BANK_NORMAL => OsuIcon.EditorBankNormalCompact,
-                    HitSampleInfo.BANK_SOFT => OsuIcon.EditorBankSoftCompact,
-                    HitSampleInfo.BANK_DRUM => OsuIcon.EditorBankDrumCompact,
-                    _ => throw new ArgumentOutOfRangeException(nameof(sampleName), sampleName, null)
-                },
-            };
-        }
-
-        public static Drawable GetIconForSample(string sampleName)
-        {
-            switch (sampleName)
-            {
-                case HitSampleInfo.HIT_CLAP:
-                    return new SpriteIcon { Icon = OsuIcon.EditorClap };
-
-                case HitSampleInfo.HIT_WHISTLE:
-                    return new SpriteIcon { Icon = OsuIcon.EditorWhistle };
-
-                case HitSampleInfo.HIT_FINISH:
-                    return new SpriteIcon { Icon = OsuIcon.EditorFinish };
-            }
-
-            return null;
-        }
-
-        private void updateAutoBankTernaryButtonTooltip()
-        {
-            bool enabled = Composer.AutoSelectionBankEnabled.Value;
-
-            var autoBankButton = SampleBankTernaryStates.Single(t => t.BankName == HitObjectComposer.HIT_BANK_AUTO);
-            autoBankButton.NormalButton.Enabled.Value = enabled;
-            autoBankButton.NormalButton.TooltipText = !enabled ? "Auto normal bank can only be used during hit object placement" : string.Empty;
         }
 
         #region Placement
@@ -321,8 +169,8 @@ namespace osu.Game.Screens.Edit.Compose.Components
             refreshPlacement();
 
             // on successful placement, the new combo button should be reset as this is the most common user interaction.
-            if (Beatmap.SelectedHitObjects.Count == 0)
-                NewCombo.Value = TernaryState.False;
+            if (Beatmap.SelectedHitObjects.Count == 0 && Composer.SelectionNewComboState != null)
+                Composer.SelectionNewComboState.Value = TernaryState.False;
         }
 
         private void ensurePlacementCreated()

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -21,6 +21,7 @@ using osu.Game.Audio;
 using osu.Game.Graphics;
 using osu.Game.Graphics.UserInterface;
 using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Input.Bindings;
 using osu.Game.Localisation;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
@@ -308,7 +309,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         return;
 
                     setBank(val.NewValue);
-                    updatePrimaryBankState();
                     playDemoSample();
                 });
 
@@ -319,7 +319,6 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         return;
 
                     setAdditionBank(val.NewValue);
-                    updateAdditionBankState();
                     playDemoSample();
                 });
 
@@ -492,6 +491,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                         relevantSamples[i] = relevantSamples[i].With(newBank: newBank);
                     }
                 });
+
+                updatePrimaryBankState();
             }
 
             /// <remarks>
@@ -517,6 +518,8 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                             relevantSamples[i] = relevantSamples[i].With(newBank: newBank, newEditorAutoBank: false);
                     }
                 });
+
+                updateAdditionBankState();
             }
 
             private void setSampleSet(EditorBeatmapSkin.SampleSet newSampleSet)
@@ -593,13 +596,15 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
             {
                 foreach ((string sampleName, var bindable) in selectionSampleStates)
                 {
-                    yield return new DrawableTernaryButton(null)
+                    yield return new DrawableTernaryButton<GlobalAction>(null)
                     {
                         Current = bindable,
                         Description = string.Empty,
                         CreateIcon = () => HitObjectComposer.GetIconForSample(sampleName),
                         RelativeSizeAxes = Axes.None,
                         Size = new Vector2(40, 40),
+                        Action = HitObjectComposer.GetActionForSample(sampleName),
+                        Hotkey = new Hotkey(HitObjectComposer.GetActionForSample(sampleName)),
                     };
                 }
             }
@@ -643,68 +648,43 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                 updateAdditionBankState();
             }
 
-            protected override bool OnKeyDown(KeyDownEvent e)
+            public override bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
             {
-                if (e.ControlPressed || e.SuperPressed || !checkRightToggleFromKey(e.Key, out int rightIndex))
-                    return base.OnKeyDown(e);
+                if (e.Repeat)
+                    return base.OnPressed(e);
 
-                if (e.ShiftPressed || e.AltPressed)
+                switch (e.Action)
                 {
-                    string? newBank = banks.ElementAtOrDefault(rightIndex);
-
-                    if (string.IsNullOrEmpty(newBank))
-                        return true;
-
-                    if (e.ShiftPressed && newBank != HitObjectComposer.HIT_BANK_AUTO)
-                    {
-                        setBank(newBank);
-                        updatePrimaryBankState();
-                    }
-
-                    if (e.AltPressed)
-                    {
-                        setAdditionBank(newBank);
-                        updateAdditionBankState();
-                    }
-                }
-                else
-                {
-                    var item = togglesCollection.ElementAtOrDefault(rightIndex - 1);
-
-                    if (item is not DrawableTernaryButton button) return base.OnKeyDown(e);
-
-                    button.Toggle();
-                }
-
-                return true;
-            }
-
-            private bool checkRightToggleFromKey(Key key, out int index)
-            {
-                switch (key)
-                {
-                    case Key.Q:
-                        index = 0;
+                    case GlobalAction.EditorToggleNormalNormalBank:
+                        setBank(HitSampleInfo.BANK_NORMAL);
                         break;
 
-                    case Key.W:
-                        index = 1;
+                    case GlobalAction.EditorToggleNormalSoftBank:
+                        setBank(HitSampleInfo.BANK_SOFT);
                         break;
 
-                    case Key.E:
-                        index = 2;
+                    case GlobalAction.EditorToggleNormalDrumBank:
+                        setBank(HitSampleInfo.BANK_DRUM);
                         break;
 
-                    case Key.R:
-                        index = 3;
+                    case GlobalAction.EditorToggleAdditionAutoBank:
+                        setAdditionBank(HitObjectComposer.HIT_BANK_AUTO);
                         break;
 
-                    default:
-                        index = -1;
+                    case GlobalAction.EditorToggleAdditionNormalBank:
+                        setAdditionBank(HitSampleInfo.BANK_NORMAL);
+                        break;
+
+                    case GlobalAction.EditorToggleAdditionSoftBank:
+                        setAdditionBank(HitSampleInfo.BANK_SOFT);
+                        break;
+
+                    case GlobalAction.EditorToggleAdditionDrumBank:
+                        setAdditionBank(HitSampleInfo.BANK_DRUM);
                         break;
                 }
 
-                return index >= 0;
+                return base.OnPressed(e);
             }
 
             #endregion

--- a/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
+++ b/osu.Game/Screens/Edit/Compose/Components/Timeline/SamplePointPiece.cs
@@ -597,7 +597,7 @@ namespace osu.Game.Screens.Edit.Compose.Components.Timeline
                     {
                         Current = bindable,
                         Description = string.Empty,
-                        CreateIcon = () => ComposeBlueprintContainer.GetIconForSample(sampleName),
+                        CreateIcon = () => HitObjectComposer.GetIconForSample(sampleName),
                         RelativeSizeAxes = Axes.None,
                         Size = new Vector2(40, 40),
                     };


### PR DESCRIPTION
<img width="240" height="688" alt="image" src="https://github.com/user-attachments/assets/a7d3b6a6-91f2-4c7f-a8cf-16a484b47c1b" />

Relevant changes:
- Each toggle depicted on the screenshot above now has its hotkeys individually rebindable via settings. Hints for hotkeys are displayed on the toggles.
- The "new combo" toggle no longer displays on rulesets that do not support combos.
- As a side effect of individual rebindability, it is now **not** possible to change both normal and addition bank simultaneously via <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-(<kbd>Q</kbd>~<kbd>R</kbd>).[^1]

---

Supersedes / closes https://github.com/ppy/osu/pull/37939.
Closes https://github.com/ppy/osu/issues/35011.

[^1]: The reason for this is the `KeyCombinationMatchingMode.Modifiers` specification in https://github.com/ppy/osu/blob/eca174b2576e90e1afa860b5f0dcf56211c2bb16/osu.Game/Input/Bindings/GlobalActionContainer.cs#L22.