### PR TITLE
Fix osu! performance calculator using `LegacyTotalScore == null` checks

### DIFF
--- a/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuLegacyScoreMissCalculator.cs
@@ -25,7 +25,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
 
         public double Calculate()
         {
-            if (attributes.MaxCombo == 0 || score.LegacyTotalScore == null)
+            if (attributes.MaxCombo == 0 || score.LegacyTotalScore == null || score.LegacyTotalScore == 0)
                 return 0;
 
             double scoreV1Multiplier = attributes.LegacyScoreBaseMultiplier * getLegacyScoreMultiplier();

--- a/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
+++ b/osu.Game.Rulesets.Osu/Difficulty/OsuPerformanceCalculator.cs
@@ -108,7 +108,7 @@ namespace osu.Game.Rulesets.Osu.Difficulty
             double comboBasedEstimatedMissCount = calculateComboBasedEstimatedMissCount(osuAttributes);
             double? scoreBasedEstimatedMissCount = null;
 
-            if (usingClassicSliderAccuracy && !usingScoreV2 && score.LegacyTotalScore != null)
+            if (usingClassicSliderAccuracy && !usingScoreV2 && score.LegacyTotalScore > 0)
             {
                 var legacyScoreMissCalculator = new OsuLegacyScoreMissCalculator(score, osuAttributes);
                 scoreBasedEstimatedMissCount = legacyScoreMissCalculator.Calculate();

--- a/osu.Game/Scoring/ScoreInfo.cs
+++ b/osu.Game/Scoring/ScoreInfo.cs
@@ -96,6 +96,7 @@ namespace osu.Game.Scoring
         /// </summary>
         /// <remarks>
         /// Not populated if <see cref="IsLegacyScore"/> is <c>false</c>.
+        /// Always 0 on scores set in lazer.
         /// </remarks>
         public long? LegacyTotalScore { get; set; }
 


### PR DESCRIPTION
As discussed on discord: https://discord.com/channels/188630481301012481/188630652340404224/1544797138741895229

Doesn't affect anything serverside, only affects lazer CL scores (which are unranked and don't give pp)