### PR TITLE
Use `Precision.AlmostEquals()` for buzz slider equality checks

### DIFF
--- a/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
+++ b/osu.Game.Rulesets.Catch/Difficulty/Evaluators/MovementEvaluator.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Utils;
 using osu.Game.Rulesets.Catch.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Difficulty.Utils;
@@ -84,8 +85,9 @@ namespace osu.Game.Rulesets.Catch.Difficulty.Evaluators
             // We are detecting this exact scenario. The first back and forth is counted but all subsequent ones are nullified.
             // To achieve that, we need to store the exact distances (distance ignoring absolute_player_positioning_error and NORMALIZED_HALF_CATCHER_WIDTH)
             if (current.Index >= 2 && Math.Abs(catchCurrent.ExactDistanceMoved) <= CatchDifficultyHitObject.NORMALIZED_HALF_CATCHER_WIDTH * 2
-                                   && catchCurrent.ExactDistanceMoved == -catchLast.ExactDistanceMoved && catchLast.ExactDistanceMoved == -catchLastLast.ExactDistanceMoved
-                                   && catchCurrent.StrainTime == catchLast.StrainTime && catchLast.StrainTime == catchLastLast.StrainTime)
+                                   && Precision.AlmostEquals(catchCurrent.ExactDistanceMoved, -catchLast.ExactDistanceMoved)
+                                   && Precision.AlmostEquals(catchLast.ExactDistanceMoved, -catchLastLast.ExactDistanceMoved)
+                                   && Precision.AlmostEquals(catchCurrent.StrainTime, catchLast.StrainTime) && Precision.AlmostEquals(catchLast.StrainTime, catchLastLast.StrainTime))
                 distanceAddition = 0;
 
             return distanceAddition / weightedStrainTime;


### PR DESCRIPTION
Due to floating point imprecisions, the buzz slider check may not trigger even if there is a valid buzz slider.

This can be seen on [this pending map](https://osu.ppy.sh/beatmapsets/2605702#fruits/5830186).
<img width="1094" height="602" alt="image" src="https://github.com/user-attachments/assets/e2fc347a-5d21-4cd6-aa64-3a8a1ad44465" />

With EZ enabled, the buzz slider is standable but not nerfed due to strain times being different by an insignificant margin.
<img width="1047" height="69" alt="image" src="https://github.com/user-attachments/assets/8ef11877-1432-45e7-8a77-b630384f13e5" />

With EZDT enabled though, the strain times are completely equal and thus get nerfed appropriately.
