### PR TITLE
Fix editor toggle states not applying to current placement

### DIFF
--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/BananaShowerPlacementBlueprint.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 
         public BananaShowerPlacementBlueprint()
         {
-            InternalChild = outline = new TimeSpanOutline();
+            Child = outline = new TimeSpanOutline();
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/FruitPlacementBlueprint.cs
@@ -16,7 +16,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 
         public FruitPlacementBlueprint()
         {
-            InternalChild = outline = new FruitOutline();
+            Child = outline = new FruitOutline();
         }
 
         protected override void LoadComplete()

--- a/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Catch/Edit/Blueprints/JuiceStreamPlacementBlueprint.cs
@@ -29,7 +29,7 @@ namespace osu.Game.Rulesets.Catch.Edit.Blueprints
 
         public JuiceStreamPlacementBlueprint()
         {
-            InternalChildren = new Drawable[]
+            Children = new Drawable[]
             {
                 scrollingPath = new ScrollingPath(),
                 nestedOutlineContainer = new NestedOutlineContainer(),

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/HoldNotePlacementBlueprint.cs
@@ -38,7 +38,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
         {
             RelativeSizeAxes = Axes.Both;
 
-            InternalChildren = new Drawable[]
+            Children = new Drawable[]
             {
                 bodyPiece = new EditBodyPiece { Origin = Anchor.TopCentre },
                 headPiece = new Circle

--- a/osu.Game.Rulesets.Mania/Edit/Blueprints/NotePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Mania/Edit/Blueprints/NotePlacementBlueprint.cs
@@ -28,7 +28,7 @@ namespace osu.Game.Rulesets.Mania.Edit.Blueprints
             RelativeSizeAxes = Axes.Both;
             Masking = true;
 
-            InternalChild = piece = new Circle
+            Child = piece = new Circle
             {
                 Origin = Anchor.Centre,
                 Colour = colours.Yellow,

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/HitCircles/HitCirclePlacementBlueprint.cs
@@ -31,7 +31,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.HitCircles
         public HitCirclePlacementBlueprint()
             : base(new HitCircle())
         {
-            InternalChild = circlePiece = new HitCirclePiece();
+            Child = circlePiece = new HitCirclePiece();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Sliders/SliderPlacementBlueprint.cs
@@ -75,7 +75,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Sliders
         [BackgroundDependencyLoader]
         private void load(OsuConfigManager config)
         {
-            InternalChildren = new Drawable[]
+            Children = new Drawable[]
             {
                 bodyPiece = new SliderBodyPiece(),
                 headCirclePiece = new HitCirclePiece(),

--- a/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Osu/Edit/Blueprints/Spinners/SpinnerPlacementBlueprint.cs
@@ -27,7 +27,7 @@ namespace osu.Game.Rulesets.Osu.Edit.Blueprints.Spinners
         public SpinnerPlacementBlueprint()
             : base(new Spinner { Position = OsuPlayfield.BASE_SIZE / 2 })
         {
-            InternalChild = piece = new SpinnerPiece { Alpha = 0.5f };
+            Child = piece = new SpinnerPiece { Alpha = 0.5f };
         }
 
         protected override void Update()

--- a/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Blueprints/HitPlacementBlueprint.cs
@@ -23,7 +23,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
         public HitPlacementBlueprint()
             : base(new Hit())
         {
-            InternalChild = piece = new HitPiece
+            Child = piece = new HitPiece
             {
                 Size = new Vector2(TaikoHitObject.DEFAULT_SIZE * TaikoPlayfield.BASE_HEIGHT)
             };

--- a/osu.Game.Rulesets.Taiko/Edit/Blueprints/TaikoSpanPlacementBlueprint.cs
+++ b/osu.Game.Rulesets.Taiko/Edit/Blueprints/TaikoSpanPlacementBlueprint.cs
@@ -37,7 +37,7 @@ namespace osu.Game.Rulesets.Taiko.Edit.Blueprints
 
             RelativeSizeAxes = Axes.Both;
 
-            InternalChildren = new Drawable[]
+            Children = new Drawable[]
             {
                 headPiece = new HitPiece
                 {

--- a/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
+++ b/osu.Game.Tests/Visual/Editing/TestScenePlacementBlueprint.cs
@@ -118,6 +118,48 @@ namespace osu.Game.Tests.Visual.Editing
         }
 
         [Test]
+        public void TestSliderPlacementNewComboAppliedCorrectly()
+        {
+            Playfield playfield = null!;
+
+            AddStep("seek to 500", () => EditorClock.Seek(500));
+            AddStep("select slider placement tool", () => InputManager.Key(Key.Number3));
+            AddStep("grab playfield", () => playfield = this.ChildrenOfType<Playfield>().Single());
+
+            AddStep("start first slider", () =>
+            {
+                InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(200)));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("toggle new combo", () => InputManager.Key(Key.Q));
+            AddStep("move", () => InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(300))));
+            AddStep("end first slider", () => InputManager.Click(MouseButton.Right));
+
+            AddStep("seek to 5000", () => EditorClock.Seek(5000));
+            AddStep("start second slider", () =>
+            {
+                InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(200)));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("toggle new combo", () => InputManager.Key(Key.Q));
+            AddStep("move", () => InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(300))));
+            AddStep("end second slider", () => InputManager.Click(MouseButton.Right));
+
+            AddStep("seek to 2000", () => EditorClock.Seek(2000));
+            AddStep("start third slider", () =>
+            {
+                InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(200)));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("toggle new combo", () => InputManager.Key(Key.Q));
+            AddStep("move", () => InputManager.MoveMouseTo(playfield.GamefieldToScreenSpace(new Vector2(300))));
+            AddStep("end third slider", () => InputManager.Click(MouseButton.Right));
+
+            AddAssert("3 hit objects", () => EditorBeatmap.HitObjects.Count, () => Is.EqualTo(3));
+            AddAssert("all sliders start combo", () => EditorBeatmap.HitObjects.OfType<Slider>().All(s => s.NewCombo));
+        }
+
+        [Test]
         public void TestPlacementOnSliderBodyDoesNotRemoveSlider()
         {
             Slider originalSlider = null!;

--- a/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
+++ b/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
@@ -31,6 +32,13 @@ namespace osu.Game.Rulesets.Edit
 
         [Resolved]
         protected EditorClock EditorClock { get; private set; } = null!;
+
+        protected override Container<Drawable> Content => content;
+
+        private readonly Container<Drawable> content = new Container<Drawable>
+        {
+            RelativeSizeAxes = Axes.Both,
+        };
 
         [Resolved]
         private EditorBeatmap beatmap { get; set; } = null!;
@@ -71,6 +79,7 @@ namespace osu.Game.Rulesets.Edit
         private void load()
         {
             AddInternal(placementStateManager = new PlacementStateManager(HitObject));
+            AddInternal(content);
 
             startTimeBindable = HitObject.StartTimeBindable.GetBoundCopy();
             startTimeBindable.BindValueChanged(_ => ApplyDefaultsToHitObject(), true);
@@ -137,5 +146,8 @@ namespace osu.Game.Rulesets.Edit
             base.PopOut();
             placementHandler.HidePlacement();
         }
+
+        protected override void ClearInternal(bool disposeChildren = true) =>
+            throw new InvalidOperationException($"Clearing {nameof(InternalChildren)} will cause critical failure. Use {nameof(Clear)} instead.");
     }
 }


### PR DESCRIPTION
Reported internally.

Regressed in https://github.com/ppy/osu/pull/38579, though I will meekly protest that the placement blueprint code was always dodgy because the inheritance hierarchy here is `HitObjectPlacementBlueprint : PlacementBlueprint : VisibilityContainer : Container` and messing with `InternalChild(ren)?` of a `Container` (not `CompositeDrawable`) is always dodgy.

Cause is that setting `InternalChild(ren)?` directly would dispose of

https://github.com/ppy/osu/blob/e9451fe70b91292c482bab203ea87bd727eaa237/osu.Game/Rulesets/Edit/HitObjectPlacementBlueprint.cs#L73

and therefore sever the subscription responsible for updating the relevant state:

https://github.com/ppy/osu/blob/e9451fe70b91292c482bab203ea87bd727eaa237/osu.Game/Screens/Edit/Compose/Components/PlacementStateManager.cs#L214-L215