### PR TITLE
Avoid using `GetDescription` for hover sounds lookups

### DIFF
--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Extensions;
 using osu.Framework.Input.Events;
 using osu.Game.Audio;
 using osuTK.Input;
@@ -40,11 +39,11 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select")
-                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
+            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetResourceName()}-select")
+                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetResourceName()}-select");
 
-            sampleClickDisabled = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select-disabled")
-                                  ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select-disabled");
+            sampleClickDisabled = audio.Samples.Get($@"UI/{SampleSet.GetResourceName()}-select-disabled")
+                                  ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetResourceName()}-select-disabled");
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSampleSet.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.ComponentModel;
 
 namespace osu.Game.Graphics.UserInterface
@@ -27,5 +28,38 @@ namespace osu.Game.Graphics.UserInterface
 
         [Description("menu-open")]
         MenuOpen,
+    }
+
+    public static class HoverSampleSetExtensions
+    {
+        public static string GetResourceName(this HoverSampleSet value)
+        {
+            switch (value)
+            {
+                case HoverSampleSet.Default:
+                    return "default";
+
+                case HoverSampleSet.Button:
+                    return "button";
+
+                case HoverSampleSet.ButtonSidebar:
+                    return "button-sidebar";
+
+                case HoverSampleSet.TabSelect:
+                    return "tabselect";
+
+                case HoverSampleSet.DialogCancel:
+                    return "dialog-cancel";
+
+                case HoverSampleSet.DialogOk:
+                    return "dialog-ok";
+
+                case HoverSampleSet.MenuOpen:
+                    return "menu-open";
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value));
+            }
+        }
     }
 }

--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -7,7 +7,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Game.Audio;
 
@@ -34,8 +33,8 @@ namespace osu.Game.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-hover")
-                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-hover");
+            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetResourceName()}-hover")
+                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetResourceName()}-hover");
         }
 
         public override void PlayHoverSample()

--- a/osu.Game/Overlays/Volume/VolumeMeter.cs
+++ b/osu.Game/Overlays/Volume/VolumeMeter.cs
@@ -11,7 +11,6 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -88,7 +87,7 @@ namespace osu.Game.Overlays.Volume
         [BackgroundDependencyLoader]
         private void load(OsuColour colours, AudioManager audio)
         {
-            hoverSample = audio.Samples.Get($@"UI/{HoverSampleSet.Button.GetDescription()}-hover");
+            hoverSample = audio.Samples.Get($@"UI/{HoverSampleSet.Button.GetResourceName()}-hover");
             notchSample = audio.Samples.Get(@"UI/notch-tick");
             sampleLastPlaybackTime = Time.Current;
 

--- a/osu.Game/Screens/OnlinePlay/Lounge/LoungeRoomPanel.cs
+++ b/osu.Game/Screens/OnlinePlay/Lounge/LoungeRoomPanel.cs
@@ -74,8 +74,8 @@ namespace osu.Game.Screens.OnlinePlay.Lounge
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleSelect = audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
-            sampleJoin = audio.Samples.Get($@"UI/{HoverSampleSet.Button.GetDescription()}-select");
+            sampleSelect = audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetResourceName()}-select");
+            sampleJoin = audio.Samples.Get($@"UI/{HoverSampleSet.Button.GetResourceName()}-select");
 
             AddRangeInternal(new Drawable[]
             {


### PR DESCRIPTION
<img width="1267" height="218" alt="JetBrains Rider 2026-08-20 at 04 44 32" src="https://github.com/user-attachments/assets/48e5e9c5-af64-47d2-b6d2-f8b20a3fe8f0" />

Also confirmed via manual stopwatch based profiling with my chat overlay (has hundreds of PM channels, is lagging on initial open for me):

<details><summary>Diff with console output</summary>
<p>

```diff
diff --git a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
index f1c14eb6b5..5a38882c91 100644
--- a/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverClickSounds.cs
@@ -1,7 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -40,11 +43,14 @@ public HoverClickSounds(HoverSampleSet sampleSet = HoverSampleSet.Default, Mouse
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select")
-                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select");
+            var sw = Stopwatch.StartNew();
+            sampleClick = audio.Samples.Get($@"UI/{SampleSet.GetLocalisableDescription()}-select")
+                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetLocalisableDescription()}-select");
 
-            sampleClickDisabled = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-select-disabled")
-                                  ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-select-disabled");
+            sampleClickDisabled = audio.Samples.Get($@"UI/{SampleSet.GetLocalisableDescription()}-select-disabled")
+                                  ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetLocalisableDescription()}-select-disabled");
+
+            Console.WriteLine($"HoverClickSounds({Interlocked.Increment(ref count)}) load call took {sw.Elapsed.TotalMicroseconds} (total {Interlocked.Add(ref total_time_spent, (int)sw.Elapsed.TotalMicroseconds)})");
         }
 
         protected override bool OnClick(ClickEvent e)
diff --git a/osu.Game/Graphics/UserInterface/HoverSounds.cs b/osu.Game/Graphics/UserInterface/HoverSounds.cs
index b305104eee..a8a1dd428d 100644
--- a/osu.Game/Graphics/UserInterface/HoverSounds.cs
+++ b/osu.Game/Graphics/UserInterface/HoverSounds.cs
@@ -3,6 +3,9 @@
 
 #nullable disable
 
+using System;
+using System.Diagnostics;
+using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
@@ -21,7 +24,7 @@ public partial class HoverSounds : HoverSampleDebounceComponent
     {
         public readonly Bindable<bool> Enabled = new Bindable<bool>(true);
 
-        private Sample sampleHover;
+        protected Sample sampleHover;
 
         protected readonly HoverSampleSet SampleSet;
 
@@ -31,11 +34,18 @@ public HoverSounds(HoverSampleSet sampleSet = HoverSampleSet.Default)
             RelativeSizeAxes = Axes.Both;
         }
 
+        protected static int count;
+        protected static int total_time_spent;
+
         [BackgroundDependencyLoader]
         private void load(AudioManager audio)
         {
-            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetDescription()}-hover")
-                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetDescription()}-hover");
+            var sw = Stopwatch.StartNew();
+            sampleHover = audio.Samples.Get($@"UI/{SampleSet.GetLocalisableDescription()}-hover")
+                          ?? audio.Samples.Get($@"UI/{HoverSampleSet.Default.GetLocalisableDescription()}-hover");
+
+            Console.WriteLine(
+                $"HoverSounds({Interlocked.Increment(ref count)}) load call took {sw.Elapsed.TotalMicroseconds} (total {Interlocked.Add(ref total_time_spent, (int)sw.Elapsed.TotalMicroseconds)})");
         }
 
         public override void PlayHoverSample()

```


</p>
</details> 

```
HoverSounds(8145) load call took 27.5 (total 108839)
HoverClickSounds(8146) load call took 9 (total 108848)
HoverSounds(8147) load call took 26.7 (total 108877)
HoverClickSounds(8148) load call took 6.6 (total 108883)
HoverSounds(8149) load call took 26.7 (total 108911)
HoverClickSounds(8150) load call took 5.9 (total 108917)
HoverSounds(8151) load call took 24.9 (total 108943)
HoverClickSounds(8152) load call took 11 (total 108954)
```

≈108 ms over 8,152 calls. not much per call but it adds up.

Unfortunately hard to ban usage of `GetDescription` here. could make a typed version and ban that, but prolly not worth. There some other similar usages but this is the only prevalent one in profiling, so just fixing locally for now.

