### PR TITLE
Do not insert leading spaces into song select search bar when it is empty

### DIFF
--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -360,7 +360,7 @@ namespace osu.Game.Screens.Select
 
             searchTextBox.Current.Value = string.IsNullOrWhiteSpace(existingQuery)
                 ? query
-                : string.Join(' ', existingQuery.TrimEnd(), query);
+                : string.Join(' ', existingQuery.Trim(), query);
         }
 
         protected override void PopIn()

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -358,7 +358,9 @@ namespace osu.Game.Screens.Select
             if (existingQuery.Contains(query))
                 return;
 
-            searchTextBox.Current.Value = string.Join(' ', existingQuery.Trim(), query);
+            searchTextBox.Current.Value = string.IsNullOrEmpty(existingQuery.Trim())
+                ? query
+                : string.Join(' ', existingQuery.TrimEnd(), query);
         }
 
         protected override void PopIn()

--- a/osu.Game/Screens/Select/FilterControl.cs
+++ b/osu.Game/Screens/Select/FilterControl.cs
@@ -358,7 +358,7 @@ namespace osu.Game.Screens.Select
             if (existingQuery.Contains(query))
                 return;
 
-            searchTextBox.Current.Value = string.IsNullOrEmpty(existingQuery.Trim())
+            searchTextBox.Current.Value = string.IsNullOrWhiteSpace(existingQuery)
                 ? query
                 : string.Join(' ', existingQuery.TrimEnd(), query);
         }


### PR DESCRIPTION
- closes #38709

changes:
- ~trims extra spaces only at the end~
- inserts query without extra leading space if existing query was empty or contained only spaces

| action | master | pr |
|-|-|-|
| `""` + `"triangles"` | `" triangles"` | `"triangles"` |
| ~`" triangles  "` + `"cYsmix"`~ | ~`"triangles cYsmix"`~ | ~`" triangles cYsmix"`~ |

~`TrimEnd()` can be reverted back to simple `Trim()` if you want to~
