### PR TITLE
Change tablet x and y offset precision to 0.01

### DIFF
--- a/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletAreaSelection.cs
@@ -196,7 +196,7 @@ namespace osu.Game.Overlays.Settings.Sections.Input
                 return;
 
             // allow for some degree of floating point error, as we don't care about being perfect here.
-            const float lenience = 0.5f;
+            const float lenience = 0.001f;
 
             var tabletArea = new Quad(-lenience, -lenience, tablet.Value.Size.X + lenience * 2, tablet.Value.Size.Y + lenience * 2);
 

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -42,8 +42,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private readonly Bindable<Vector2> outputAreaOffset = new Bindable<Vector2>();
         private readonly IBindable<TabletInfo> tablet = new Bindable<TabletInfo>();
 
-        private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0, Precision = 1 };
-        private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0, Precision = 1 };
+        private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0, Precision = 0.01f };
+        private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0, Precision = 0.01f };
 
         private readonly BindableNumber<float> sizeX = new BindableNumber<float> { MinValue = 10, Precision = 1 };
         private readonly BindableNumber<float> sizeY = new BindableNumber<float> { MinValue = 10, Precision = 1 };

--- a/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
+++ b/osu.Game/Overlays/Settings/Sections/Input/TabletSettings.cs
@@ -45,8 +45,8 @@ namespace osu.Game.Overlays.Settings.Sections.Input
         private readonly BindableNumber<float> offsetX = new BindableNumber<float> { MinValue = 0, Precision = 0.01f };
         private readonly BindableNumber<float> offsetY = new BindableNumber<float> { MinValue = 0, Precision = 0.01f };
 
-        private readonly BindableNumber<float> sizeX = new BindableNumber<float> { MinValue = 10, Precision = 1 };
-        private readonly BindableNumber<float> sizeY = new BindableNumber<float> { MinValue = 10, Precision = 1 };
+        private readonly BindableNumber<float> sizeX = new BindableNumber<float> { MinValue = 10, Precision = 0.01f };
+        private readonly BindableNumber<float> sizeY = new BindableNumber<float> { MinValue = 10, Precision = 0.01f };
 
         private readonly BindableNumber<float> rotation = new BindableNumber<float> { MinValue = 0, MaxValue = 360, Precision = 1 };
 


### PR DESCRIPTION
In my case, Y offset of 72.5 is the maximum within the bounds. But due to lenience of 0.5, Y offset of 73 is shown as inside bounds(blue tablet area instead of red) so I changed the lenience to 0.001 and offset precision to 0.01 so you can set the offset to right at the edge of bounds

https://github.com/user-attachments/assets/66003134-b6f7-4a67-bed8-b75a6997ac2c

(before) You can see that the cursor doesn't go up to the top with 73 with blue tablet area

https://github.com/user-attachments/assets/7d5676bf-50e6-494e-bd11-be6bcf7bc304

(after) You can set the offset to 72.5 and tablet area turns red properly when set to 73