### PR TITLE
Fix user tags on initial beatmap selection

### DIFF
--- a/osu.Game/Screens/Select/BeatmapMetadataWedge.cs
+++ b/osu.Game/Screens/Select/BeatmapMetadataWedge.cs
@@ -412,11 +412,12 @@ namespace osu.Game.Screens.Select
             userTagsCancellationSource = new CancellationTokenSource();
 
             var token = userTagsCancellationSource.Token;
+            Guid beatmapId = beatmap.Value.BeatmapInfo.ID;
 
             realm.RunAsync(r =>
             {
                 // need to refetch because `beatmap.Value.BeatmapInfo` is not going to have the latest tags
-                var refetchedBeatmap = r.Find<BeatmapInfo>(beatmap.Value.BeatmapInfo.ID);
+                var refetchedBeatmap = r.Find<BeatmapInfo>(beatmapId);
                 return refetchedBeatmap?.Metadata.UserTags.ToArray() ?? [];
             }, token).ContinueWith(t =>
             {


### PR DESCRIPTION

  ## Description

  Fixes #38680.

  User tags were missing when opening a beatmap set on its initially selected difficulty. They only appeared after
  manually switching difficulties.

  ## Cause

  The asynchronous Realm lookup read `beatmap.Value` after the selection could have changed, causing it to query the
  wrong beatmap.

  ## Solution

  Capture the selected beatmap ID before starting the asynchronous lookup and use that stable ID for the Realm query.