### PR TITLE
Replace the strain penalty in flow with a specialised factor that relies on deviation

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -112,7 +112,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             // Reduce difficulty for low spacing since spacing below radius is always to be flowed
             if (aimCheese)
-                flowDifficulty *= DiffUtils.Smootherstep(currDistance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);
+                flowDifficulty *= DiffUtils.Smootherstep(currDistance, 0, OsuDifficultyHitObject.NORMALISED_DIAMETER);
 
             return flowDifficulty;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -15,7 +15,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
         /// <summary>
         /// Evaluates difficulty of "flow aim" - aiming pattern where player doesn't stop their cursor on every object and instead "flows" through them.
         /// </summary>
-        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance)
+        public static double EvaluateDifficultyOf(DifficultyHitObject current, bool withSliderTravelDistance, bool aimCheese)
         {
             var osuCurrObj = (OsuDifficultyHitObject)current;
             var osuLastObj = (OsuDifficultyHitObject)current.Previous();
@@ -111,7 +111,10 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             flowDifficulty = DiffUtils.Pow(flowDifficulty, 1.45);
 
             // Reduce difficulty for low spacing since spacing below radius is always to be flowed
-            return flowDifficulty * DiffUtils.Smootherstep(currDistance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);
+            if (aimCheese)
+                flowDifficulty *= DiffUtils.Smootherstep(currDistance, 0, OsuDifficultyHitObject.NORMALISED_RADIUS);
+
+            return flowDifficulty;
         }
 
         private static double calculateOverlapFactor(OsuDifficultyHitObject first, OsuDifficultyHitObject second)

--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/FlowAimEvaluator.cs
@@ -110,7 +110,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
             // Final velocity is being raised to a power because flow difficulty scales harder with both high distance and time, and we want to account for that
             flowDifficulty = DiffUtils.Pow(flowDifficulty, 1.45);
 
-            // Reduce difficulty for low spacing since spacing below radius is always to be flowed
+            // Check how much of the difficulty relies on small distances that can be cheesed by playing them improperly
             if (aimCheese)
                 flowDifficulty *= DiffUtils.Smootherstep(currDistance, 0, OsuDifficultyHitObject.NORMALISED_DIAMETER);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -60,9 +60,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public double SliderFactor { get; set; }
 
         /// <summary>
-        /// Describes how much of <see cref="AimDifficulty"/> is contributed to by cheesing patterns.
-        /// A value closer to 1.0 indicates most of <see cref="AimDifficulty"/> is contributed by normal gameplay.
-        /// A value closer to 0.0 indicates most of <see cref="AimDifficulty"/> is contributed by taking shortcuts.
+        /// Describes how much of <see cref="AimDifficulty"/> is contributed to by cheesable patterns..
+        /// A value closer to 1.0 indicates most of <see cref="AimDifficulty"/> is contributed by normal patterns.
+        /// A value closer to 0.0 indicates most of <see cref="AimDifficulty"/> is contributed by cheesable patterns.
         /// </summary>
         [JsonProperty("cheese_factor")]
         public double CheeseFactor { get; set; }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyAttributes.cs
@@ -60,6 +60,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         public double SliderFactor { get; set; }
 
         /// <summary>
+        /// Describes how much of <see cref="AimDifficulty"/> is contributed to by cheesing patterns.
+        /// A value closer to 1.0 indicates most of <see cref="AimDifficulty"/> is contributed by normal gameplay.
+        /// A value closer to 0.0 indicates most of <see cref="AimDifficulty"/> is contributed by taking shortcuts.
+        /// </summary>
+        [JsonProperty("cheese_factor")]
+        public double CheeseFactor { get; set; }
+
+        /// <summary>
         /// Describes how much of <see cref="AimDifficultStrainCount"/> is contributed to by hitcircles or sliders
         /// A value closer to 0.0 indicates most of <see cref="AimDifficultStrainCount"/> is contributed by hitcircles
         /// A value closer to Infinity indicates most of <see cref="AimDifficultStrainCount"/> is contributed by sliders

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -33,14 +33,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (beatmap.HitObjects.Count == 0)
                 return new OsuDifficultyAttributes { Mods = mods };
 
-            var aim = skills.OfType<Aim>().Single(a => a.IncludeSliders);
-            var aimWithoutSliders = skills.OfType<Aim>().Single(a => !a.IncludeSliders);
+            var aim = skills.OfType<Aim>().Single(a => a.IncludeSliders && a.AimCheese);
+            var aimWithoutSliders = skills.OfType<Aim>().Single(a => !a.IncludeSliders && a.AimCheese);
+            var aimWithoutCheese = skills.OfType<Aim>().Single(a => a.IncludeSliders && !a.AimCheese);
             var speed = skills.OfType<Speed>().Single();
             var flashlight = skills.OfType<Flashlight>().SingleOrDefault();
             var reading = skills.OfType<Reading>().Single();
 
             double aimDifficultyValue = aim.DifficultyValue();
             double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
+            double aimNoCheeseDifficultyValue = aimWithoutCheese.DifficultyValue();
             double speedDifficultyValue = speed.DifficultyValue();
             double readingDifficultyValue = reading.DifficultyValue();
 
@@ -68,9 +70,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimRating = calculateAimDifficultyRating(aimDifficultyValue);
             double aimNoSlidersRating = calculateAimDifficultyRating(aimNoSlidersDifficultyValue);
+            double aimNoCheeseRating = calculateAimDifficultyRating(aimNoCheeseDifficultyValue);
 
             double sliderFactor = aimDifficultyValue > 0
                 ? aimNoSlidersRating / aimRating
+                : 1;
+
+            double cheeseFactor = aimDifficultyValue > 0
+                ? aimRating / aimNoCheeseRating
                 : 1;
 
             double speedRating = calculateDifficultyRating(speedDifficultyValue);
@@ -108,6 +115,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 FlashlightDifficulty = flashlightRating,
                 ReadingDifficulty = readingRating,
                 SliderFactor = sliderFactor,
+                CheeseFactor = cheeseFactor,
                 AimDifficultStrainCount = aimDifficultStrainCount,
                 SpeedDifficultStrainCount = speedDifficultStrainCount,
                 ReadingDifficultNoteCount = readingDifficultNoteCount,
@@ -166,8 +174,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var skills = new List<Skill>
             {
-                new Aim(mods, true),
-                new Aim(mods, false),
+                new Aim(mods, true, true),
+                new Aim(mods, false, true),
+                new Aim(mods, true, false),
                 new Speed(mods),
                 new Reading(mods)
             };

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuDifficultyCalculator.cs
@@ -33,16 +33,16 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             if (beatmap.HitObjects.Count == 0)
                 return new OsuDifficultyAttributes { Mods = mods };
 
-            var aim = skills.OfType<Aim>().Single(a => a.IncludeSliders && a.AimCheese);
-            var aimWithoutSliders = skills.OfType<Aim>().Single(a => !a.IncludeSliders && a.AimCheese);
-            var aimWithoutCheese = skills.OfType<Aim>().Single(a => a.IncludeSliders && !a.AimCheese);
+            var aim = skills.OfType<Aim>().Single(a => a.IncludeSliders && !a.AimCheese);
+            var aimWithoutSliders = skills.OfType<Aim>().Single(a => !a.IncludeSliders && !a.AimCheese);
+            var aimWithCheese = skills.OfType<Aim>().Single(a => a.IncludeSliders && a.AimCheese);
             var speed = skills.OfType<Speed>().Single();
             var flashlight = skills.OfType<Flashlight>().SingleOrDefault();
             var reading = skills.OfType<Reading>().Single();
 
             double aimDifficultyValue = aim.DifficultyValue();
             double aimNoSlidersDifficultyValue = aimWithoutSliders.DifficultyValue();
-            double aimNoCheeseDifficultyValue = aimWithoutCheese.DifficultyValue();
+            double aimCheeseDifficultyValue = aimWithCheese.DifficultyValue();
             double speedDifficultyValue = speed.DifficultyValue();
             double readingDifficultyValue = reading.DifficultyValue();
 
@@ -70,14 +70,14 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double aimRating = calculateAimDifficultyRating(aimDifficultyValue);
             double aimNoSlidersRating = calculateAimDifficultyRating(aimNoSlidersDifficultyValue);
-            double aimNoCheeseRating = calculateAimDifficultyRating(aimNoCheeseDifficultyValue);
+            double aimCheeseRating = calculateAimDifficultyRating(aimCheeseDifficultyValue);
 
             double sliderFactor = aimDifficultyValue > 0
                 ? aimNoSlidersRating / aimRating
                 : 1;
 
             double cheeseFactor = aimDifficultyValue > 0
-                ? aimRating / aimNoCheeseRating
+                ? aimCheeseRating / aimRating
                 : 1;
 
             double speedRating = calculateDifficultyRating(speedDifficultyValue);
@@ -174,9 +174,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         {
             var skills = new List<Skill>
             {
-                new Aim(mods, true, true),
-                new Aim(mods, false, true),
                 new Aim(mods, true, false),
+                new Aim(mods, false, false),
+                new Aim(mods, true, true),
                 new Speed(mods),
                 new Reading(mods)
             };

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -233,9 +233,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.0 + calculateTraceableBonus(attributes.SliderFactor);
             }
 
-            double baseNerf = 1 - DiffUtils.Smootherstep(cheeseFactor, 1, 0.93);
+            double baseNerf = 1 - DiffUtils.Smootherstep(cheeseFactor, 1, 0.95);
 
-            double cheeseNerf = baseNerf + (1 - baseNerf) * DiffUtils.Pow(DiffUtils.Erf(30.0 / totalDeviation.Value), 4);
+            double cheeseNerf = baseNerf + (1 - baseNerf) * DiffUtils.Pow(DiffUtils.Erf(23.0 / totalDeviation.Value), 4);
 
             aimValue *= accuracy * cheeseNerf;
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -233,7 +233,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.0 + calculateTraceableBonus(attributes.SliderFactor);
             }
 
-            double baseNerf = 1 - DiffUtils.Smootherstep(cheeseFactor, 1, 0.95);
+            double baseNerf = 1 - DiffUtils.Smootherstep(cheeseFactor, 1, 0.9);
 
             double cheeseNerf = baseNerf + (1 - baseNerf) * DiffUtils.Pow(DiffUtils.Erf(23.0 / totalDeviation.Value), 4);
 

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -58,7 +58,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         private double approachRate;
         private double drainRate;
 
+        private double? totalDeviation;
         private double? speedDeviation;
+        private double cheeseFactor;
 
         private double aimEstimatedSliderBreaks;
         private double speedEstimatedSliderBreaks;
@@ -150,7 +152,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 effectiveMissCount = Math.Min(effectiveMissCount + countOk * okMultiplier + countMeh * mehMultiplier, totalHits);
             }
 
+            totalDeviation = calculateTotalDeviation(osuAttributes);
             speedDeviation = calculateSpeedDeviation(osuAttributes);
+            cheeseFactor = osuAttributes.CheeseFactor;
 
             double aimValue = computeAimValue(score, osuAttributes);
             double speedValue = computeSpeedValue(score, osuAttributes);
@@ -181,7 +185,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         private double computeAimValue(ScoreInfo score, OsuDifficultyAttributes attributes)
         {
-            if (score.Mods.Any(h => h is OsuModAutopilot))
+            if (score.Mods.Any(h => h is OsuModAutopilot) || totalDeviation == null)
                 return 0.0;
 
             double aimDifficulty = attributes.AimDifficulty;
@@ -203,7 +207,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                     estimateImproperlyFollowedDifficultSliders = Math.Clamp(countSliderEndsDropped + countSliderTickMiss, 0, attributes.AimDifficultSliderCount);
                 }
 
-                double sliderNerfFactor = (1 - attributes.SliderFactor) * DiffUtils.Pow(1 - estimateImproperlyFollowedDifficultSliders / attributes.AimDifficultSliderCount, 3) + attributes.SliderFactor;
+                double sliderNerfFactor = (1 - attributes.SliderFactor) * DiffUtils.Pow(1 - estimateImproperlyFollowedDifficultSliders / attributes.AimDifficultSliderCount, 3)
+                                          + attributes.SliderFactor;
                 aimDifficulty *= sliderNerfFactor;
             }
 
@@ -228,7 +233,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty
                 aimValue *= 1.0 + calculateTraceableBonus(attributes.SliderFactor);
             }
 
-            aimValue *= accuracy;
+            double baseNerf = 1 - DiffUtils.Smootherstep(cheeseFactor, 1, 0.93);
+
+            double cheeseNerf = baseNerf + (1 - baseNerf) * DiffUtils.Pow(DiffUtils.Erf(30.0 / totalDeviation.Value), 4);
+
+            aimValue *= accuracy * cheeseNerf;
 
             return aimValue;
         }
@@ -482,6 +491,50 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             return deviation;
         }
 
+        /// <summary>
+        /// Estimates the player's total tapping deviation.
+        /// </summary>
+        private double? calculateTotalDeviation(OsuDifficultyAttributes attributes)
+        {
+            if (totalSuccessfulHits == 0)
+                return null;
+
+            if (!usingClassicSliderAccuracy)
+                return calculateDeviation(countGreat, countOk, countMeh);
+
+            int circleCount = attributes.HitCircleCount;
+            int missCountCircles = Math.Min(countMiss, circleCount);
+            int mehCountCircles = Math.Min(countMeh, circleCount - missCountCircles);
+            int okCountCircles = Math.Min(countOk, circleCount - missCountCircles - mehCountCircles);
+            int greatCountCircles = Math.Max(0, circleCount - missCountCircles - mehCountCircles - okCountCircles);
+
+            // Assume 100s, 50s, and misses happen on circles. If there are less non-300s on circles than 300s,
+            // compute the deviation on circles.
+            if (greatCountCircles > 0)
+            {
+                return calculateDeviation(greatCountCircles, okCountCircles, mehCountCircles);
+            }
+
+            // If there are more non-300s than there are circles, compute the deviation on sliders instead.
+            // Here, all that matters is whether or not the slider was missed, since it is impossible
+            // to get a 100 or 50 on a slider by mis-tapping it.
+            int sliderCount = attributes.SliderCount;
+            int missCountSliders = Math.Min(sliderCount, countMiss - missCountCircles);
+            int greatCountSliders = sliderCount - missCountSliders;
+
+            // We only get here if nothing was hit. In this case, there is no estimate for deviation.
+            // Note that this is never negative, so checking if this is only equal to 0 makes sense.
+            if (greatCountSliders == 0)
+            {
+                return null;
+            }
+
+            double greatProbabilitySlider = greatCountSliders / (sliderCount + 1.0);
+            double deviationOnSliders = mehHitWindow / (DiffUtils.SQRT2 * DiffUtils.ErfInv(greatProbabilitySlider));
+
+            return deviationOnSliders;
+        }
+
         // Calculates multiplier for speed to account for improper tapping based on the deviation and speed difficulty
         // https://www.desmos.com/calculator/dmogdhzofn
         private double calculateSpeedHighDeviationNerf(OsuDifficultyAttributes attributes)
@@ -536,7 +589,9 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         // so we use the amount of relatively difficult sections to adjust miss penalty
         // to make it more punishing on maps with lower amount of hard sections.
         private double calculateMissPenalty(double missCount, double difficultStrainCount) => 0.93 / (missCount / (4 * Math.Log(Math.Max(1, difficultStrainCount))) + 1);
-        private double getComboScalingFactor(OsuDifficultyAttributes attributes) => attributes.MaxCombo <= 0 ? 1.0 : Math.Min(DiffUtils.Pow(scoreMaxCombo, 0.8) / DiffUtils.Pow(attributes.MaxCombo, 0.8), 1.0);
+
+        private double getComboScalingFactor(OsuDifficultyAttributes attributes) =>
+            attributes.MaxCombo <= 0 ? 1.0 : Math.Min(DiffUtils.Pow(scoreMaxCombo, 0.8) / DiffUtils.Pow(attributes.MaxCombo, 0.8), 1.0);
 
         private double calculateRateAdjustedApproachRate(double approachRate, double clockRate)
         {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -589,9 +589,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
         // so we use the amount of relatively difficult sections to adjust miss penalty
         // to make it more punishing on maps with lower amount of hard sections.
         private double calculateMissPenalty(double missCount, double difficultStrainCount) => 0.93 / (missCount / (4 * Math.Log(Math.Max(1, difficultStrainCount))) + 1);
-
-        private double getComboScalingFactor(OsuDifficultyAttributes attributes) =>
-            attributes.MaxCombo <= 0 ? 1.0 : Math.Min(DiffUtils.Pow(scoreMaxCombo, 0.8) / DiffUtils.Pow(attributes.MaxCombo, 0.8), 1.0);
+        private double getComboScalingFactor(OsuDifficultyAttributes attributes) => attributes.MaxCombo <= 0 ? 1.0 : Math.Min(DiffUtils.Pow(scoreMaxCombo, 0.8) / DiffUtils.Pow(attributes.MaxCombo, 0.8), 1.0);
 
         private double calculateRateAdjustedApproachRate(double approachRate, double clockRate)
         {

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double cheeseNerf = baseNerf + (1 - baseNerf) * DiffUtils.Pow(DiffUtils.Erf(23.0 / totalDeviation.Value), 4);
 
-            aimValue *= accuracy * Math.Max(Math.Pow(cheeseFactor, 5), cheeseNerf);
+            aimValue *= accuracy * cheeseNerf;
 
             return aimValue;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -237,7 +237,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
             double cheeseNerf = baseNerf + (1 - baseNerf) * DiffUtils.Pow(DiffUtils.Erf(23.0 / totalDeviation.Value), 4);
 
-            aimValue *= accuracy * cheeseNerf;
+            aimValue *= accuracy * Math.Max(Math.Pow(cheeseFactor, 5), cheeseNerf);
 
             return aimValue;
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Aim.cs
@@ -22,11 +22,13 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
     public class Aim : VariableLengthStrainSkill
     {
         public readonly bool IncludeSliders;
+        public readonly bool AimCheese;
 
-        public Aim(Mod[] mods, bool includeSliders)
+        public Aim(Mod[] mods, bool includeSliders, bool aimCheese)
             : base(mods)
         {
             IncludeSliders = includeSliders;
+            AimCheese = aimCheese;
         }
 
         private double currentStrain;
@@ -62,7 +64,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double snapDifficulty = SnapAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skill_multiplier_snap;
             double agilityDifficulty = AgilityEvaluator.EvaluateDifficultyOf(current) * skill_multiplier_agility;
-            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders) * skill_multiplier_flow;
+            double flowDifficulty = FlowAimEvaluator.EvaluateDifficultyOf(current, IncludeSliders, AimCheese) * skill_multiplier_flow;
 
             double totalDifficulty = calculateTotalValue(snapDifficulty, agilityDifficulty, flowDifficulty);
 


### PR DESCRIPTION
Currently the flow evaluator is holding the strain nerf for low spacing initially created to nerf "doubles" pattern maps such as [Little Summer Party](https://osu.ppy.sh/beatmapsets/2361582#osu/5090215) and [Crystalia](https://osu.ppy.sh/beatmapsets/2288605#osu/4883677). 

These patterns are broken when played unoptimally, practically disregarding the flow aim required and snapping between them while galloping. This is only possible to achieve either with tanking your accuracy or having the map on OD low enough that the extra hitwindow gives you enough leniency to do so which is why the highest pp plays on these maps are set with the EZ mod. 

The live implementation of the nerf does not punish such play enough while also overpunishing correct play on the patterns. This change aims to create a factor to be used in performance calculation that relies on deviation, heavily nerfing attempts at using increased hit windows or bad accuracy to make the patterns trivial. 