### PR TITLE
Temporarily disable online asset cache due to unacceptable performance

### DIFF
--- a/osu.Game/Graphics/OnlineAssetCachingStore.cs
+++ b/osu.Game/Graphics/OnlineAssetCachingStore.cs
@@ -2,16 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
-using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Database;
-using osu.Game.Extensions;
-using osu.Game.Models;
 using osu.Game.Online;
-using Realms;
 
 namespace osu.Game.Graphics
 {
@@ -31,6 +26,7 @@ namespace osu.Game.Graphics
     /// </summary>
     public class OnlineAssetCachingStore : IDisposable
     {
+        // ReSharper disable NotAccessedField.Local
         private readonly RealmAccess realmAccess;
         private readonly OnlineStore onlineStore;
         private readonly RealmFileStore fileStore;
@@ -41,39 +37,48 @@ namespace osu.Game.Graphics
             this.realmAccess = realmAccess;
             onlineStore = new TrustedDomainOnlineStore();
             fileStore = new RealmFileStore(realmAccess, host.Storage);
-            largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(new StorageBackedResourceStore(fileStore.Storage)));
+            // largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(new StorageBackedResourceStore(fileStore.Storage)));
+            largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(onlineStore));
         }
 
         public Texture? Get(string url)
         {
-            string? path = realmAccess.Write(r =>
-            {
-                var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
-                if (a != null)
-                    a.LastAccessed = DateTimeOffset.Now;
-                return a?.File.File.GetStoragePath();
-            });
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
 
-            if (path == null)
-            {
-                var onlineStream = onlineStore.GetStream(url);
+            return largeTextureStore.Get(url);
 
-                if (onlineStream == null)
-                    return null;
+            // TODO: logic below temporarily disabled as it causes unacceptable performance on devices with slow I/O due to realm abuse
+            // see https://github.com/ppy/osu/issues/38651#issuecomment-5356443643 for details
 
-                path = realmAccess.Write(r =>
-                {
-                    var file = fileStore.Add(onlineStream, r);
-                    r.Add(new RealmOnlineAsset(file, url));
-                    return file.GetStoragePath();
-                });
-            }
-            else
-            {
-                Logger.Log($"Online asset {url} retrieved from {nameof(OnlineAssetCachingStore)}.", LoggingTarget.Network);
-            }
+            // string? path = realmAccess.Write(r =>
+            // {
+            //     var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
+            //     if (a != null)
+            //         a.LastAccessed = DateTimeOffset.Now;
+            //     return a?.File.File.GetStoragePath();
+            // });
 
-            return largeTextureStore.Get(path);
+            // if (path == null)
+            // {
+            //     var onlineStream = onlineStore.GetStream(url);
+
+            //     if (onlineStream == null)
+            //         return null;
+
+            //     path = realmAccess.Write(r =>
+            //     {
+            //         var file = fileStore.Add(onlineStream, r);
+            //         r.Add(new RealmOnlineAsset(file, url));
+            //         return file.GetStoragePath();
+            //     });
+            // }
+            // else
+            // {
+            //     Logger.Log($"Online asset {url} retrieved from {nameof(OnlineAssetCachingStore)}.", LoggingTarget.Network);
+            // }
+
+            // return largeTextureStore.Get(path);
         }
 
         public void Dispose()


### PR DESCRIPTION
For hotfix purposes.

I had hoped to prepare a roll-forward attempt at fixing the problem, but I ran out of time to figure and properly test one out before the weekend. See https://github.com/ppy/osu/compare/master...bdach:osu:online-cache-hotfix?expand=1 if you wish to see.

Note that a straight revert doesn't work here as there were realm migrations involved in the original PR and thus a straight revert will brick people's databases.