### PR TITLE
Adjust snap acute bpm scaling

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/Evaluators/Aim/SnapAimEvaluator.cs
@@ -81,8 +81,8 @@ namespace osu.Game.Rulesets.Osu.Difficulty.Evaluators.Aim
 
             double velocity = Math.Min(currVelocity, prevVelocity);
 
-            // Apply acute angle bonus for BPM above 300 1/2 and distance more than one diameter
-            acuteAngleBonus *= velocity * DiffUtils.Smootherstep(DiffUtils.MillisecondsToBPM(osuCurrObj.AdjustedDeltaTime, 2), 300, 400) *
+            // Apply acute angle bonus for BPM above 270 1/2 and distance more than one diameter
+            acuteAngleBonus *= velocity * DiffUtils.SmoothTransition(DiffUtils.MillisecondsToBPM(osuCurrObj.AdjustedDeltaTime, 2), 270, 400) *
                                DiffUtils.Smootherstep(currDistance, 0, OsuDifficultyHitObject.NORMALISED_DIAMETER * 2);
 
             return acuteAngleBonus * acute_angle_multiplier;

--- a/osu.Game/Rulesets/Difficulty/Utils/DiffUtils.cs
+++ b/osu.Game/Rulesets/Difficulty/Utils/DiffUtils.cs
@@ -143,6 +143,20 @@ namespace osu.Game.Rulesets.Difficulty.Utils
         }
 
         /// <summary>
+        /// Smoothly transitions from 0 to 1, and then slowly slowing down afterwards
+        /// </summary>
+        /// <param name="x">Value to calculate the function for</param>
+        /// <param name="start">Value at which function returns 0</param>
+        /// <param name="end">Value at which function returns 1</param>
+        /// <param name="power">The steepness of the function</param>
+        /// <param name="limit">Value the function is approaching after the end. Should be greater than 1</param>
+        public static double SmoothTransition(double x, double start, double end, double power = 2.5, double limit = 2)
+        {
+            x = Math.Pow(Math.Max(0.0, (x - start) / (end - start)), power);
+            return limit * x / (x + limit - 1);
+        }
+
+        /// <summary>
         /// Error function (https://en.wikipedia.org/wiki/Error_function)
         /// </summary>
         /// <param name="x">Value to calculate the function for</param>


### PR DESCRIPTION
Current curve has a problem: it's first slowly accelerating before reaching the highest at 350 bpm, after which it starts to decelerate.
This makes the bpm from 350 to 370 to be a "sweet spot", when bpm above 400 is at disadvantage.

This change adjust the scaling so that acceleration is much smaller, but it never decelerates, instead being on the same level after 400 bpm. This makes the curve much more natural, and doesn't have the arbitrary "sweet spot" anymore.
Also starting point was moved to the 270 BPM to make the acceleration smaller, and buff currently disadvantaged range of 310-330 BPM.

Visualization (https://www.desmos.com/calculator/8kpwjbekwx):
<img width="527" height="557" alt="image" src="https://github.com/user-attachments/assets/7fc98251-82b7-4e8e-928f-314cb86f8ba7" />

P.S. New curve actually does slows down, but does so very slowly. For no slowdown at all 2-part compound curve should be used instead, and I'm not sure if such thing is necessary.