### PR TITLE
Make "clear all local scores" menu item destructive

### DIFF
--- a/osu.Game/Localisation/SongSelectStrings.cs
+++ b/osu.Game/Localisation/SongSelectStrings.cs
@@ -150,9 +150,9 @@ namespace osu.Game.Localisation
         public static LocalisableString RemoveFromPlayed => new TranslatableString(getKey(@"remove_from_played"), @"Remove from played");
 
         /// <summary>
-        /// "Clear all local scores"
+        /// "Clear all local scores..."
         /// </summary>
-        public static LocalisableString ClearAllLocalScores => new TranslatableString(getKey(@"clear_all_local_scores"), @"Clear all local scores");
+        public static LocalisableString ClearAllLocalScores => new TranslatableString(getKey(@"clear_all_local_scores"), @"Clear all local scores...");
 
         /// <summary>
         /// "Restore all hidden"

--- a/osu.Game/Screens/Select/SoloSongSelect.cs
+++ b/osu.Game/Screens/Select/SoloSongSelect.cs
@@ -85,7 +85,7 @@ namespace osu.Game.Screens.Select
             else
                 yield return new OsuMenuItem(SongSelectStrings.RemoveFromPlayed, MenuItemType.Standard, () => beatmaps.MarkNotPlayed(beatmap)) { Icon = FontAwesome.Solid.TimesCircle };
 
-            yield return new OsuMenuItem(SongSelectStrings.ClearAllLocalScores, MenuItemType.Standard, () => dialogOverlay?.Push(new BeatmapClearScoresDialog(beatmap)))
+            yield return new OsuMenuItem(SongSelectStrings.ClearAllLocalScores, MenuItemType.Destructive, () => dialogOverlay?.Push(new BeatmapClearScoresDialog(beatmap)))
             {
                 Icon = FontAwesome.Solid.Eraser
             };

--- a/osu.Game/Screens/Select/SoloSongSelect.cs
+++ b/osu.Game/Screens/Select/SoloSongSelect.cs
@@ -91,7 +91,7 @@ namespace osu.Game.Screens.Select
             };
 
             if (beatmaps.CanHide(beatmap))
-                yield return new OsuMenuItem(WebCommonStrings.ButtonsHide.ToSentence(), MenuItemType.Destructive, () => beatmaps.Hide(beatmap));
+                yield return new OsuMenuItem(WebCommonStrings.ButtonsHide.ToSentence(), MenuItemType.Standard, () => beatmaps.Hide(beatmap));
         }
 
         protected override void OnStart()


### PR DESCRIPTION
- Regressed in https://github.com/ppy/osu/pull/33193

Clearing scores is currently more destructive than anything else. You can restore hidden beatmaps anytime and deleted beatmaps within the session but not scores yet(?).

| Before | After |
| --- | --- |
| <img width="158" height="220" alt="osu!_vq3Jy9mSAm" src="https://github.com/user-attachments/assets/48982bad-5293-4b52-860c-5acd3ec6046b" /> <img width="297" height="162" alt="osu!_UMEE9Vl2b8" src="https://github.com/user-attachments/assets/5cb7da87-e692-4692-ac03-ccd2379a7ca5" /> | <img width="251" height="314" alt="Screenshot 2026-08-24 at 6 26 53 PM" src="https://github.com/user-attachments/assets/477bdc96-493f-4daf-9a71-bbd554dd02b2" /> <img width="374" height="230" alt="Screenshot 2026-08-24 at 6 27 05 PM" src="https://github.com/user-attachments/assets/0902fb15-0eac-4910-bffe-4dfa49b3e4b3" /> |