### PR TITLE
Replace Early Strain Reduction with Peak Difficulty Reduction in Reading Skill

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -39,19 +39,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             double decay = strainDecay(current.DeltaTime);
 
-            // This currently operates under the assumption that `ObjectDifficultyOf` is called once per object, and in order.
-            // Under that assumption, we can trust that `current.StartTime` refers to the start time of the first object in the case that `firstObjectStartTime` is yet to be set.
-            firstObjectStartTime ??= current.StartTime;
-
-            const double reduced_difficulty_base_line = 0.8; // Assume that even with full memorisation, skill is still required to read and play the first objects.
-
             double currentObjectStrain = calculateAdjustedDifficulty(current) * (1 - decay) * skill_multiplier;
-
-            if (current.StartTime <= firstObjectStartTime + reduced_difficulty_duration)
-            {
-                double scale = Math.Log10(double.Lerp(1, 10, Math.Clamp((current.StartTime - firstObjectStartTime.Value) / reduced_difficulty_duration, 0, 1)));
-                currentObjectStrain *= double.Lerp(reduced_difficulty_base_line, 1.0, scale);
-            }
 
             currentStrain *= decay;
             currentStrain += currentObjectStrain;
@@ -110,8 +98,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
             for (int i = 0; i < difficulties.Count; i++)
             {
-                double scale = (i + topWeightedObjectDifficulties) / topWeightedObjectDifficulties;
-                difficulties[i] *= 1 - (0.1 * DiffUtils.Pow(0.99, scale));
+                double scale = (i * 2 + topWeightedObjectDifficulties) / topWeightedObjectDifficulties;
+                difficulties[i] *= 1 - (0.12 * DiffUtils.Pow(0.99, scale));
             }
 
             return difficulties;

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Collections.Generic;
 using osu.Game.Rulesets.Difficulty.Aggregation;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Skills;
@@ -42,7 +43,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             // Under that assumption, we can trust that `current.StartTime` refers to the start time of the first object in the case that `firstObjectStartTime` is yet to be set.
             firstObjectStartTime ??= current.StartTime;
 
-            const double reduced_difficulty_base_line = 0.2; // Assume that even with full memorisation, skill is still required to read and play the first objects.
+            const double reduced_difficulty_base_line = 0.8; // Assume that even with full memorisation, skill is still required to read and play the first objects.
 
             double currentObjectStrain = calculateAdjustedDifficulty(current) * (1 - decay) * skill_multiplier;
 
@@ -84,12 +85,36 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         public override double DifficultyValue()
         {
-            if (ObjectDifficulties.Count == 0)
-                return 0;
+            var difficulties = ObjectDifficulties.Where(d => d > 0).ToList();
 
-            (double difficulty, harmonicWeightSum) = HarmonicSeries.Aggregate(ObjectDifficulties);
+            if (difficulties.Count == 0)
+                return 0.0;
+
+            (double difficulty, harmonicWeightSum) = HarmonicSeries.Aggregate(difficulties);
+
+            double topWeightedObjectDifficulties = CountTopWeightedObjectDifficulties(difficulty);
+
+            if (topWeightedObjectDifficulties == 0)
+                return 0.0;
+
+            difficulties = GetTransformedDifficulties(difficulties, topWeightedObjectDifficulties);
+
+            (difficulty, harmonicWeightSum) = HarmonicSeries.Aggregate(difficulties);
 
             return difficulty;
+        }
+
+        protected List<double> GetTransformedDifficulties(List<double> difficulties, double topWeightedObjectDifficulties)
+        {
+            difficulties.Sort((a, b) => b.CompareTo(a));
+
+            for (int i = 0; i < difficulties.Count; i++)
+            {
+                double scale = (i + topWeightedObjectDifficulties) / topWeightedObjectDifficulties;
+                difficulties[i] *= 1 - (0.1 * DiffUtils.Pow(0.99, scale));
+            }
+
+            return difficulties;
         }
 
         public double CountTopWeightedObjectDifficulties(double difficultyValue)
@@ -103,7 +128,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
             double consistentTopNote = difficultyValue / harmonicWeightSum; // What would the top difficulty be if all object difficulties were identical
 
             if (consistentTopNote == 0)
-                return 0;
+                return 0.0;
 
             return ObjectDifficulties.Sum(d => DiffUtils.Logistic(d / consistentTopNote, 1.15, 5, 1.1));
         }

--- a/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Skills/Reading.cs
@@ -28,14 +28,11 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Skills
 
         private double currentStrain;
 
-        private double? firstObjectStartTime;
-
         private double strainDecay(double ms) => DiffUtils.Pow(0.8, ms / 1000);
 
         protected override double ProcessInternal(DifficultyHitObject current)
         {
             const double skill_multiplier = 2.5;
-            const double reduced_difficulty_duration = 40 * 1000;
 
             double decay = strainDecay(current.DeltaTime);
 


### PR DESCRIPTION
Adds a peak difficulty reduction to the reading skill. This should avoid adding objects decreasing difficulty as it uses the `CountTopWeightedObjectDifficulties` method.

### Benchmarks:
pp-dev:
| Method                             | Mean       | Error      | StdDev    | Gen0       | Gen1       | Allocated |
|----------------------------------- |-----------:|-----------:|----------:|-----------:|-----------:|----------:|
| CalculateDifficultyOsu             |   6.533 ms |  0.1273 ms | 0.1515 ms |   320.3125 |   312.5000 |   5.18 MB |
| CalculateDifficultyOsuHundredTimes | 645.351 ms | 10.3624 ms | 8.0903 ms | 32000.0000 | 31000.0000 | 518.06 MB |

This PR:
| Method                             | Mean       | Error      | StdDev     | Gen0       | Gen1       | Allocated |
|----------------------------------- |-----------:|-----------:|-----------:|-----------:|-----------:|----------:|
| CalculateDifficultyOsu             |   6.701 ms |  0.0594 ms |  0.0526 ms |   320.3125 |   312.5000 |   5.21 MB |
| CalculateDifficultyOsuHundredTimes | 667.266 ms | 11.7154 ms | 15.2334 ms | 32000.0000 | 31000.0000 | 520.64 MB |