### PR TITLE
formdropdown - contentcontainer resize so it fits inside the border

### DIFF
--- a/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
+++ b/osu.Game/Graphics/UserInterfaceV2/FormDropdown.cs
@@ -296,6 +296,10 @@ namespace osu.Game.Graphics.UserInterfaceV2
                 MaskingContainer.BorderThickness = FormControlBackground.BORDER_THICKNESS;
                 MaskingContainer.CornerExponent = FormControlBackground.CORNER_EXPONENT;
                 MaskingContainer.BorderColour = colourProvider.Highlight1;
+
+                ContentContainer.Masking = true;
+                ContentContainer.RelativeSizeAxes = Axes.X;
+                ContentContainer.Margin = new MarginPadding { Top = FormControlBackground.BORDER_THICKNESS * 2.0f };
             }
 
             protected override void AnimateOpen()
@@ -312,6 +316,13 @@ namespace osu.Game.Graphics.UserInterfaceV2
             {
                 base.AnimateClose();
                 this.TransformTo(nameof(Margin), new MarginPadding(), 300, Easing.OutQuint);
+            }
+
+            protected override void UpdateSize(Vector2 newSize)
+            {
+                ContentContainer.Height = newSize.Y - FormControlBackground.BORDER_THICKNESS * 4.0f;
+
+                base.UpdateSize(newSize);
             }
         }
     }


### PR DESCRIPTION
Fix for [https://github.com/ppy/osu/issues/37047](https://github.com/ppy/osu/issues/37047)

The ContentContainer is always the same size as the MaskingContainer and since the borders are inset they get covered up by the items. The obvious solution of adding a padding to the MaskingContainer doesn't work cause it disables the borders. Would make sense updating with that if there is a known fix. 

screenshots after:
<img width="490" height="120" alt="Screenshot_2026-08-26_02-20-46" src="https://github.com/user-attachments/assets/09102c49-21c5-46f2-9f21-b662bfd4c952" />
<img width="512" height="107" alt="Screenshot_2026-08-26_02-21-01" src="https://github.com/user-attachments/assets/f0d57f8d-fca5-44f5-b3c1-0f7527ae70c9" />
