### PR TITLE
Do not paste hitobjects after the end of the song

### DIFF
--- a/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
+++ b/osu.Game/Screens/Edit/Compose/ComposeScreen.cs
@@ -160,12 +160,14 @@ namespace osu.Game.Screens.Edit.Compose
             foreach (var h in objects)
                 h.StartTime += timeOffset;
 
+            var validHitObjects = objects.Where(o => o.StartTime <= clock.TrackLength).ToArray();
+
             EditorBeatmap.BeginChange();
 
             EditorBeatmap.SelectedHitObjects.Clear();
 
-            EditorBeatmap.AddRange(objects);
-            EditorBeatmap.SelectedHitObjects.AddRange(objects);
+            EditorBeatmap.AddRange(validHitObjects);
+            EditorBeatmap.SelectedHitObjects.AddRange(validHitObjects);
 
             EditorBeatmap.EndChange();
         }


### PR DESCRIPTION
Coming from https://osu.ppy.sh/community/forums/topics/2231933

This is one way for hitobjects to end up after song end, and then there is no way to delete them. 

Can write a test if asked.