### PR TITLE
Dismiss config-persisted search criteria in freestyle select screen

### DIFF
--- a/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
+++ b/osu.Game/Screens/OnlinePlay/OnlinePlayFreestyleSelect.cs
@@ -74,6 +74,13 @@ namespace osu.Game.Screens.OnlinePlay
             criteria.Length.Max = itemLength + 30000;
             criteria.Length.IsLowerInclusive = true;
             criteria.Length.IsUpperInclusive = true;
+
+            // Dismiss the user's config-persisted search criteria (difficulty range, selected collection, converts).
+            // In the context of freestyle selection applying them is counterproductive and can cause no beatmaps to be displayed at all.
+            criteria.UserStarDifficulty.Min = null;
+            criteria.UserStarDifficulty.Max = null;
+            criteria.CollectionBeatmapMD5Hashes = null;
+            criteria.AllowConvertedBeatmaps = true;
         }
 
         private bool isValidForSelection()


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/38727.

In freestyle select it seems counterproductive to apply filters that are persisted to config such as: the user's star difficulty range, convert preference, and collection selection, since applying those filters could yield no results and then make the impression that the user has no choices available.

The caveat here is that this change as written does not change the visual state of the relevant controls on the screen in any way. Listening for opinions as to whether that should be done, as it'll likely complicate matters significantly.