### PR TITLE
Add wiki search box

### DIFF
--- a/osu.Game.Tests/Visual/Online/TestSceneWikiMainPage.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiMainPage.cs
@@ -15,6 +15,9 @@ namespace osu.Game.Tests.Visual.Online
         [Cached]
         private readonly OverlayColourProvider overlayColour = new OverlayColourProvider(OverlayColourScheme.Orange);
 
+        [Cached]
+        private readonly OverlayScrollContainer scrollContainer = new OverlayScrollContainer();
+
         public TestSceneWikiMainPage()
         {
             Children = new Drawable[]

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -13,10 +13,11 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Overlays;
+using osuTK.Input;
 
 namespace osu.Game.Tests.Visual.Online
 {
-    public partial class TestSceneWikiOverlay : OsuTestScene
+    public partial class TestSceneWikiOverlay : OsuManualInputManagerTestScene
     {
         private DummyAPIAccess dummyAPI => (DummyAPIAccess)API;
 
@@ -103,6 +104,16 @@ namespace osu.Game.Tests.Visual.Online
             AddStep("Focus search box", () => searchBox?.TakeFocus());
             AddStep("Type in search box", () => searchBox!.Text = "wi");
             AddUntilStep("Suggestions shown", () => wiki.ChildrenOfType<OsuClickableContainer>().Any(d => d.GetType().Name == "ResultItem"));
+
+            AddRepeatStep("Press up", () => InputManager.Key(Key.Up), 2);
+            AddAssert("Search box text is changed", () => searchBox?.Text == "osu! wiki maintainers");
+
+            AddRepeatStep("Press down", () => InputManager.Key(Key.Down), 3);
+            AddAssert("Search box text is changed again", () => searchBox?.Text == "osu! wiki");
+
+            AddStep("Press up again", () => InputManager.Key(Key.Up));
+            AddAssert("Search box text is restored", () => searchBox?.Text == "wi");
+
             AddStep("Unfocus search box", () => searchBox?.KillFocus());
             AddUntilStep("Suggestions cleared", () => wiki.ChildrenOfType<OsuClickableContainer>().All(d => d.GetType().Name != "ResultItem"));
         }

--- a/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
+++ b/osu.Game.Tests/Visual/Online/TestSceneWikiOverlay.cs
@@ -7,6 +7,8 @@ using System.Net;
 using NUnit.Framework;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Online.API.Requests.Responses;
@@ -87,8 +89,26 @@ namespace osu.Game.Tests.Visual.Online
             AddUntilStep("Error message not displayed", () => wiki.ChildrenOfType<SpriteText>().All(text => text.Text != "\"This_page_will_error_out\"."));
         }
 
+        [Test]
+        public void TestSuggestion()
+        {
+            setUpWikiResponse(responseMainPage);
+            AddStep("Show main page", () => wiki.ShowPage());
+
+            setUpWikiSuggestionResponse();
+
+            SearchTextBox? searchBox = null;
+
+            AddUntilStep("Wait for search box", () => (searchBox = wiki.ChildrenOfType<SearchTextBox>().FirstOrDefault()) != null);
+            AddStep("Focus search box", () => searchBox?.TakeFocus());
+            AddStep("Type in search box", () => searchBox!.Text = "wi");
+            AddUntilStep("Suggestions shown", () => wiki.ChildrenOfType<OsuClickableContainer>().Any(d => d.GetType().Name == "ResultItem"));
+            AddStep("Unfocus search box", () => searchBox?.KillFocus());
+            AddUntilStep("Suggestions cleared", () => wiki.ChildrenOfType<OsuClickableContainer>().All(d => d.GetType().Name != "ResultItem"));
+        }
+
         private void setUpWikiResponse(APIWikiPage r, string? redirectionPath = null)
-            => AddStep("set up response", () =>
+            => AddStep("set up wiki page response", () =>
             {
                 dummyAPI.HandleRequest = request =>
                 {
@@ -103,6 +123,19 @@ namespace osu.Game.Tests.Visual.Online
                     else
                         getWikiRequest.TriggerFailure(new WebException());
 
+                    return true;
+                };
+            });
+
+        private void setUpWikiSuggestionResponse()
+            => AddStep("set up wiki suggestion response", () =>
+            {
+                dummyAPI.HandleRequest = request =>
+                {
+                    if (!(request is GetWikiSuggestionRequest getWikiSuggestionRequest))
+                        return false;
+
+                    getWikiSuggestionRequest.TriggerSuccess(responseWikiSuggestion);
                     return true;
                 };
             });
@@ -141,6 +174,80 @@ namespace osu.Game.Tests.Visual.Online
             Subtitle = null,
             Markdown =
                 "---\ntags:\n  - wiki standards\n---\n\n# Article styling criteria\n\n*For news posts, see: [News Styling Criteria](/wiki/News_styling_criteria)*\n\nThe article styling criteria (ASC) serve as the osu! wiki's enforced styling standards to keep consistency in clarity, formatting, and layout in all articles, and to help them strive for proper grammar, correct spelling, and correct information.\n\nThese articles are primarily tools to aid in reviewing and represent the consensus of osu! wiki contributors formed over the years. Since the wiki is a collaborative effort through the review process, it is not necessary to read or memorise all of the ASC at once. If you are looking to contribute, read the [contribution guide](/wiki/osu!_wiki/Contribution_guide).\n\nTo suggest changes regarding the article styling criteria, [open an issue on GitHub](https://github.com/ppy/osu-wiki/issues/new).\n\n## Standards\n\n*Notice: The articles below use [RFC 2119](https://tools.ietf.org/html/rfc2119) to describe requirement levels.*\n\nThe article styling criteria are split up into two articles:\n\n- [Formatting](Formatting): includes Markdown and other formatting rules\n- [Writing](Writing): includes writing practices and other grammar rules\n"
+        };
+
+        private APIWikiSuggestion[] responseWikiSuggestion => new[]
+        {
+            new APIWikiSuggestion
+            {
+                Highlight = "osu! *wi*ki",
+                Locale = "en",
+                Path = "osu!_wiki",
+                Title = "osu! wiki"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "*Wi*imote",
+                Locale = "en",
+                Path = "Gameplay/Input_device/Wiimote",
+                Title = "Wiimote"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "*Wi*nd Up (mod)",
+                Locale = "en",
+                Path = "Gameplay/Game_modifier/Wind_Up",
+                Title = "Wind Up (mod)"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "Hit *wi*ndow",
+                Locale = "en",
+                Path = "Gameplay/Hit_window",
+                Title = "Hit window"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "*Wi*ggle (mod)",
+                Locale = "en",
+                Path = "Gameplay/Game_modifier/Wiggle",
+                Title = "Wiggle (mod)"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "*Wi*nd Down (mod)",
+                Locale = "en",
+                Path = "Gameplay/Game_modifier/Wind_Down",
+                Title = "Wind Down (mod)"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "Offset *Wi*zard",
+                Locale = "en",
+                Path = "Client/Options/Offset_Wizard",
+                Title = "Offset Wizard"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "Song setup *wi*ndow",
+                Locale = "en",
+                Path = "Client/Beatmap_editor/Song_setup",
+                Title = "Song setup window"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "osu! *wi*ki maintainers",
+                Locale = "en",
+                Path = "People/osu!_wiki_maintainers",
+                Title = "osu! wiki maintainers"
+            },
+            new APIWikiSuggestion
+            {
+                Highlight = "nik's *Wi*nter Tour 2019",
+                Locale = "en",
+                Path = "Tournaments/NT/NWT_2019",
+                Title = "nik's Winter Tour 2019"
+            }
         };
     }
 }

--- a/osu.Game/Graphics/UserInterface/BasicSearchTextBox.cs
+++ b/osu.Game/Graphics/UserInterface/BasicSearchTextBox.cs
@@ -11,16 +11,18 @@ namespace osu.Game.Graphics.UserInterface
     {
         public BasicSearchTextBox()
         {
-            Add(new SpriteIcon
-            {
-                Icon = FontAwesome.Solid.Search,
-                Origin = Anchor.CentreRight,
-                Anchor = Anchor.CentreRight,
-                Margin = new MarginPadding { Right = 10 },
-                Size = new Vector2(20),
-            });
+            Add(CreateIcon());
 
             TextFlow.Padding = new MarginPadding { Right = 35 };
         }
+
+        protected virtual SpriteIcon CreateIcon() => new SpriteIcon
+        {
+            Icon = FontAwesome.Solid.Search,
+            Origin = Anchor.CentreRight,
+            Anchor = Anchor.CentreRight,
+            Margin = new MarginPadding { Right = 10 },
+            Size = new Vector2(20),
+        };
     }
 }

--- a/osu.Game/Online/API/Requests/GetWikiSuggestionRequest.cs
+++ b/osu.Game/Online/API/Requests/GetWikiSuggestionRequest.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.IO.Network;
+using osu.Game.Extensions;
+using osu.Game.Localisation;
+using osu.Game.Online.API.Requests.Responses;
+
+namespace osu.Game.Online.API.Requests
+{
+    public class GetWikiSuggestionRequest : APIRequest<APIWikiSuggestion[]>
+    {
+        private readonly string query;
+        private readonly Language language;
+
+        public GetWikiSuggestionRequest(string query, Language language = Language.en)
+        {
+            this.query = query;
+            this.language = language;
+        }
+
+        protected override WebRequest CreateWebRequest()
+        {
+            var req = base.CreateWebRequest();
+
+            req.AddParameter(@"query", query);
+            req.AddParameter(@"locale", language.ToCultureCode());
+
+            return req;
+        }
+
+        protected override string Target => @"suggestions/wiki";
+    }
+}

--- a/osu.Game/Online/API/Requests/Responses/APIWikiSuggestion.cs
+++ b/osu.Game/Online/API/Requests/Responses/APIWikiSuggestion.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Newtonsoft.Json;
+
+namespace osu.Game.Online.API.Requests.Responses
+{
+    public class APIWikiSuggestion
+    {
+        [JsonProperty("highlight")]
+        public string Highlight { get; set; } = string.Empty;
+
+        [JsonProperty("locale")]
+        public string Locale { get; set; } = string.Empty;
+
+        [JsonProperty("path")]
+        public string Path { get; set; } = string.Empty;
+
+        [JsonProperty("title")]
+        public string Title { get; set; } = string.Empty;
+    }
+}

--- a/osu.Game/Overlays/OverlayColourProvider.cs
+++ b/osu.Game/Overlays/OverlayColourProvider.cs
@@ -33,6 +33,7 @@ namespace osu.Game.Overlays
         public Color4 Colour4 => getColour(0.4f, 0.3f);
 
         public Color4 Highlight1 => getColour(1, 0.7f);
+        public Color4 Highlight2 => getColour(0.5f, 0.45f);
         public Color4 Content1 => getColour(0.4f, 1);
         public Color4 Content2 => getColour(0.4f, 0.9f);
         public Color4 Light1 => getColour(0.4f, 0.8f);

--- a/osu.Game/Overlays/Wiki/WikiMainPage.cs
+++ b/osu.Game/Overlays/Wiki/WikiMainPage.cs
@@ -35,7 +35,10 @@ namespace osu.Game.Overlays.Wiki
 
             Children = new Drawable[]
             {
-                new WikiSearch(),
+                new WikiSearch
+                {
+                    Depth = -1, // This depth is to ensure the suggestion result is always in front of other element.
+                },
                 createBlurb(html),
                 new GridContainer
                 {

--- a/osu.Game/Overlays/Wiki/WikiMainPage.cs
+++ b/osu.Game/Overlays/Wiki/WikiMainPage.cs
@@ -35,6 +35,7 @@ namespace osu.Game.Overlays.Wiki
 
             Children = new Drawable[]
             {
+                new WikiSearch(),
                 createBlurb(html),
                 new GridContainer
                 {

--- a/osu.Game/Overlays/Wiki/WikiSearch.cs
+++ b/osu.Game/Overlays/Wiki/WikiSearch.cs
@@ -1,13 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
+using osu.Framework.Threading;
+using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
+using osu.Game.Online.API;
+using osu.Game.Online.API.Requests;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
 
@@ -15,6 +24,19 @@ namespace osu.Game.Overlays.Wiki
 {
     public partial class WikiSearch : CompositeDrawable
     {
+        private GetWikiSuggestionRequest? request;
+        private ScheduledDelegate? queryChangeDebounce;
+
+        private readonly Bindable<ResultItem[]> resultItems = new Bindable<ResultItem[]>([]);
+
+        private WikiSearchTextBox textBox = null!;
+
+        [Resolved]
+        private IAPIProvider api { get; set; } = null!;
+
+        [Resolved]
+        private OsuGameBase game { get; set; } = null!;
+
         public WikiSearch()
         {
             RelativeSizeAxes = Axes.X;
@@ -24,17 +46,61 @@ namespace osu.Game.Overlays.Wiki
         [BackgroundDependencyLoader]
         private void load()
         {
-            InternalChildren = new[]
+            FillFlowContainer resultContainer;
+
+            InternalChildren = new Drawable[]
             {
-                new WikiSearchTextBox
+                textBox = new WikiSearchTextBox
                 {
                     RelativeSizeAxes = Axes.X,
+                    OnTextBoxFocusLost = onTextBoxFocusLost,
+                },
+                resultContainer = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.TopCentre,
+                    Direction = FillDirection.Vertical,
                 }
             };
+
+            textBox.Current.BindValueChanged(_ =>
+            {
+                queryChangeDebounce = Scheduler.AddDelayed(performRequest, 200);
+            });
+
+            resultItems.BindValueChanged(e =>
+            {
+                resultContainer.Children = e.NewValue;
+            });
+        }
+
+        private void performRequest()
+        {
+            request?.Cancel();
+
+            request = new GetWikiSuggestionRequest(textBox.Current.Value, game.CurrentLanguage.Value);
+            request.Success += response => resultItems.Value = response.Select(r => new ResultItem
+            {
+                Highlight = r.Highlight,
+                ArticleUrl = $"{api.Endpoints.WebsiteUrl}/wiki/{r.Locale}/{r.Path}",
+            }).ToArray();
+            request.Failure += _ => resultItems.Value = [];
+
+            api.PerformAsync(request);
+        }
+
+        private void onTextBoxFocusLost()
+        {
+            request?.Cancel();
+            queryChangeDebounce?.Cancel();
+            resultItems.Value = [];
         }
 
         private partial class WikiSearchTextBox : BasicSearchTextBox
         {
+            public Action? OnTextBoxFocusLost;
+
             private const int font_size = 18;
             private const int vertical_padding = 13;
             private const int horizontal_padding = 20;
@@ -82,8 +148,77 @@ namespace osu.Game.Overlays.Wiki
             protected override void OnFocusLost(FocusLostEvent e)
             {
                 base.OnFocusLost(e);
+                OnTextBoxFocusLost?.Invoke();
                 BorderThickness = 0;
                 EdgeEffect = new EdgeEffectParameters();
+            }
+        }
+
+        private partial class ResultItem : OsuClickableContainer
+        {
+            public required string Highlight;
+            public required string ArticleUrl;
+
+            private Box background = null!;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            [Resolved]
+            private ILinkHandler? linkHandler { get; set; }
+
+            public ResultItem()
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                OsuTextFlowContainer textFlow;
+
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = colourProvider.Background6,
+                    },
+                    textFlow = new OsuTextFlowContainer(t =>
+                    {
+                        t.Colour = colourProvider.Content1;
+                        t.Font = t.Font.With(size: 14);
+                    })
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Padding = new MarginPadding { Vertical = 5, Horizontal = 20 },
+                    },
+                };
+
+                string[] textPart = Highlight.Split('*');
+                textFlow.AddText(textPart[0]);
+                textFlow.AddText(textPart[1], t => t.Colour = colourProvider.Light2);
+                textFlow.AddText(textPart[2]);
+            }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                linkHandler?.HandleLink(ArticleUrl);
+                return base.OnClick(e);
+            }
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                background.Colour = colourProvider.Background3;
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                background.Colour = colourProvider.Background6;
+                base.OnHoverLost(e);
             }
         }
     }

--- a/osu.Game/Overlays/Wiki/WikiSearch.cs
+++ b/osu.Game/Overlays/Wiki/WikiSearch.cs
@@ -44,7 +44,7 @@ namespace osu.Game.Overlays.Wiki
         private OsuGameBase game { get; set; } = null!;
 
         [Resolved]
-        private OverlayScrollContainer scrollFlow { get; set; } = null!;
+        private OverlayScrollContainer scrollContainer { get; set; } = null!;
 
         [Resolved]
         private ILinkHandler? linkHandler { get; set; }
@@ -118,7 +118,7 @@ namespace osu.Game.Overlays.Wiki
 
         private void onTextBoxKeyDown(KeyDownEvent e)
         {
-            scrollFlow.ScrollToStart();
+            scrollContainer.ScrollToStart();
 
             switch (e.Key)
             {

--- a/osu.Game/Overlays/Wiki/WikiSearch.cs
+++ b/osu.Game/Overlays/Wiki/WikiSearch.cs
@@ -1,0 +1,90 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Resources.Localisation.Web;
+using osuTK;
+
+namespace osu.Game.Overlays.Wiki
+{
+    public partial class WikiSearch : CompositeDrawable
+    {
+        public WikiSearch()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            InternalChildren = new[]
+            {
+                new WikiSearchTextBox
+                {
+                    RelativeSizeAxes = Axes.X,
+                }
+            };
+        }
+
+        private partial class WikiSearchTextBox : BasicSearchTextBox
+        {
+            private const int font_size = 18;
+            private const int vertical_padding = 13;
+            private const int horizontal_padding = 20;
+
+            [Resolved]
+            private OverlayColourProvider colourProvider { get; set; } = null!;
+
+            protected override float LeftRightPadding => horizontal_padding;
+
+            public WikiSearchTextBox()
+            {
+                Height = font_size + vertical_padding * 2;
+                FontSize = font_size;
+                PlaceholderText = CommonStrings.InputSearch;
+                Placeholder.Font = Placeholder.Font.With(size: font_size);
+                CornerRadius = 0;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                BackgroundFocused = colourProvider.Background6;
+                BackgroundUnfocused = colourProvider.Background6;
+                BorderColour = colourProvider.Highlight2;
+            }
+
+            protected override SpriteIcon CreateIcon() => base.CreateIcon().With(s =>
+            {
+                s.Size = new Vector2(font_size);
+                s.Margin = new MarginPadding { Right = horizontal_padding };
+            });
+
+            protected override void OnFocus(FocusEvent e)
+            {
+                base.OnFocus(e);
+                BorderThickness = 2;
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Glow,
+                    Colour = colourProvider.Highlight2,
+                    Radius = 10,
+                };
+            }
+
+            protected override void OnFocusLost(FocusLostEvent e)
+            {
+                base.OnFocusLost(e);
+                BorderThickness = 0;
+                EdgeEffect = new EdgeEffectParameters();
+            }
+        }
+    }
+}

--- a/osu.Game/Overlays/Wiki/WikiSearch.cs
+++ b/osu.Game/Overlays/Wiki/WikiSearch.cs
@@ -19,6 +19,7 @@ using osu.Game.Online.API;
 using osu.Game.Online.API.Requests;
 using osu.Game.Resources.Localisation.Web;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Game.Overlays.Wiki
 {
@@ -26,8 +27,13 @@ namespace osu.Game.Overlays.Wiki
     {
         private GetWikiSuggestionRequest? request;
         private ScheduledDelegate? queryChangeDebounce;
+        private string lastQuery = string.Empty;
 
         private readonly Bindable<ResultItem[]> resultItems = new Bindable<ResultItem[]>([]);
+        private int selectedItemIndex;
+
+        // index 0 means no item selected
+        private ResultItem? selectedItem => selectedItemIndex == 0 ? null : resultItems.Value[selectedItemIndex - 1];
 
         private WikiSearchTextBox textBox = null!;
 
@@ -36,6 +42,12 @@ namespace osu.Game.Overlays.Wiki
 
         [Resolved]
         private OsuGameBase game { get; set; } = null!;
+
+        [Resolved]
+        private OverlayScrollContainer scrollFlow { get; set; } = null!;
+
+        [Resolved]
+        private ILinkHandler? linkHandler { get; set; }
 
         public WikiSearch()
         {
@@ -54,6 +66,7 @@ namespace osu.Game.Overlays.Wiki
                 {
                     RelativeSizeAxes = Axes.X,
                     OnTextBoxFocusLost = onTextBoxFocusLost,
+                    OnTextBoxKeyDown = onTextBoxKeyDown,
                 },
                 resultContainer = new FillFlowContainer
                 {
@@ -64,26 +77,32 @@ namespace osu.Game.Overlays.Wiki
                 }
             };
 
-            textBox.Current.BindValueChanged(_ =>
+            textBox.Current.BindValueChanged(e =>
             {
+                if (e.NewValue == lastQuery || e.NewValue == selectedItem?.Title)
+                    return;
+
                 queryChangeDebounce = Scheduler.AddDelayed(performRequest, 200);
             });
 
             resultItems.BindValueChanged(e =>
             {
+                selectedItemIndex = 0;
                 resultContainer.Children = e.NewValue;
             });
         }
 
         private void performRequest()
         {
-            request?.Cancel();
+            lastQuery = textBox.Current.Value;
 
-            request = new GetWikiSuggestionRequest(textBox.Current.Value, game.CurrentLanguage.Value);
+            request?.Cancel();
+            request = new GetWikiSuggestionRequest(lastQuery, game.CurrentLanguage.Value);
             request.Success += response => resultItems.Value = response.Select(r => new ResultItem
             {
                 Highlight = r.Highlight,
                 ArticleUrl = $"{api.Endpoints.WebsiteUrl}/wiki/{r.Locale}/{r.Path}",
+                Title = r.Title,
             }).ToArray();
             request.Failure += _ => resultItems.Value = [];
 
@@ -97,9 +116,43 @@ namespace osu.Game.Overlays.Wiki
             resultItems.Value = [];
         }
 
+        private void onTextBoxKeyDown(KeyDownEvent e)
+        {
+            scrollFlow.ScrollToStart();
+
+            switch (e.Key)
+            {
+                case Key.Down:
+                    shiftSelectedItem(1);
+                    break;
+
+                case Key.Up:
+                    shiftSelectedItem(-1);
+                    break;
+
+                case Key.Enter:
+                    if (selectedItem != null)
+                        linkHandler?.HandleLink(selectedItem.ArticleUrl);
+                    break;
+            }
+        }
+
+        private void shiftSelectedItem(int direction)
+        {
+            selectedItem?.Selected.Toggle();
+
+            // non-negative modulo
+            int mod(int x, int m) => ((x % m) + m) % m;
+            selectedItemIndex = mod(selectedItemIndex + direction, resultItems.Value.Length + 1);
+
+            selectedItem?.Selected.Toggle();
+            textBox.Current.Value = selectedItem?.Title ?? lastQuery;
+        }
+
         private partial class WikiSearchTextBox : BasicSearchTextBox
         {
             public Action? OnTextBoxFocusLost;
+            public Action<KeyDownEvent>? OnTextBoxKeyDown;
 
             private const int font_size = 18;
             private const int vertical_padding = 13;
@@ -152,12 +205,21 @@ namespace osu.Game.Overlays.Wiki
                 BorderThickness = 0;
                 EdgeEffect = new EdgeEffectParameters();
             }
+
+            protected override bool OnKeyDown(KeyDownEvent e)
+            {
+                OnTextBoxKeyDown?.Invoke(e);
+                return base.OnKeyDown(e);
+            }
         }
 
         private partial class ResultItem : OsuClickableContainer
         {
             public required string Highlight;
             public required string ArticleUrl;
+            public required string Title;
+
+            public readonly BindableBool Selected = new BindableBool();
 
             private Box background = null!;
 
@@ -201,6 +263,16 @@ namespace osu.Game.Overlays.Wiki
                 textFlow.AddText(textPart[0]);
                 textFlow.AddText(textPart[1], t => t.Colour = colourProvider.Light2);
                 textFlow.AddText(textPart[2]);
+
+                Selected.BindValueChanged(_ => changeBackgroundColour());
+            }
+
+            private void changeBackgroundColour()
+            {
+                if (IsHovered || Selected.Value)
+                    background.Colour = colourProvider.Background3;
+                else
+                    background.Colour = colourProvider.Background6;
             }
 
             protected override bool OnClick(ClickEvent e)
@@ -211,13 +283,13 @@ namespace osu.Game.Overlays.Wiki
 
             protected override bool OnHover(HoverEvent e)
             {
-                background.Colour = colourProvider.Background3;
+                changeBackgroundColour();
                 return base.OnHover(e);
             }
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                background.Colour = colourProvider.Background6;
+                changeBackgroundColour();
                 base.OnHoverLost(e);
             }
         }


### PR DESCRIPTION
- Addresses https://github.com/ppy/osu/discussions/38401

This search box only shows suggestion results using wiki suggestion API (https://github.com/ppy/osu-web/pull/13229), not a [full search page](https://osu.ppy.sh/home/search?mode=wiki_page). The UX is basically the same with osu! web.


https://github.com/user-attachments/assets/52b12f94-1b64-432d-8e0e-cf32c349b73d

