### PR TITLE
Re-enable online asset cache with hopefully improved performance

### DIFF
--- a/osu.Game.Tests/Database/GeneralUsageTests.cs
+++ b/osu.Game.Tests/Database/GeneralUsageTests.cs
@@ -97,20 +97,24 @@ namespace osu.Game.Tests.Database
         [Test]
         public void TestAsyncWriteBeforeDisposal()
         {
-            ManualResetEventSlim resetEvent = new ManualResetEventSlim();
+            ManualResetEventSlim asyncWriteStarted = new ManualResetEventSlim();
+            ManualResetEventSlim asyncWriteCompleted = new ManualResetEventSlim();
 
             RunTestWithRealm((realm, _) =>
             {
                 var writeTask = realm.WriteAsync(r =>
                 {
-                    // ensure that disposal blocks for our execution
-                    Assert.That(resetEvent.Wait(100), Is.False);
+                    asyncWriteStarted.Set();
 
                     r.Add(TestResources.CreateTestBeatmapSetInfo());
+
+                    // ensure that disposal blocks for our execution
+                    Assert.That(asyncWriteCompleted.Wait(100), Is.False);
                 });
 
+                asyncWriteStarted.Wait(10000);
                 realm.Dispose();
-                resetEvent.Set();
+                asyncWriteCompleted.Set();
 
                 writeTask.WaitSafely();
             });

--- a/osu.Game/Database/RealmAccess.cs
+++ b/osu.Game/Database/RealmAccess.cs
@@ -106,23 +106,18 @@ namespace osu.Game.Database
         private const int schema_version = 52;
 
         /// <summary>
-        /// Lock object which is held during <see cref="BlockAllOperations"/> sections, blocking realm retrieval during blocking periods.
+        /// Reader-writer lock used to coordinate async operations.
+        /// Its main purpose is to make an effort to ensure off-thread operations conclude before performing operations
+        /// that could cause loss of data if async operations were to be permitted to execute concurrently.
+        /// <list type="bullet">
+        /// <item>The reader lock is taken by threads other than update performing the operations.</item>
+        /// <item>The writer lock is taken by <see cref="BlockAllOperations"/> and <see cref="Dispose"/>.</item>
+        /// </list>
         /// </summary>
-        private readonly SemaphoreSlim realmRetrievalLock = new SemaphoreSlim(1);
-
-        /// <summary>
-        /// This <see cref="CancellationTokenSource"/> is cancelled on disposal
-        /// so that all callers of <see cref="getRealmInstance"/> who are blocked on <see cref="realmRetrievalLock"/>
-        /// can hard-fail the retrieval rather than spin on the semaphore forever.
-        /// </summary>
-        private readonly CancellationTokenSource realmRetrievalCancellation = new CancellationTokenSource();
-
-        private readonly CountdownEvent pendingAsyncOperations = new CountdownEvent(0);
-
-        /// <summary>
-        /// <c>true</c> when the current thread has already entered the <see cref="realmRetrievalLock"/>.
-        /// </summary>
-        private readonly ThreadLocal<bool> currentThreadHasRealmRetrievalLock = new ThreadLocal<bool>();
+        /// <remarks>
+        /// <see cref="LockRecursionPolicy.SupportsRecursion"/> is specified to support nested calls of <see cref="Run"/> and <see cref="Write"/> inside themselves or one another.
+        /// </remarks>
+        private readonly ReaderWriterLockSlim offThreadOperationLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
 
         /// <summary>
         /// Holds a map of functions registered via <see cref="RegisterCustomSubscription"/> and <see cref="RegisterForNotifications{T}"/> and a coinciding action which when triggered,
@@ -220,8 +215,17 @@ namespace osu.Game.Database
 #endif
 
             // `prepareFirstRealmAccess()` triggers the first `getRealmInstance` call, which will implicitly run realm migrations and bring the schema up-to-date.
-            using (var realm = prepareFirstRealmAccess())
-                cleanupPendingDeletions(realm);
+            try
+            {
+                offThreadOperationLock.EnterWriteLock();
+                using (var realm = prepareFirstRealmAccess())
+                    cleanupPendingDeletions(realm);
+            }
+            finally
+            {
+                if (offThreadOperationLock.IsWriteLockHeld)
+                    offThreadOperationLock.ExitWriteLock();
+            }
         }
 
         /// <summary>
@@ -459,9 +463,18 @@ namespace osu.Game.Database
                 return action(Realm);
             }
 
-            total_reads_async.Value++;
-            using (var realm = getRealmInstance())
-                return action(realm);
+            try
+            {
+                offThreadOperationLock.EnterReadLock();
+                total_reads_async.Value++;
+                using (var realm = getRealmInstance())
+                    return action(realm);
+            }
+            finally
+            {
+                if (offThreadOperationLock.IsReadLockHeld)
+                    offThreadOperationLock.ExitReadLock();
+            }
         }
 
         /// <summary>
@@ -474,12 +487,20 @@ namespace osu.Game.Database
             {
                 total_reads_update.Value++;
                 action(Realm);
+                return;
             }
-            else
+
+            try
             {
+                offThreadOperationLock.EnterReadLock();
                 total_reads_async.Value++;
                 using (var realm = getRealmInstance())
                     action(realm);
+            }
+            finally
+            {
+                if (offThreadOperationLock.IsReadLockHeld)
+                    offThreadOperationLock.ExitReadLock();
             }
         }
 
@@ -490,19 +511,13 @@ namespace osu.Game.Database
         {
             ObjectDisposedException.ThrowIf(isDisposed, this);
 
-            // Required to ensure the read is tracked and accounted for before disposal.
-            // Can potentially be avoided if we have a need to do so in the future.
-            if (!ThreadSafety.IsUpdateThread)
-                throw new InvalidOperationException($@"{nameof(RunAsync)} must be called from the update thread.");
-
-            // CountdownEvent will fail if already at zero.
-            if (!pendingAsyncOperations.TryAddCount())
-                pendingAsyncOperations.Reset(1);
-
             return Task.Run(() =>
             {
+                ObjectDisposedException.ThrowIf(isDisposed, this);
+
+                offThreadOperationLock.EnterReadLock();
                 var result = Run(action);
-                pendingAsyncOperations.Signal();
+                offThreadOperationLock.ExitReadLock();
                 return result;
             }, token);
         }
@@ -518,12 +533,19 @@ namespace osu.Game.Database
                 total_writes_update.Value++;
                 return Realm.Write(action);
             }
-            else
-            {
-                total_writes_async.Value++;
 
+            total_writes_async.Value++;
+
+            try
+            {
+                offThreadOperationLock.EnterReadLock();
                 using (var realm = getRealmInstance())
                     return realm.Write(action);
+            }
+            finally
+            {
+                if (offThreadOperationLock.IsReadLockHeld)
+                    offThreadOperationLock.ExitReadLock();
             }
         }
 
@@ -537,13 +559,21 @@ namespace osu.Game.Database
             {
                 total_writes_update.Value++;
                 Realm.Write(action);
+                return;
             }
-            else
+
+            try
             {
+                offThreadOperationLock.EnterReadLock();
                 total_writes_async.Value++;
 
                 using (var realm = getRealmInstance())
                     realm.Write(action);
+            }
+            finally
+            {
+                if (offThreadOperationLock.IsReadLockHeld)
+                    offThreadOperationLock.ExitReadLock();
             }
         }
 
@@ -555,32 +585,31 @@ namespace osu.Game.Database
         {
             ObjectDisposedException.ThrowIf(isDisposed, this);
 
-            // Required to ensure the write is tracked and accounted for before disposal.
-            // Can potentially be avoided if we have a need to do so in the future.
-            if (!ThreadSafety.IsUpdateThread)
-                throw new InvalidOperationException(@$"{nameof(WriteAsync)} must be called from the update thread.");
-
-            // CountdownEvent will fail if already at zero.
-            if (!pendingAsyncOperations.TryAddCount())
-                pendingAsyncOperations.Reset(1);
-
             // Regardless of calling Realm.GetInstance or Realm.GetInstanceAsync, there is a blocking overhead on retrieval.
             // Adding a forced Task.Run resolves this.
-            var writeTask = Task.Run(async () =>
+            return Task.Run(async () =>
             {
+                ObjectDisposedException.ThrowIf(isDisposed, this);
+
                 total_writes_async.Value++;
 
-                // Not attempting to use Realm.GetInstanceAsync as there's seemingly no benefit to us (for now) and it adds complexity due to locking
-                // concerns in getRealmInstance(). On a quick check, it looks to be more suited to cases where realm is connecting to an online sync
-                // server, which we don't use. May want to report upstream or revisit in the future.
-                using (var realm = getRealmInstance())
-                    // ReSharper disable once AccessToDisposedClosure (WriteAsync should be marked as [InstantHandle]).
-                    await realm.WriteAsync(() => action(realm)).ConfigureAwait(false);
+                try
+                {
+                    offThreadOperationLock.EnterReadLock();
 
-                pendingAsyncOperations.Signal();
+                    // Not attempting to use Realm.GetInstanceAsync as there's seemingly no benefit to us (for now) and it adds complexity due to locking
+                    // concerns in getRealmInstance(). On a quick check, it looks to be more suited to cases where realm is connecting to an online sync
+                    // server, which we don't use. May want to report upstream or revisit in the future.
+                    using (var realm = getRealmInstance())
+                        // ReSharper disable once AccessToDisposedClosure (WriteAsync should be marked as [InstantHandle]).
+                        await realm.WriteAsync(() => action(realm)).ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (offThreadOperationLock.IsReadLockHeld)
+                        offThreadOperationLock.ExitReadLock();
+                }
             });
-
-            return writeTask;
         }
 
         /// <summary>
@@ -591,31 +620,33 @@ namespace osu.Game.Database
         {
             ObjectDisposedException.ThrowIf(isDisposed, this);
 
-            // Required to ensure the write is tracked and accounted for before disposal.
-            // Can potentially be avoided if we have a need to do so in the future.
-            if (!ThreadSafety.IsUpdateThread)
-                throw new InvalidOperationException(@$"{nameof(WriteAsync)} must be called from the update thread.");
-
-            // CountdownEvent will fail if already at zero.
-            if (!pendingAsyncOperations.TryAddCount())
-                pendingAsyncOperations.Reset(1);
-
             // Regardless of calling Realm.GetInstance or Realm.GetInstanceAsync, there is a blocking overhead on retrieval.
             // Adding a forced Task.Run resolves this.
             var writeTask = Task.Run(async () =>
             {
-                T result;
-                total_writes_async.Value++;
+                ObjectDisposedException.ThrowIf(isDisposed, this);
 
-                // Not attempting to use Realm.GetInstanceAsync as there's seemingly no benefit to us (for now) and it adds complexity due to locking
-                // concerns in getRealmInstance(). On a quick check, it looks to be more suited to cases where realm is connecting to an online sync
-                // server, which we don't use. May want to report upstream or revisit in the future.
-                using (var realm = getRealmInstance())
-                    // ReSharper disable once AccessToDisposedClosure (WriteAsync should be marked as [InstantHandle]).
-                    result = await realm.WriteAsync(() => action(realm)).ConfigureAwait(false);
+                try
+                {
+                    offThreadOperationLock.EnterReadLock();
 
-                pendingAsyncOperations.Signal();
-                return result;
+                    T result;
+                    total_writes_async.Value++;
+
+                    // Not attempting to use Realm.GetInstanceAsync as there's seemingly no benefit to us (for now) and it adds complexity due to locking
+                    // concerns in getRealmInstance(). On a quick check, it looks to be more suited to cases where realm is connecting to an online sync
+                    // server, which we don't use. May want to report upstream or revisit in the future.
+                    using (var realm = getRealmInstance())
+                        // ReSharper disable once AccessToDisposedClosure (WriteAsync should be marked as [InstantHandle]).
+                        result = await realm.WriteAsync(() => action(realm)).ConfigureAwait(false);
+
+                    return result;
+                }
+                finally
+                {
+                    if (offThreadOperationLock.IsReadLockHeld)
+                        offThreadOperationLock.ExitReadLock();
+                }
             });
 
             return writeTask;
@@ -777,37 +808,8 @@ namespace osu.Game.Database
         private Realm getRealmInstance()
         {
             ObjectDisposedException.ThrowIf(isDisposed, this);
-
-            bool tookSemaphoreLock = false;
-
-            try
-            {
-                // Ensure that the thread that currently has the `realmRetrievalLock` can retrieve nested contexts and not deadlock on itself.
-                if (!currentThreadHasRealmRetrievalLock.Value)
-                {
-                    realmRetrievalLock.Wait(realmRetrievalCancellation.Token);
-                    currentThreadHasRealmRetrievalLock.Value = true;
-                    tookSemaphoreLock = true;
-                }
-                else
-                {
-                    // the semaphore is used to handle blocking of all realm retrieval during certain periods.
-                    // once the semaphore has been taken by this code section, it is safe to retrieve further realm instances on the same thread.
-                    // this can happen if a realm subscription is active and triggers a callback which has user code that calls `Run`.
-                }
-
-                realm_instances_created.Value++;
-
-                return Realm.GetInstance(getConfiguration());
-            }
-            finally
-            {
-                if (tookSemaphoreLock)
-                {
-                    realmRetrievalLock.Release();
-                    currentThreadHasRealmRetrievalLock.Value = false;
-                }
-            }
+            realm_instances_created.Value++;
+            return Realm.GetInstance(getConfiguration());
         }
 
         private RealmConfiguration getConfiguration(string? filename = null)
@@ -1343,8 +1345,8 @@ namespace osu.Game.Database
         /// <param name="backupFilename">The filename for the backup.</param>
         public void CreateBackup(string backupFilename)
         {
-            if (realmRetrievalLock.CurrentCount != 0)
-                throw new InvalidOperationException($"Call {nameof(BlockAllOperations)} before creating a backup.");
+            if (!offThreadOperationLock.IsWriteLockHeld)
+                throw new InvalidOperationException($@"Call {nameof(BlockAllOperations)} before creating a backup.");
 
             createBackup(backupFilename);
         }
@@ -1389,7 +1391,8 @@ namespace osu.Game.Database
 
             try
             {
-                realmRetrievalLock.Wait();
+                if (!offThreadOperationLock.TryEnterWriteLock(10000))
+                    Logger.Log(@"Realm took too long waiting on pending off-thread operations", level: LogLevel.Error);
 
                 if (hasInitialisedOnce)
                 {
@@ -1441,7 +1444,7 @@ namespace osu.Game.Database
                 syncContext?.Send(_ =>
                 {
                     // Flag ensures that we don't get in a deadlocked scenario due to a callback attempting to access `RealmAccess.Realm` or `RealmAccess.Run`
-                    // and hitting `realmRetrievalLock` a second time. Generally such usages should not exist, and as such we throw when an attempt is made
+                    // and hitting `offThreadOperationLock` a second time. Generally such usages should not exist, and as such we throw when an attempt is made
                     // to use in this fashion.
                     isSendingNotificationResetEvents = true;
 
@@ -1469,10 +1472,7 @@ namespace osu.Game.Database
 
             void restoreOperation()
             {
-                // Release of lock needs to happen here rather than on the update thread, as there may be another
-                // operation already blocking the update thread waiting for the blocking operation to complete.
                 Logger.Log(@"Restoring realm operations.", LoggingTarget.Database);
-                realmRetrievalLock.Release();
 
                 if (syncContext == null) return;
 
@@ -1485,6 +1485,8 @@ namespace osu.Game.Database
                 {
                     syncContext.Send(_ =>
                     {
+                        if (offThreadOperationLock.IsWriteLockHeld)
+                            offThreadOperationLock.ExitWriteLock();
                         ensureUpdateRealm();
                         updateRealmReestablished.Set();
                     }, null);
@@ -1493,6 +1495,8 @@ namespace osu.Game.Database
                 {
                     syncContext.Post(_ =>
                     {
+                        if (offThreadOperationLock.IsWriteLockHeld)
+                            offThreadOperationLock.ExitWriteLock();
                         ensureUpdateRealm();
                         updateRealmReestablished.Set();
                     }, null);
@@ -1512,20 +1516,27 @@ namespace osu.Game.Database
 
         public void Dispose()
         {
-            if (!pendingAsyncOperations.Wait(10000))
-                Logger.Log("Realm took too long waiting on pending async writes", level: LogLevel.Error);
+            if (isDisposed)
+                return;
+
+            // first, start by attempting to prevent simultaneous off-thread operations by taking the async operation write lock.
+            // the timeout is specified because cleaning up resources is more important than an absolute guarantee of taking the lock.
+            bool tookWriteLock = offThreadOperationLock.TryEnterWriteLock(10000);
+            if (!tookWriteLock)
+                Logger.Log(@"Realm took too long waiting on pending async writes", level: LogLevel.Error);
+
+            // setting the disposal flag prevents other callers of `Dispose()` from attempting to acquire the write lock too,
+            // and ensures that anyone wanting to take the read lock can check `isDisposed` first and throw.
+            isDisposed = true;
 
             updateRealm?.Dispose();
 
-            if (!isDisposed)
+            if (tookWriteLock)
             {
-                // intentionally block realm retrieval indefinitely. this ensures that nothing can start consuming a new instance after disposal.
-                realmRetrievalLock.Wait();
-                realmRetrievalLock.Dispose();
-                // also unblock all readers who may be spinning on realm retrieval.
-                realmRetrievalCancellation.Cancel();
-
-                isDisposed = true;
+                offThreadOperationLock.ExitWriteLock();
+                // the rwlock can only be disposed if nobody is waiting on it, otherwise it will throw exceptions.
+                // if the write lock was never taken, just let this spill on the floor - not much can be done in this situation anyway.
+                offThreadOperationLock.Dispose();
             }
         }
     }

--- a/osu.Game/Graphics/OnlineAssetCachingStore.cs
+++ b/osu.Game/Graphics/OnlineAssetCachingStore.cs
@@ -2,11 +2,21 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Game.Database;
+using osu.Game.Extensions;
+using osu.Game.Models;
 using osu.Game.Online;
+using Realms;
 
 namespace osu.Game.Graphics
 {
@@ -24,66 +34,103 @@ namespace osu.Game.Graphics
     /// as it both makes the caching ineffective <b>AND</b> trashes the cache with entries that will never be used again.
     /// </para>
     /// </summary>
-    public class OnlineAssetCachingStore : IDisposable
+    public class OnlineAssetCachingStore : IResourceStore<byte[]?>
     {
-        // ReSharper disable NotAccessedField.Local
         private readonly RealmAccess realmAccess;
-        private readonly OnlineStore onlineStore;
-        private readonly RealmFileStore fileStore;
+        private readonly RealmFileStore realmFileStore;
+        private readonly OnlineStore onlineResourceStore;
+        private readonly StorageBackedResourceStore localResourceStore;
         private readonly LargeTextureStore largeTextureStore;
+
+        private readonly ConcurrentDictionary<string, string> cachedPaths = [];
 
         public OnlineAssetCachingStore(GameHost host, RealmAccess realmAccess)
         {
             this.realmAccess = realmAccess;
-            onlineStore = new TrustedDomainOnlineStore();
-            fileStore = new RealmFileStore(realmAccess, host.Storage);
-            // largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(new StorageBackedResourceStore(fileStore.Storage)));
-            largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(onlineStore));
+            realmFileStore = new RealmFileStore(realmAccess, host.Storage);
+            onlineResourceStore = new TrustedDomainOnlineStore();
+            localResourceStore = new StorageBackedResourceStore(realmFileStore.Storage);
+            largeTextureStore = new LargeTextureStore(host.Renderer, host.CreateTextureLoaderStore(this));
         }
 
-        public Texture? Get(string url)
+        public Texture? Get(string url) => largeTextureStore.Get(url);
+
+        #region IResourceStore<byte[]>
+
+        byte[] IResourceStore<byte[]?>.Get(string name) => throw new NotSupportedException();
+
+        Task<byte[]?> IResourceStore<byte[]?>.GetAsync(string name, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        /// <remarks>
+        /// The reason why this class implements <see cref="IResourceStore{T}"/> explicitly
+        /// instead of just wrapping <see cref="largeTextureStore"/>
+        /// is that in the cache miss case, it is not desirable to wait for realm operations to complete
+        /// as that will induce additional delays on devices with slow disk I/O.
+        /// To this end, the online asset is retrieved, then copied off;
+        /// the original requester of the asset gets the original online stream, while the realm store write happens in the background.
+        /// </remarks>
+        Stream? IResourceStore<byte[]?>.GetStream(string url)
         {
-            if (string.IsNullOrWhiteSpace(url))
+            if (string.IsNullOrEmpty(url))
                 return null;
 
-            return largeTextureStore.Get(url);
+            if (cachedPaths.TryGetValue(url, out string? cachedPath))
+                return localResourceStore.GetStream(cachedPath);
 
-            // TODO: logic below temporarily disabled as it causes unacceptable performance on devices with slow I/O due to realm abuse
-            // see https://github.com/ppy/osu/issues/38651#issuecomment-5356443643 for details
+            string? path = realmAccess.Run(r =>
+            {
+                var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
+                return a?.File.File.GetStoragePath();
+            });
 
-            // string? path = realmAccess.Write(r =>
-            // {
-            //     var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
-            //     if (a != null)
-            //         a.LastAccessed = DateTimeOffset.Now;
-            //     return a?.File.File.GetStoragePath();
-            // });
+            if (path == null)
+            {
+                var onlineStream = onlineResourceStore.GetStream(url);
 
-            // if (path == null)
-            // {
-            //     var onlineStream = onlineStore.GetStream(url);
+                if (onlineStream == null)
+                    return null;
 
-            //     if (onlineStream == null)
-            //         return null;
+                var copyForAsyncWrite = new MemoryStream();
+                onlineStream.CopyTo(copyForAsyncWrite);
+                // relies on the underlying stream being `MemoryStream` (implementation-dependent)
+                onlineStream.Seek(0, SeekOrigin.Begin);
 
-            //     path = realmAccess.Write(r =>
-            //     {
-            //         var file = fileStore.Add(onlineStream, r);
-            //         r.Add(new RealmOnlineAsset(file, url));
-            //         return file.GetStoragePath();
-            //     });
-            // }
-            // else
-            // {
-            //     Logger.Log($"Online asset {url} retrieved from {nameof(OnlineAssetCachingStore)}.", LoggingTarget.Network);
-            // }
+                realmAccess.WriteAsync(r =>
+                {
+                    var file = realmFileStore.Add(copyForAsyncWrite, r, addToRealm: false);
+                    return r.Add(new RealmOnlineAsset(file, url));
+                }).ContinueWith(t =>
+                {
+                    if (t.IsFaulted)
+                        Logger.Log($@"Failed to write {nameof(RealmOnlineAsset)} to realm: {t.Exception}", LoggingTarget.Database);
+                });
 
-            // return largeTextureStore.Get(path);
+                return onlineStream;
+            }
+
+            Logger.Log($"Online asset {url} retrieved from {nameof(OnlineAssetCachingStore)}.", LoggingTarget.Network);
+            realmAccess.WriteAsync(r =>
+            {
+                var a = r.All<RealmOnlineAsset>().Filter($@"{nameof(RealmOnlineAsset.File)}.{nameof(RealmNamedFileUsage.Filename)} == $0", url).FirstOrDefault();
+                if (a != null)
+                    a.LastAccessed = DateTimeOffset.Now;
+            }).ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    Logger.Log($@"Failed to update last access date of {nameof(RealmOnlineAsset)} to realm: {t.Exception}", LoggingTarget.Database);
+            });
+
+            cachedPaths.TryAdd(url, path);
+            return localResourceStore.GetStream(path);
         }
+
+        IEnumerable<string> IResourceStore<byte[]?>.GetAvailableResources() => throw new NotSupportedException();
+
+        #endregion
 
         public void Dispose()
         {
-            onlineStore.Dispose();
+            onlineResourceStore.Dispose();
             largeTextureStore.Dispose();
         }
     }


### PR DESCRIPTION
## [Rewrite synchronisation logic in RealmAccess to permit off-update-thread async writes](https://github.com/ppy/osu/commit/ab83222062484c2f016f21a2b7d193779dff0594)

### Why off-update-thread async writes matter

(Note to reader: this is mostly a re-hash of https://github.com/ppy/osu/issues/38651#issuecomment-5356443643, so if you feel like you're up to speed with that, you can skip this section.)

The attempt to add a store for caching online assets backed by realm (https://github.com/ppy/osu/pull/38454) [pushed realm to a painful breaking point *on some devices*.](https://github.com/ppy/osu/issues/38651) In particular, most complainants of bad performance of the cache self-report as having HDDs / spinning rust drives rather than SSDs.

There were echoes of this even prior to this change, as users would frequently complain of degraded performance after difficulty / pp calculation change rollouts, which trigger many background writes to realm.

Upon closer inspections in deeply unfavourable I/O conditions (read: a 15-year-old USB 2.0 pendrive being the backing for game storage), it has emerged that Realm has a major serialising factor in the form of a mutex called `m_notifier_mutex`.

The particularly notable takers of that mutex are:

- [`RealmCoordinator::process_available_async()`](https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/impl/realm_coordinator.cpp#L1177) is in particular triggered via the retrieval of a new realm instance.

- [`RealmCoordinator::commit_write()`](https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/impl/realm_coordinator.cpp#L777) is triggered on every realm write. Of note, this critical section includes a call to [`commit_and_continue_as_read()`](https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/impl/realm_coordinator.cpp#L778), and that call passes forward the `commit_to_disk` parameter.

  `commit_to_disk` is [true when the transaction is synchronous](https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/shared_realm.cpp#L1072), and [false when the transaction is asynchronous](https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/shared_realm.cpp#L960). What this means in essence is that synchronous writes - most notably, the part of it related to persistence to disk - are *entirely* in this critical section. Thus, if this write takes a long time, it will result in significant lock contention.

- [`RealmCoordinator::advance_to_ready()`](https://github.com/realm/realm-core/blob/f8752e180b7f288feadffafdef818068755efe0a/src/realm/object-store/impl/realm_coordinator.cpp#L1068) is triggered on every realm subscription callback via every realm write, *regardless* of whether the write *actually needs to fire the callback at all*. What makes matters considerably worse is that due to installation of the update thread synchronisation context to realm callbacks (see [[1]](https://github.com/ppy/osu/blob/e9451fe70b91292c482bab203ea87bd727eaa237/osu.Game/Database/RealmAccess.cs#L210), [[2]](https://github.com/realm/realm-dotnet/blob/113c01264fc00f6cedf3c829caa9cfb30b963914/Realm/Realm/Native/SynchronizationContextScheduler.cs#L80-L83)), the *entirety* of any lock wait here occurs *squarely* on the update thread.

In light of all the above, permitting asynchronous writes makes the situation *marginally* less bad by excluding the slow disk write from the commit critical path, which by extension should reduce lock contention and therefore decrease (**but not eliminate**) blocking lock waits on update thread from realm subscriptions, which people refer to as "horrible stutters".

The blocking lock waits **will** still occur whenever realm decides to write out any pending async changes to disk.

Note that there's a second implication to all the above, namely that generally realm instances should be taken *as little as possible* to avoid lock thrashing as well. This is not going to be significant in subsequent deliberations, but it is worth putting a pin in for the future.

### Why rewrite synchronisation completely

As I was working through making async writes from threads other than update, I found myself more and more confounded by the current synchronisation logic.

I will leave aside cryptic comments which I mostly cannot decipher these days, and focus on what synchronisation primitives are there currently in master.

- `realmRetrievalLock`: a `SemaphoreSlim`, with maximum capacity of one. It ensures that only one thread at a time can be taking out a realm instance. The xmldoc states that its entire purpose is to make `BlockAllOperations()` work, as in while some blocking work is done on the entire realm (like a remove or a backup), threads should not be able to access the realm.

  Note that if that is the sole purpose of this synchronisation primitive, then it is too *strong* for that purpose. Because that semaphore has a maximum capacity of one, it ensures *mutual exclusion*. But in normal conditions there's no reason to ensure that. The thing we want is a *subset* of this guarantee - if a *blocking operation* is occurring, no other threads are allowed. But there's no reason to disallow *concurrent* accesses otherwise.

  Additionally, a pertinent note is that the lock only protects the critical section of *retrieving* the realm. It does not protect *executing actions* on the realm. So you could very well take out a realm safely, but then hold onto it for some inordinate amount of time and then find yourself in a position of performing operations on it when it's already in an invalid / disposed state.

  A final observation is that this semaphore is supplemented by `currentThreadHasRealmRetrievalLock` to essentially make the semaphore re-entrant.

- `pendingAsyncOperations`: a `CountdownEvent`. Its stated purpose is to track any ongoing async operations; the countdown hits zero when there are no more async operations in progress. This matters because ideally we want to let async operations complete before shutting things down, e.g. in disposal.

  There are two issues with this countdown. One is that in several instances the following pattern is used:

  ```csharp
  // CountdownEvent will fail if already at zero.
  if (!pendingAsyncOperations.TryAddCount())
      pendingAsyncOperations.Reset(1);
  ```

  That is just incorrect usage. The pattern of usage is not atomic, and therefore the countdown offers *no* protection over a plain, *unsynchronised* counter field.

  Secondly, for reasons I do not follow, `BlockAllOperations()` just *completely ignores* this counter. Would it not be pertinent to attempt to wait for async writes before a blocking operation?

The general pattern of this analysis is this: the locking is both incorrect in places, and insufficient in others. I would not be surprised to find that this is why we've had a bunch of CI runs crash on realm subscription-related code, though that is a hypothesis that is currently not falsifiable as I have not run enough CI runs.

Looking at this from a simpler angle: a lot of synchronisation is already handled by realm[^disposal-assumption]. As far as our usage goes, there are two special cases to handle, which are blocking operations and shutdowns, and both essentially boil down to making sure nobody else is touching the realm. Which is what a [readers-writer lock](https://en.wikipedia.org/wiki/Readers–writer_lock) is for.

[^disposal-assumption]: In particular, here I am assuming that e.g. disposing a realm instance that has writes pending *on the realm side* will somehow ensure the write is flushed. I haven't verified this, I am mostly hoping this is the case.

All three synchronisation primitives that previously existed are pretty easily replaced with a rwlock. All off-thread realm reads and writes take the read side of the lock, while `BlockAllOperations()` and disposal take the write side of the lock.

Note that `ReaderWriterLockSlim` is *thread-level*, e.g. it uses thread-locals to operate.

There are two caveats here:

- All realm reads and writes *on the update thread* do not take the rwlock *at all*. Initially I wanted the update thread to take an upgradeable read lock and upgrade it to write during `BlockAllOperations()`. This concept is however broken because of async disposal.

  Async disposal has to take the write lock to clean up, and if that is attempted while the update thread is holding the upgradeable read lock, the write lock will be waited on forever. And there is no apparent clean attachment point to tell the update thread to relinquish the upgradeable read lock.

  To that end, update thread safety is mostly upheld by `IsUpdateThread` checks. I *think* that makes sense, but it may make sense to review that with a finer comb.

- The rwlock is created with `LockRecursionPolicy.SupportsRecursion`. This is [advised against](https://learn.microsoft.com/en-us/dotnet/api/system.threading.readerwriterlockslim?view=net-10.0#enter-the-lock-recursively) and I generally did not want to do this, but it *is* important because there are usage sites that e.g. nest `RealmAccess.Run()` calls inside `RealmAccess.Write()` calls. This would result in recursive lock-taking and thus a crash.

  Declaring this policy is *probably* avoidable, but would result in much more annoying code; every thread taking the lock would need to *explicitly* track whether it already is holding it, then maybe take it, and then finally depending on whether it took it relinquish it again. I'd rather just try recursive taking first and see if it blows up instead.

## [Rewrite online asset caching store to incur less synchronous overhead](https://github.com/ppy/osu/commit/ae2da408fba4379244c0a8c972495730445e91aa)

This commit attempts to reshuffle `OnlineAssetCachingStore` itself in a way that maybe results in more acceptable performance with users who are I/O-capped.

It is somewhat difficult for me to tell what the results will be in practice; in testing with a setup predicated on a slow pendrive, I appear to have basically wasted the pendrive to the degree that it looks almost completely fried to a degree that it was not when I started.

That said, let's explain the changes.

### The entirety of the store to the realm file store occurs outside of the main operation

One thing that I didn't really consider when writing the original version of the cache is that in the event of a cache miss, the loading time of the asset is increased by the *totality* of the duration required to copy the asset out into the store. In scenarios of significant I/O degradation this may appear as significantly worsened UX.

To counteract this, the store now implements `IResourceStore<byte>?` itself. In the event of a cache miss, the memory stream containing the retrieved online asset is copied out; the caller receives the original, while the copy is used to store the asset to disk and to realm entirely in the background. That's still *slower* than a straight online retrieval, but hopefully less so.

### All writes are turned async

The rationale for this is given mostly in the previous commit's description.

As a side note, this links to the previous point. `RealmFileStore.Add()`, of particular note, can return an *already existing, managed* realm model. Trying tricks like

```csharp
(var asset, path) = realmAccess.Run(r =>
{
    var file = fileStore.Add(onlineStream, r, addToRealm: false);
    return (new RealmOnlineAsset(file, url), file.GetStoragePath());
});
realmAccess.WriteAsync(r => r.Add(asset)).ContinueWith(t =>
{
    if (t.IsFaulted)
	Logger.Log($@"Failed to write {nameof(RealmOnlineAsset)} to realm: {t.Exception}", LoggingTarget.Database);
});
```

is thus very unsafe because there's no real guarantee that nobody hasn't e.g. completely moved the realm between the read and the write, and thus exceptions of "objects belonging to closed realms" can surface.

### Separate url-to-local-path mapping is maintained

A dictionary is added which maps remote asset URLs to local file paths. This short-circuits realm in two ways: subsequent lookups of any single asset no longer hits realm synchronously for the realm, *and* subsequent lookups of any *already-cached* asset no longer updates the last access time, which means that any asset will have its access time bumped at most once per session, decreasing the number of writes and thus the bad overheads.